### PR TITLE
fix(ci): switch Docker build cache from registry to GHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,7 @@ jobs:
         permissions:
             contents: read
             packages: write
+            actions: write
 
         steps:
             - name: Checkout repository
@@ -67,8 +68,8 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=registry,ref=ghcr.io/yurvon-screamo/origa:buildcache
-                  cache-to: type=registry,ref=ghcr.io/yurvon-screamo/origa:buildcache,mode=max
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
                   provenance: false
                   build-args: |
                       ORIGA_VERSION=${{ needs.version.outputs.version }}


### PR DESCRIPTION
Registry cache serves stale COPY layers, causing builds to skip code changes. Switch to GHA cache which properly invalidates based on file checksums.