### PR TITLE
🐛(updater): fix missing updater permission preventing update window

### DIFF
--- a/tauri/capabilities/default.json
+++ b/tauri/capabilities/default.json
@@ -7,6 +7,7 @@
 		"core:default",
 		"core:event:default",
 		"deep-link:default",
+		"updater:default",
 		{
 			"identifier": "opener:default",
 			"allow": [


### PR DESCRIPTION
The updater:default permission was missing from default capabilities, which prevented the Tauri updater API from being accessible on the frontend via __TAURI__.updater. This caused the update window to never appear during the self-update process.