### PR TITLE
feat: add positive/negative/total ratings metrics to daily history an…

### DIFF
--- a/origa/src/domain/knowledge/daily_history.rs
+++ b/origa/src/domain/knowledge/daily_history.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::domain::memory::Rating;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DailyHistoryItem {
     timestamp: DateTime<Utc>,
@@ -13,6 +15,10 @@ pub struct DailyHistoryItem {
     in_progress_words: usize,
     high_difficulty_words: usize,
     lessons_completed: usize,
+
+    positive_ratings: usize,
+    negative_ratings: usize,
+    total_ratings: usize,
 }
 
 impl Default for DailyHistoryItem {
@@ -33,6 +39,9 @@ impl DailyHistoryItem {
             in_progress_words: 0,
             high_difficulty_words: 0,
             lessons_completed: 0,
+            positive_ratings: 0,
+            negative_ratings: 0,
+            total_ratings: 0,
         }
     }
 
@@ -72,6 +81,18 @@ impl DailyHistoryItem {
         self.lessons_completed
     }
 
+    pub fn positive_ratings(&self) -> usize {
+        self.positive_ratings
+    }
+
+    pub fn negative_ratings(&self) -> usize {
+        self.negative_ratings
+    }
+
+    pub fn total_ratings(&self) -> usize {
+        self.total_ratings
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn update(
         &mut self,
@@ -82,6 +103,7 @@ impl DailyHistoryItem {
         new_words: usize,
         in_progress_words: usize,
         high_difficulty_words: usize,
+        rating: Rating,
     ) {
         self.update_stats(
             avg_stability,
@@ -91,6 +113,17 @@ impl DailyHistoryItem {
             new_words,
             in_progress_words,
             high_difficulty_words,
+            self.positive_ratings
+                + match rating {
+                    Rating::Easy | Rating::Good => 1,
+                    Rating::Hard | Rating::Again => 0,
+                },
+            self.negative_ratings
+                + match rating {
+                    Rating::Hard | Rating::Again => 1,
+                    Rating::Easy | Rating::Good => 0,
+                },
+            self.total_ratings + 1,
         );
         self.lessons_completed += 1;
     }
@@ -105,6 +138,9 @@ impl DailyHistoryItem {
         new_words: usize,
         in_progress_words: usize,
         high_difficulty_words: usize,
+        positive_ratings: usize,
+        negative_ratings: usize,
+        total_ratings: usize,
     ) {
         self.avg_stability = Some(avg_stability);
         self.avg_difficulty = Some(avg_difficulty);
@@ -113,10 +149,16 @@ impl DailyHistoryItem {
         self.new_words = new_words;
         self.in_progress_words = in_progress_words;
         self.high_difficulty_words = high_difficulty_words;
+        self.positive_ratings = positive_ratings;
+        self.negative_ratings = negative_ratings;
+        self.total_ratings = total_ratings;
     }
 
     pub fn merge_with(&mut self, other: &DailyHistoryItem) {
         self.lessons_completed = self.lessons_completed.max(other.lessons_completed);
+        self.positive_ratings = self.positive_ratings.max(other.positive_ratings);
+        self.negative_ratings = self.negative_ratings.max(other.negative_ratings);
+        self.total_ratings = self.total_ratings.max(other.total_ratings);
 
         if other.timestamp > self.timestamp {
             self.timestamp = other.timestamp;
@@ -146,6 +188,9 @@ mod tests {
             total - known, // new_words
             0,             // in_progress
             0,             // high_difficulty
+            0,             // positive_ratings
+            0,             // negative_ratings
+            0,             // total_ratings
         );
         for _ in 0..lessons {
             item.lessons_completed += 1;
@@ -181,7 +226,7 @@ mod tests {
     fn test_daily_history_item_update() {
         let mut item = DailyHistoryItem::new();
 
-        item.update(0.5, 0.3, 5, 10, 2, 3, 1);
+        item.update(0.5, 0.3, 5, 10, 2, 3, 1, Rating::Good);
 
         assert_eq!(item.lessons_completed(), 1);
         assert_eq!(item.total_words(), 5);
@@ -191,6 +236,9 @@ mod tests {
         assert_eq!(item.high_difficulty_words(), 1);
         assert_eq!(item.avg_stability(), Some(0.5));
         assert_eq!(item.avg_difficulty(), Some(0.3));
+        assert_eq!(item.positive_ratings(), 1);
+        assert_eq!(item.negative_ratings(), 0);
+        assert_eq!(item.total_ratings(), 1);
     }
 
     #[test]
@@ -250,7 +298,7 @@ mod tests {
         let newer = now + Duration::seconds(100);
         let mut item1 = create_test_item(now, 2, 5, 10);
         let mut item2 = create_test_item(newer, 5, 3, 8);
-        item2.update_stats(0.8, 0.6, 8, 3, 5, 0, 0);
+        item2.update_stats(0.8, 0.6, 8, 3, 5, 0, 0, 0, 0, 0);
 
         item1.merge_with(&item2);
 
@@ -264,7 +312,7 @@ mod tests {
         let older = now - Duration::seconds(100);
         let mut item1 = create_test_item(now, 2, 5, 10);
         let mut item2 = create_test_item(older, 5, 3, 8);
-        item2.update_stats(0.8, 0.6, 8, 3, 5, 0, 0);
+        item2.update_stats(0.8, 0.6, 8, 3, 5, 0, 0, 0, 0, 0);
 
         let stability_before = item1.avg_stability();
         let difficulty_before = item1.avg_difficulty();
@@ -272,5 +320,75 @@ mod tests {
 
         assert_eq!(item1.avg_stability(), stability_before);
         assert_eq!(item1.avg_difficulty(), difficulty_before);
+    }
+
+    #[test]
+    fn test_update_increments_positive_ratings_on_good() {
+        let mut item = DailyHistoryItem::new();
+        item.update(0.5, 0.3, 5, 10, 2, 3, 1, Rating::Good);
+
+        assert_eq!(item.positive_ratings(), 1);
+        assert_eq!(item.negative_ratings(), 0);
+        assert_eq!(item.total_ratings(), 1);
+    }
+
+    #[test]
+    fn test_update_increments_positive_ratings_on_easy() {
+        let mut item = DailyHistoryItem::new();
+        item.update(0.5, 0.3, 5, 10, 2, 3, 1, Rating::Easy);
+
+        assert_eq!(item.positive_ratings(), 1);
+        assert_eq!(item.negative_ratings(), 0);
+        assert_eq!(item.total_ratings(), 1);
+    }
+
+    #[test]
+    fn test_update_increments_negative_ratings_on_again() {
+        let mut item = DailyHistoryItem::new();
+        item.update(0.5, 0.3, 5, 10, 2, 3, 1, Rating::Again);
+
+        assert_eq!(item.positive_ratings(), 0);
+        assert_eq!(item.negative_ratings(), 1);
+        assert_eq!(item.total_ratings(), 1);
+    }
+
+    #[test]
+    fn test_update_increments_negative_ratings_on_hard() {
+        let mut item = DailyHistoryItem::new();
+        item.update(0.5, 0.3, 5, 10, 2, 3, 1, Rating::Hard);
+
+        assert_eq!(item.positive_ratings(), 0);
+        assert_eq!(item.negative_ratings(), 1);
+        assert_eq!(item.total_ratings(), 1);
+    }
+
+    #[test]
+    fn test_update_accumulates_ratings() {
+        let mut item = DailyHistoryItem::new();
+        item.update(0.5, 0.3, 5, 10, 2, 3, 1, Rating::Good);
+        item.update(0.5, 0.3, 5, 10, 2, 3, 1, Rating::Easy);
+        item.update(0.5, 0.3, 5, 10, 2, 3, 1, Rating::Again);
+
+        assert_eq!(item.positive_ratings(), 2);
+        assert_eq!(item.negative_ratings(), 1);
+        assert_eq!(item.total_ratings(), 3);
+    }
+
+    #[test]
+    fn test_merge_with_takes_max_ratings() {
+        let now = Utc::now();
+        let mut item1 = DailyHistoryItem::new();
+        item1.update_stats(0.5, 0.3, 10, 5, 5, 0, 0, 3, 2, 5);
+        item1.timestamp = now;
+
+        let mut item2 = DailyHistoryItem::new();
+        item2.update_stats(0.6, 0.4, 12, 6, 6, 0, 0, 5, 3, 8);
+        item2.timestamp = now;
+
+        item1.merge_with(&item2);
+
+        assert_eq!(item1.positive_ratings(), 5);
+        assert_eq!(item1.negative_ratings(), 3);
+        assert_eq!(item1.total_ratings(), 8);
     }
 }

--- a/origa/src/domain/knowledge/mod.rs
+++ b/origa/src/domain/knowledge/mod.rs
@@ -276,7 +276,7 @@ impl KnowledgeSet {
             let review = ReviewLog::new(rating, interval);
             card.add_review(memory_state, review);
             card.handle_favorite_rating(rating);
-            self.update_history();
+            self.update_history(rating);
             Ok(())
         } else {
             Err(OrigaError::CardNotFound { card_id })
@@ -292,7 +292,7 @@ impl KnowledgeSet {
         }
     }
 
-    fn update_history(&mut self) {
+    fn update_history(&mut self, rating: Rating) {
         let mut avg_stability = 0.0;
         let mut avg_difficulty = 0.0;
         let mut total_words = 0;
@@ -330,6 +330,7 @@ impl KnowledgeSet {
                 new_words,
                 in_progress_words,
                 high_difficulty_words,
+                rating,
             );
         } else {
             let mut item = DailyHistoryItem::new();
@@ -341,6 +342,7 @@ impl KnowledgeSet {
                 new_words,
                 in_progress_words,
                 high_difficulty_words,
+                rating,
             );
             self.lesson_history.push(item);
         }
@@ -372,8 +374,16 @@ impl KnowledgeSet {
         avg_stability /= total_words as f64;
         avg_difficulty /= total_words as f64;
 
-        let now = Utc::now();
-        let today = now.date_naive();
+        let today = Utc::now().date_naive();
+        let (positive, negative, total) = self
+            .study_cards
+            .values()
+            .flat_map(|card| card.memory().reviews())
+            .filter(|review| review.timestamp().date_naive() == today)
+            .fold((0, 0, 0), |(pos, neg, tot), review| match review.rating() {
+                Rating::Easy | Rating::Good => (pos + 1, neg, tot + 1),
+                Rating::Hard | Rating::Again => (pos, neg + 1, tot + 1),
+            });
 
         if let Some(existing_item) = self
             .lesson_history
@@ -388,6 +398,9 @@ impl KnowledgeSet {
                 new_words,
                 in_progress_words,
                 high_difficulty_words,
+                positive,
+                negative,
+                total,
             );
         } else {
             let mut item = DailyHistoryItem::new();
@@ -399,6 +412,9 @@ impl KnowledgeSet {
                 new_words,
                 in_progress_words,
                 high_difficulty_words,
+                positive,
+                negative,
+                total,
             );
             self.lesson_history.push(item);
         }

--- a/origa_ui/src/pages/home/content.rs
+++ b/origa_ui/src/pages/home/content.rs
@@ -125,6 +125,12 @@ pub fn HomeContent() -> impl IntoView {
     let new_cards = Signal::derive(move || format_number(stats.get().map(|s| s.new).unwrap_or(0)));
     let high_difficulty =
         Signal::derive(move || format_number(stats.get().map(|s| s.high_difficulty).unwrap_or(0)));
+    let positive =
+        Signal::derive(move || format_number(stats.get().map(|s| s.positive).unwrap_or(0)));
+    let negative =
+        Signal::derive(move || format_number(stats.get().map(|s| s.negative).unwrap_or(0)));
+    let total_ratings =
+        Signal::derive(move || format_number(stats.get().map(|s| s.total_ratings).unwrap_or(0)));
 
     let total_cards_delta =
         Signal::derive(move || format_delta(stats.get().map(|s| s.total_cards_delta).unwrap_or(0)));
@@ -136,6 +142,13 @@ pub fn HomeContent() -> impl IntoView {
         Signal::derive(move || format_delta(stats.get().map(|s| s.new_delta).unwrap_or(0)));
     let high_difficulty_delta = Signal::derive(move || {
         format_delta(stats.get().map(|s| s.high_difficulty_delta).unwrap_or(0))
+    });
+    let positive_delta =
+        Signal::derive(move || format_delta(stats.get().map(|s| s.positive_delta).unwrap_or(0)));
+    let negative_delta =
+        Signal::derive(move || format_delta(stats.get().map(|s| s.negative_delta).unwrap_or(0)));
+    let total_ratings_delta = Signal::derive(move || {
+        format_delta(stats.get().map(|s| s.total_ratings_delta).unwrap_or(0))
     });
 
     let open_history = move |metric: StatMetric| {
@@ -182,6 +195,12 @@ pub fn HomeContent() -> impl IntoView {
                         new_delta=new_delta
                         high_difficulty=high_difficulty
                         high_difficulty_delta=high_difficulty_delta
+                        positive=positive
+                        positive_delta=positive_delta
+                        negative=negative
+                        negative_delta=negative_delta
+                        total_ratings=total_ratings
+                        total_ratings_delta=total_ratings_delta
                         open_history=open_history
                     />
                 </Show>

--- a/origa_ui/src/pages/home/history_modal.rs
+++ b/origa_ui/src/pages/home/history_modal.rs
@@ -10,6 +10,9 @@ pub enum StatMetric {
     InProgress,
     New,
     HighDifficulty,
+    PositiveRatings,
+    NegativeRatings,
+    TotalRatings,
 }
 
 impl StatMetric {
@@ -20,6 +23,9 @@ impl StatMetric {
             StatMetric::InProgress => "В процессе",
             StatMetric::New => "Новые",
             StatMetric::HighDifficulty => "Сложные",
+            StatMetric::PositiveRatings => "Позитивные",
+            StatMetric::NegativeRatings => "Негативные",
+            StatMetric::TotalRatings => "Всего оценок",
         }
     }
 }
@@ -31,6 +37,9 @@ fn get_metric_value(item: &DailyHistoryItem, metric: StatMetric) -> usize {
         StatMetric::InProgress => item.in_progress_words(),
         StatMetric::New => item.new_words(),
         StatMetric::HighDifficulty => item.high_difficulty_words(),
+        StatMetric::PositiveRatings => item.positive_ratings(),
+        StatMetric::NegativeRatings => item.negative_ratings(),
+        StatMetric::TotalRatings => item.total_ratings(),
     }
 }
 

--- a/origa_ui/src/pages/home/home_stats.rs
+++ b/origa_ui/src/pages/home/home_stats.rs
@@ -12,6 +12,12 @@ pub struct HomeStats {
     pub in_progress_delta: isize,
     pub new_delta: isize,
     pub high_difficulty_delta: isize,
+    pub positive: usize,
+    pub negative: usize,
+    pub total_ratings: usize,
+    pub positive_delta: isize,
+    pub negative_delta: isize,
+    pub total_ratings_delta: isize,
 }
 
 pub fn format_number(n: usize) -> String {
@@ -39,19 +45,30 @@ pub fn calculate_stats(history: &[DailyHistoryItem]) -> HomeStats {
 
     let last = history.last().unwrap();
 
-    let (total_delta, learned_delta, in_progress_delta, new_delta, high_difficulty_delta) =
-        if history.len() >= 2 {
-            let prev = &history[history.len() - 2];
-            (
-                last.total_words() as isize - prev.total_words() as isize,
-                last.known_words() as isize - prev.known_words() as isize,
-                last.in_progress_words() as isize - prev.in_progress_words() as isize,
-                last.new_words() as isize - prev.new_words() as isize,
-                last.high_difficulty_words() as isize - prev.high_difficulty_words() as isize,
-            )
-        } else {
-            (0, 0, 0, 0, 0)
-        };
+    let (
+        total_delta,
+        learned_delta,
+        in_progress_delta,
+        new_delta,
+        high_difficulty_delta,
+        positive_delta,
+        negative_delta,
+        total_ratings_delta,
+    ) = if history.len() >= 2 {
+        let prev = &history[history.len() - 2];
+        (
+            last.total_words() as isize - prev.total_words() as isize,
+            last.known_words() as isize - prev.known_words() as isize,
+            last.in_progress_words() as isize - prev.in_progress_words() as isize,
+            last.new_words() as isize - prev.new_words() as isize,
+            last.high_difficulty_words() as isize - prev.high_difficulty_words() as isize,
+            last.positive_ratings() as isize - prev.positive_ratings() as isize,
+            last.negative_ratings() as isize - prev.negative_ratings() as isize,
+            last.total_ratings() as isize - prev.total_ratings() as isize,
+        )
+    } else {
+        (0, 0, 0, 0, 0, 0, 0, 0)
+    };
 
     HomeStats {
         total_cards: last.total_words(),
@@ -64,5 +81,11 @@ pub fn calculate_stats(history: &[DailyHistoryItem]) -> HomeStats {
         in_progress_delta,
         new_delta,
         high_difficulty_delta,
+        positive: last.positive_ratings(),
+        negative: last.negative_ratings(),
+        total_ratings: last.total_ratings(),
+        positive_delta,
+        negative_delta,
+        total_ratings_delta,
     }
 }

--- a/origa_ui/src/pages/home/stats_grid.rs
+++ b/origa_ui/src/pages/home/stats_grid.rs
@@ -13,10 +13,16 @@ pub fn StatsGrid(
     new_delta: Signal<String>,
     high_difficulty: Signal<String>,
     high_difficulty_delta: Signal<String>,
+    positive: Signal<String>,
+    positive_delta: Signal<String>,
+    negative: Signal<String>,
+    negative_delta: Signal<String>,
+    total_ratings: Signal<String>,
+    total_ratings_delta: Signal<String>,
     open_history: impl Fn(StatMetric) -> Callback<()> + 'static,
 ) -> impl IntoView {
     view! {
-        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-6">
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-9 gap-6">
             <LessonButtonsCard />
 
             <StatCard
@@ -57,6 +63,30 @@ pub fn StatsGrid(
                 subtitle=Signal::derive(|| "требуют внимания".to_string())
                 delta=high_difficulty_delta
                 on_history=open_history(StatMetric::HighDifficulty)
+            />
+
+            <StatCard
+                title=Signal::derive(|| "Позитивные".to_string())
+                value=positive
+                subtitle=Signal::derive(|| "оценок".to_string())
+                delta=positive_delta
+                on_history=open_history(StatMetric::PositiveRatings)
+            />
+
+            <StatCard
+                title=Signal::derive(|| "Негативные".to_string())
+                value=negative
+                subtitle=Signal::derive(|| "оценок".to_string())
+                delta=negative_delta
+                on_history=open_history(StatMetric::NegativeRatings)
+            />
+
+            <StatCard
+                title=Signal::derive(|| "Всего оценок".to_string())
+                value=total_ratings
+                subtitle=Signal::derive(|| "за сегодня".to_string())
+                delta=total_ratings_delta
+                on_history=open_history(StatMetric::TotalRatings)
             />
         </div>
     }

--- a/origa_ui/src/pages/lesson/radical_card_details.rs
+++ b/origa_ui/src/pages/lesson/radical_card_details.rs
@@ -1,6 +1,5 @@
 use crate::ui_components::{
-    Button, ButtonVariant, KanjiAnimation, KanjiDrawingPractice, KanjiViewMode, Text, TextSize,
-    TypographyVariant,
+    KanjiAnimation, KanjiDrawingPractice, KanjiViewMode, Text, TextSize, TypographyVariant,
 };
 use leptos::prelude::*;
 
@@ -19,7 +18,6 @@ pub fn RadicalCardDetails(
     #[prop(into)] show_details: Signal<bool>,
 ) -> impl IntoView {
     let radical_stored = StoredValue::new(radical);
-    let kanji_examples_stored = StoredValue::new(radical_stored.get_value().kanji_examples.clone());
 
     view! {
         <Show when=move || show_details.get()>


### PR DESCRIPTION
…d home page

- Add positive_ratings, negative_ratings, total_ratings fields to DailyHistoryItem
- Integrate rating tracking in KnowledgeSet.update_history()
- Add rating metrics to HomeStats with delta calculations
- Add new StatCards for ratings display on home page
- Add StatMetric variants for ratings history modal