### PR TITLE
fix(history): show most recent 7 history items instead of oldest 7

### DIFF
--- a/origa_ui/src/pages/home/history_modal.rs
+++ b/origa_ui/src/pages/home/history_modal.rs
@@ -55,7 +55,8 @@ pub fn HistoryModal(
     let recent_history = move || {
         let mut items: Vec<_> = history.get();
         items.sort_by_key(|a| a.timestamp());
-        items.into_iter().take(7).collect::<Vec<_>>()
+        let start = items.len().saturating_sub(7);
+        items.into_iter().skip(start).collect::<Vec<_>>()
     };
 
     let has_data = move || !recent_history().is_empty();


### PR DESCRIPTION
Changed `recent_history` function in history_modal.rs to skip old items and take the last 7 records after sorting, ensuring fresh data is displayed on the /home page chart.