### PR TITLE
fix(ocr): disposed reactive value panic on modal navigation

### DIFF
--- a/origa_ui/src/pages/words/image_input_stage.rs
+++ b/origa_ui/src/pages/words/image_input_stage.rs
@@ -330,15 +330,8 @@ pub fn ImageInputStage(
         </div>
 
         <OcrLoadingModal
+            is_open=show_loading_modal
             state=ocr_loading_state_for_modal
-            on_cancel=Callback::new({
-                let state = ocr_loading_state_for_modal;
-                let show_modal = show_loading_modal;
-                move |_| {
-                    state.cancel_requested.set(true);
-                    show_modal.set(false);
-                }
-            })
             on_retry=Callback::new({
                 let state = ocr_loading_state_for_modal;
                 let show_modal = show_loading_modal_for_retry;

--- a/origa_ui/src/ui_components/ocr_loading_modal.rs
+++ b/origa_ui/src/ui_components/ocr_loading_modal.rs
@@ -1,4 +1,7 @@
+use crate::ui_components::{Button, ButtonVariant};
+use leptos::ev::{KeyboardEvent, MouseEvent};
 use leptos::prelude::*;
+use leptos_use::use_event_listener;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum StageStatus {
@@ -117,22 +120,22 @@ pub fn LoadingStageItem(
     #[prop(default = None)] error_message: Option<String>,
 ) -> impl IntoView {
     let (icon_class, icon_content, icon_label) = match status {
-        StageStatus::Waiting => ("text-slate-600", "\u{25CB}", "Ожидание"),
-        StageStatus::Active => ("text-sky-500 animate-spin", "\u{25C9}", "Загрузка"),
-        StageStatus::Completed => ("text-emerald-500", "\u{2713}", "Завершено"),
-        StageStatus::Error => ("text-rose-500", "\u{2717}", "Ошибка"),
+        StageStatus::Waiting => ("text-[var(--fg-light)]", "\u{25CB}", "Ожидание"),
+        StageStatus::Active => ("text-[var(--accent-olive)]", "\u{25C9}", "Загрузка"),
+        StageStatus::Completed => ("text-[var(--success)]", "\u{2713}", "Завершено"),
+        StageStatus::Error => ("text-[var(--error)]", "\u{2717}", "Ошибка"),
     };
 
     let card_class = match status {
-        StageStatus::Active => "bg-slate-800 border border-sky-500/30 ring-1 ring-sky-500/20",
-        StageStatus::Error => "bg-rose-500/5 border border-rose-500/30",
-        StageStatus::Completed => "bg-slate-800/30 border border-slate-700/50",
-        StageStatus::Waiting => "bg-slate-800/50 border border-slate-700",
+        StageStatus::Active => "bg-[var(--bg-warm)] border border-[var(--accent-olive)]",
+        StageStatus::Error => "bg-[var(--bg-warm)] border border-[var(--error)]",
+        StageStatus::Completed => "bg-[var(--bg-paper)] border border-[var(--border-light)]",
+        StageStatus::Waiting => "bg-[var(--bg-aged)] border border-[var(--border-light)]",
     };
 
     let text_class = match status {
-        StageStatus::Waiting => "text-slate-500",
-        _ => "text-slate-200",
+        StageStatus::Waiting => "text-[var(--fg-muted)]",
+        _ => "text-[var(--fg-black)]",
     };
 
     let progress_view = progress.and_then(|p| {
@@ -155,18 +158,21 @@ pub fn LoadingStageItem(
                     )
                 }
             } else {
-                format!("{:.0} MB / {:.0} MB \u{2022} {}%", loaded_mb, total_mb, percent)
+                format!(
+                    "{:.0} MB / {:.0} MB \u{2022} {}%",
+                    loaded_mb, total_mb, percent
+                )
             };
 
             Some(view! {
                 <div class="mt-2 space-y-1">
-                    <div class="w-full h-1 rounded-full bg-slate-700 overflow-hidden">
+                    <div class="progress-track">
                         <div
-                            class="h-full rounded-full bg-sky-500 transition-all duration-300 ease-out"
+                            class="progress-fill"
                             style=format!("width: {}%", percent)
                         ></div>
                     </div>
-                    <div class="text-xs text-slate-400">{details}</div>
+                    <div class="text-xs text-[var(--fg-muted)]">{details}</div>
                 </div>
             })
         } else {
@@ -176,14 +182,14 @@ pub fn LoadingStageItem(
 
     let error_view = if status == StageStatus::Error {
         error_message.map(|msg| {
-            view! { <div class="mt-2 text-xs text-rose-400">{msg}</div> }
+            view! { <div class="mt-2 text-xs text-[var(--error)]">{msg}</div> }
         })
     } else {
         None
     };
 
     view! {
-        <div class=format!("p-3 rounded-lg {}", card_class)>
+        <div class=format!("p-3 {}", card_class)>
             <div class="flex items-start gap-3">
                 <span
                     class=format!("w-5 h-5 flex-shrink-0 {}", icon_class)
@@ -192,7 +198,7 @@ pub fn LoadingStageItem(
                 >{icon_content}</span>
                 <div class="flex-1 min-w-0">
                     <div class=format!("text-sm font-medium {}", text_class)>{title}</div>
-                    <div class="text-xs text-slate-400 mt-0.5">{description}</div>
+                    <div class="text-xs text-[var(--fg-muted)] mt-0.5">{description}</div>
                     {progress_view}
                     {error_view}
                 </div>
@@ -335,6 +341,7 @@ fn get_stage_info(stage: &OcrLoadingStage, stage_type: StageType) -> StageInfo {
 
 #[component]
 pub fn OcrLoadingModal(
+    #[prop(optional)] is_open: RwSignal<bool>,
     state: OcrLoadingState,
     #[prop(optional, into)] on_cancel: Option<Callback<()>>,
     #[prop(optional, into)] on_retry: Option<Callback<()>>,
@@ -342,15 +349,9 @@ pub fn OcrLoadingModal(
     let stage = state.stage;
     let cancel_requested = state.cancel_requested;
 
-    let deim_info = Memo::new(move |_| get_stage_info(&stage.get(), StageType::Deim));
-    let parseq_info = Memo::new(move |_| get_stage_info(&stage.get(), StageType::Parseq));
-    let init_info = Memo::new(move |_| get_stage_info(&stage.get(), StageType::Init));
-    let recognize_info = Memo::new(move |_| get_stage_info(&stage.get(), StageType::Recognize));
-
-    let is_error = Memo::new(move |_| matches!(stage.get(), OcrLoadingStage::Error { .. }));
-
-    let handle_cancel = move || {
+    let close_modal = move || {
         cancel_requested.set(true);
+        is_open.set(false);
         if let Some(cb) = on_cancel {
             cb.run(());
         }
@@ -362,133 +363,141 @@ pub fn OcrLoadingModal(
         }
     };
 
-    let handle_keydown = move |ev: leptos::ev::KeyboardEvent| {
-        if ev.key() == "Escape" {
+    let cleanup = use_event_listener(document(), leptos::ev::keydown, move |ev: KeyboardEvent| {
+        if ev.key() == "Escape" && is_open.get() {
             ev.prevent_default();
-            handle_cancel();
+            close_modal();
         }
-    };
-
-    let title_icon = move || {
-        if is_error.get() {
-            view! {
-                <span class="text-rose-500" role="img" aria-label="Предупреждение">
-                    "\u{26a0}"
-                </span>
-            }
-            .into_any()
-        } else {
-            view! {
-                <span class="text-sky-500" role="img" aria-label="Загрузка">
-                    "\u{25c9}"
-                </span>
-            }
-            .into_any()
-        }
-    };
-
-    let title_text = move || {
-        if is_error.get() {
-            "Ошибка загрузки"
-        } else {
-            "Подготовка к распознаванию"
-        }
-    };
-
-    let buttons = move || {
-        if is_error.get() {
-            view! {
-                <>
-                    <button
-                        class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-200 font-medium transition-colors duration-150"
-                        on:click=move |_| handle_cancel()
-                    >
-                        "Отмена"
-                    </button>
-                    <button
-                        class="px-4 py-2 rounded-lg bg-sky-500 hover:bg-sky-400 text-white font-medium transition-colors duration-150"
-                        on:click=move |_| handle_retry()
-                    >
-                        "Повторить"
-                    </button>
-                </>
-            }
-            .into_any()
-        } else {
-            view! {
-                <button
-                    class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-200 font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-                    on:click=move |_| handle_cancel()
-                    disabled=cancel_requested.get()
-                >
-                    {move || if cancel_requested.get() { "Отмена..." } else { "Отменить" }}
-                </button>
-            }
-            .into_any()
-        }
-    };
+    });
+    on_cleanup(move || drop(cleanup));
 
     view! {
-        <div
-            class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 backdrop-blur-sm"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="ocr-loading-title"
-            aria-describedby="ocr-loading-desc"
-            tabindex="-1"
-            on:keydown=handle_keydown
-        >
-            <div class="w-full max-w-md mx-4 bg-slate-900 rounded-xl shadow-2xl border border-slate-700 p-6 space-y-4">
-                <h2
-                    id="ocr-loading-title"
-                    class="text-lg font-semibold text-slate-100 flex items-center gap-2"
-                >
-                    {title_icon}
-                    {title_text}
-                </h2>
+        <Show when=move || is_open.get()>
+            <div
+                class="modal-backdrop flex items-center justify-center"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="ocr-loading-title"
+                aria-describedby="ocr-loading-desc"
+            >
+                <div class="modal-content max-w-md mx-4 space-y-4">
+                    <h2
+                        id="ocr-loading-title"
+                        class="text-lg font-semibold text-[var(--fg-black)] flex items-center gap-2"
+                    >
+                        {move || {
+                            if matches!(stage.get(), OcrLoadingStage::Error { .. }) {
+                                view! {
+                                    <>
+                                        <span class="text-[var(--error)]" role="img" aria-label="Предупреждение">
+                                            "\u{26a0}"
+                                        </span>
+                                        "Ошибка загрузки"
+                                    </>
+                                }.into_any()
+                            } else {
+                                view! {
+                                    <>
+                                        <span class="spinner spinner-sm"></span>
+                                        "Подготовка к распознаванию"
+                                    </>
+                                }.into_any()
+                            }
+                        }}
+                    </h2>
 
-                <div id="ocr-loading-desc" class="sr-only">
-                    "Загрузка моделей для распознавания японского текста"
-                </div>
+                    <div id="ocr-loading-desc" class="sr-only">
+                        "Загрузка моделей для распознавания японского текста"
+                    </div>
 
-                <div class="space-y-3" role="list">
-                    <LoadingStageItem
-                        status=deim_info.get().status
-                        title="Сегментация текста".to_string()
-                        description=deim_info.get().description
-                        progress=deim_info.get().progress
-                        error_message=deim_info.get().error_message
-                    />
+                    <div class="space-y-3" role="list">
+                        {move || {
+                            let info = get_stage_info(&stage.get(), StageType::Deim);
+                            view! {
+                                <LoadingStageItem
+                                    status=info.status
+                                    title="Сегментация текста".to_string()
+                                    description=info.description
+                                    progress=info.progress
+                                    error_message=info.error_message
+                                />
+                            }
+                        }}
 
-                    <LoadingStageItem
-                        status=parseq_info.get().status
-                        title="Распознавание символов".to_string()
-                        description=parseq_info.get().description
-                        progress=parseq_info.get().progress
-                        error_message=parseq_info.get().error_message
-                    />
+                        {move || {
+                            let info = get_stage_info(&stage.get(), StageType::Parseq);
+                            view! {
+                                <LoadingStageItem
+                                    status=info.status
+                                    title="Распознавание символов".to_string()
+                                    description=info.description
+                                    progress=info.progress
+                                    error_message=info.error_message
+                                />
+                            }
+                        }}
 
-                    <LoadingStageItem
-                        status=init_info.get().status
-                        title="Инициализация моделей".to_string()
-                        description=init_info.get().description
-                        progress=init_info.get().progress
-                        error_message=init_info.get().error_message
-                    />
+                        {move || {
+                            let info = get_stage_info(&stage.get(), StageType::Init);
+                            view! {
+                                <LoadingStageItem
+                                    status=info.status
+                                    title="Инициализация моделей".to_string()
+                                    description=info.description
+                                    progress=info.progress
+                                    error_message=info.error_message
+                                />
+                            }
+                        }}
 
-                    <LoadingStageItem
-                        status=recognize_info.get().status
-                        title="Распознавание текста".to_string()
-                        description=recognize_info.get().description
-                        progress=recognize_info.get().progress
-                        error_message=recognize_info.get().error_message
-                    />
-                </div>
+                        {move || {
+                            let info = get_stage_info(&stage.get(), StageType::Recognize);
+                            view! {
+                                <LoadingStageItem
+                                    status=info.status
+                                    title="Распознавание текста".to_string()
+                                    description=info.description
+                                    progress=info.progress
+                                    error_message=info.error_message
+                                />
+                            }
+                        }}
+                    </div>
 
-                <div class="flex justify-end gap-2 pt-2">
-                    {buttons}
+                    <div class="flex justify-end gap-2 pt-2">
+                        {move || {
+                            if matches!(stage.get(), OcrLoadingStage::Error { .. }) {
+                                view! {
+                                    <>
+                                        <Button
+                                            variant=Signal::derive(|| ButtonVariant::Ghost)
+                                            on_click=Callback::new(move |_: MouseEvent| close_modal())
+                                        >
+                                            "Отмена"
+                                        </Button>
+                                        <Button
+                                            variant=Signal::derive(|| ButtonVariant::Default)
+                                            on_click=Callback::new(move |_: MouseEvent| handle_retry())
+                                        >
+                                            "Повторить"
+                                        </Button>
+                                    </>
+                                }.into_any()
+                            } else {
+                                view! {
+                                    <Button
+                                        variant=Signal::derive(|| ButtonVariant::Ghost)
+                                        disabled=Signal::derive(move || cancel_requested.get())
+                                        on_click=Callback::new(move |_: MouseEvent| close_modal())
+                                    >
+                                        {move || if cancel_requested.get() { "Отмена..." } else { "Отменить" }}
+                                    </Button>
+                                }.into_any()
+                            }
+                        }}
+                    </div>
                 </div>
             </div>
-        </div>
+        </Show>
     }
 }


### PR DESCRIPTION
- Add is_open prop to OcrLoadingModal for proper visibility control
- Wrap content in <Show when=is_open> to prevent Memo reads from disposed signals
- Use project CSS classes (modal-backdrop, modal-content, progress-track, progress-fill)
- Add use_event_listener + on_cleanup for Escape key handling
- Use Button component instead of inline buttons
- Remove duplicate on_cancel callback in image_input_stage.rs