### PR TITLE
feat(lesson): auto-include kanji cards when their word appears in lesson

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,6 @@ jobs:
         permissions:
             contents: read
             packages: write
-            actions: write
 
         steps:
             - name: Checkout repository
@@ -68,8 +67,8 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
+                  cache-from: type=registry,ref=ghcr.io/yurvon-screamo/origa:buildcache
+                  cache-to: type=registry,ref=ghcr.io/yurvon-screamo/origa:buildcache,mode=max
                   provenance: false
                   build-args: |
                       ORIGA_VERSION=${{ needs.version.outputs.version }}

--- a/origa/src/domain/knowledge/kanji_companions.rs
+++ b/origa/src/domain/knowledge/kanji_companions.rs
@@ -1,30 +1,148 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use ulid::Ulid;
 
 use super::lesson::{LessonCard, LessonData, LessonViewGenerator};
+use super::lesson_builder::MAX_LESSON_SIZE;
 use super::{Card, KnowledgeSet, MAX_COMPANION_WORDS};
 use crate::dictionary::kanji::get_kanji_info;
+use crate::domain::japanese::JapaneseChar;
+use crate::domain::value_objects::JapaneseLevel;
 
 const MAX_COMPANION_CARDS_PER_LESSON: usize = 15;
+const MAX_REVERSE_COMPANION_CARDS_PER_LESSON: usize = 10;
 
 pub(crate) fn add_kanji_companions(
     lesson_data: LessonData,
     knowledge_set: &KnowledgeSet,
+    user_level: JapaneseLevel,
 ) -> LessonData {
+    let already_in_lesson: HashSet<Ulid> = lesson_data.cards.iter().map(|(id, _)| *id).collect();
+
+    let (lesson_data, already_in_lesson) =
+        add_forward_companions(lesson_data, knowledge_set, already_in_lesson);
+
+    add_reverse_companions(lesson_data, knowledge_set, user_level, &already_in_lesson)
+}
+
+fn add_forward_companions(
+    lesson_data: LessonData,
+    knowledge_set: &KnowledgeSet,
+    mut already_in_lesson: HashSet<Ulid>,
+) -> (LessonData, HashSet<Ulid>) {
     let kanji_ids = collect_kanji_ids(&lesson_data, knowledge_set);
     if kanji_ids.is_empty() {
-        return lesson_data;
+        return (lesson_data, already_in_lesson);
     }
-
-    let already_in_lesson: HashSet<Ulid> = lesson_data.cards.iter().map(|(id, _)| *id).collect();
 
     let companions = find_companion_cards(&kanji_ids, knowledge_set, &already_in_lesson);
     if companions.is_empty() {
+        return (lesson_data, already_in_lesson);
+    }
+
+    for (id, _) in &companions {
+        already_in_lesson.insert(*id);
+    }
+
+    (
+        append_companions(lesson_data, knowledge_set, &companions),
+        already_in_lesson,
+    )
+}
+
+fn add_reverse_companions(
+    lesson_data: LessonData,
+    knowledge_set: &KnowledgeSet,
+    user_level: JapaneseLevel,
+    already_in_lesson: &HashSet<Ulid>,
+) -> LessonData {
+    let kanji_index: HashMap<char, (&Ulid, &super::StudyCard)> = knowledge_set
+        .study_cards()
+        .iter()
+        .filter_map(|(id, sc)| {
+            let Card::Kanji(k) = sc.card() else {
+                return None;
+            };
+            k.kanji().text().chars().next().map(|ch| (ch, (id, sc)))
+        })
+        .collect();
+
+    let vocab_kanji_chars = collect_kanji_from_vocab(&lesson_data, knowledge_set);
+    if vocab_kanji_chars.is_empty() {
         return lesson_data;
     }
 
-    append_companions(lesson_data, knowledge_set, &companions)
+    let candidates = find_reverse_companions(
+        &vocab_kanji_chars,
+        &kanji_index,
+        already_in_lesson,
+        user_level,
+    );
+    if candidates.is_empty() {
+        return lesson_data;
+    }
+
+    let effective_limit = MAX_REVERSE_COMPANION_CARDS_PER_LESSON
+        .min(MAX_LESSON_SIZE.saturating_sub(lesson_data.cards.len()));
+    let capped: Vec<_> = candidates.into_iter().take(effective_limit).collect();
+
+    append_companions(lesson_data, knowledge_set, &capped)
+}
+
+fn collect_kanji_from_vocab(
+    lesson_data: &LessonData,
+    knowledge_set: &KnowledgeSet,
+) -> HashSet<char> {
+    let mut kanji_chars = HashSet::new();
+
+    for (id, _) in &lesson_data.cards {
+        let study_card = match knowledge_set.get_card(*id) {
+            Some(sc) => sc,
+            None => continue,
+        };
+
+        if let Card::Vocabulary(v) = study_card.card() {
+            for ch in v.word().text().chars() {
+                if ch.is_kanji() {
+                    kanji_chars.insert(ch);
+                }
+            }
+        }
+    }
+
+    kanji_chars
+}
+
+fn find_reverse_companions<'a>(
+    kanji_chars: &HashSet<char>,
+    kanji_index: &HashMap<char, (&'a Ulid, &'a super::StudyCard)>,
+    already_in_lesson: &HashSet<Ulid>,
+    user_level: JapaneseLevel,
+) -> Vec<(Ulid, &'a super::StudyCard)> {
+    let mut companions = Vec::new();
+
+    for &ch in kanji_chars {
+        let (card_id, study_card) = match kanji_index.get(&ch) {
+            Some(&(id, sc)) => (id, sc),
+            None => continue,
+        };
+
+        if already_in_lesson.contains(card_id) {
+            continue;
+        }
+
+        let Card::Kanji(kanji_card) = study_card.card() else {
+            continue;
+        };
+        let kanji_level = kanji_card.jlpt();
+        if kanji_level > user_level {
+            continue;
+        }
+
+        companions.push((*card_id, study_card));
+    }
+
+    companions
 }
 
 fn collect_kanji_ids(lesson_data: &LessonData, knowledge_set: &KnowledgeSet) -> Vec<Ulid> {
@@ -162,7 +280,7 @@ mod tests {
         let vocab_sc = ks.create_card(create_vocab_card(&first_popular)).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*kanji_sc.card_id()]);
-        let result = add_kanji_companions(lesson, &ks);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
 
         assert!(
             result.contains_key(vocab_sc.card_id()),
@@ -212,7 +330,7 @@ mod tests {
         );
 
         let lesson = build_empty_lesson_with_cards(&ks, &lesson_card_ids);
-        let result = add_kanji_companions(lesson, &ks);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
 
         let companion_count = result.len() - lesson_card_ids.len();
         assert!(
@@ -238,7 +356,7 @@ mod tests {
 
         let lesson =
             build_empty_lesson_with_cards(&ks, &[*kanji_sc.card_id(), *vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson.clone(), &ks);
+        let result = add_kanji_companions(lesson.clone(), &ks, JapaneseLevel::N5);
 
         let count = result
             .cards
@@ -259,7 +377,7 @@ mod tests {
         let vocab_sc = ks.create_card(create_vocab_card("猫")).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson.clone(), &ks);
+        let result = add_kanji_companions(lesson.clone(), &ks, JapaneseLevel::N5);
 
         assert_eq!(
             result.len(),
@@ -269,6 +387,215 @@ mod tests {
         assert_eq!(
             result.core_count, lesson.core_count,
             "core_count should remain unchanged"
+        );
+    }
+
+    // --- Reverse companion tests ---
+
+    #[test]
+    fn reverse_adds_kanji_from_vocab() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let vocab_sc = ks.create_card(create_vocab_card("日本")).unwrap();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+        let kanji_hon_sc = ks.create_card(create_kanji_card("本")).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        assert!(
+            result.contains_key(kanji_nichi_sc.card_id()),
+            "Kanji 日 should be added as reverse companion from vocab 日本"
+        );
+        assert!(
+            result.contains_key(kanji_hon_sc.card_id()),
+            "Kanji 本 should be added as reverse companion from vocab 日本"
+        );
+    }
+
+    #[test]
+    fn reverse_respects_jlpt_level_filter() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+        let nichi_level = if let Card::Kanji(k) = kanji_nichi_sc.card() {
+            k.jlpt()
+        } else {
+            panic!("Expected Kanji card");
+        };
+
+        let n1_kanji = "鬱";
+        let kanji_utsu_sc = ks.create_card(create_kanji_card(n1_kanji)).unwrap();
+        let utsu_level = if let Card::Kanji(k) = kanji_utsu_sc.card() {
+            k.jlpt()
+        } else {
+            panic!("Expected Kanji card");
+        };
+
+        assert!(
+            utsu_level > nichi_level,
+            "鬱 ({utsu_level:?}) should be higher JLPT than 日 ({nichi_level:?})"
+        );
+
+        let vocab_with_both = format!("{n1_kanji}日");
+        let vocab_sc = ks.create_card(create_vocab_card(&vocab_with_both)).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
+
+        let user_level = nichi_level;
+        let result = add_kanji_companions(lesson, &ks, user_level);
+
+        assert!(
+            result.contains_key(kanji_nichi_sc.card_id()),
+            "Kanji 日 ({nichi_level:?}) should be included at user_level={user_level:?}"
+        );
+        assert!(
+            !result.contains_key(kanji_utsu_sc.card_id()),
+            "Kanji 鬱 ({utsu_level:?}) should be excluded at user_level={user_level:?}"
+        );
+    }
+
+    #[test]
+    fn reverse_no_duplicate_kanji() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+        let vocab_sc = ks.create_card(create_vocab_card("日本")).unwrap();
+
+        let lesson =
+            build_empty_lesson_with_cards(&ks, &[*kanji_nichi_sc.card_id(), *vocab_sc.card_id()]);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        let count = result
+            .cards
+            .iter()
+            .filter(|(id, _)| *id == *kanji_nichi_sc.card_id())
+            .count();
+        assert_eq!(
+            count, 1,
+            "Kanji 日 already in lesson should not be duplicated by reverse"
+        );
+    }
+
+    #[test]
+    fn reverse_skips_kanji_not_in_deck() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let vocab_sc = ks.create_card(create_vocab_card("日本")).unwrap();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        assert!(
+            result.contains_key(kanji_nichi_sc.card_id()),
+            "Kanji 日 should be added (exists in KnowledgeSet)"
+        );
+
+        let reverse_kanji_count = result
+            .cards
+            .iter()
+            .filter(|(id, _)| *id != *vocab_sc.card_id() && *id != *kanji_nichi_sc.card_id())
+            .count();
+        assert_eq!(
+            reverse_kanji_count, 0,
+            "Kanji 本 should NOT be added (not in KnowledgeSet)"
+        );
+    }
+
+    #[test]
+    fn reverse_intra_dedup_shared_kanji() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let vocab_nihon_sc = ks.create_card(create_vocab_card("日本")).unwrap();
+        let vocab_nichiyoubi_sc = ks.create_card(create_vocab_card("日曜日")).unwrap();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(
+            &ks,
+            &[*vocab_nihon_sc.card_id(), *vocab_nichiyoubi_sc.card_id()],
+        );
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        let count = result
+            .cards
+            .iter()
+            .filter(|(id, _)| *id == *kanji_nichi_sc.card_id())
+            .count();
+        assert_eq!(
+            count, 1,
+            "Kanji 日 shared by two vocab words should be added exactly once"
+        );
+    }
+
+    #[test]
+    fn reverse_respects_max_limit() {
+        init_real_dictionaries();
+
+        let kanji_chars = [
+            "日", "本", "人", "大", "出", "見", "食", "飲", "行", "来", "読",
+        ];
+
+        let mut ks = KnowledgeSet::new();
+        let mut vocab_ids = Vec::new();
+
+        for ch in &kanji_chars {
+            ks.create_card(create_kanji_card(ch)).unwrap();
+        }
+
+        let vocab_word: String = kanji_chars.concat();
+        let vocab_sc = ks.create_card(create_vocab_card(&vocab_word)).unwrap();
+        vocab_ids.push(*vocab_sc.card_id());
+
+        let lesson = build_empty_lesson_with_cards(&ks, &vocab_ids);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        let reverse_count = result.cards.len() - vocab_ids.len();
+        assert!(
+            reverse_count <= MAX_REVERSE_COMPANION_CARDS_PER_LESSON,
+            "Reverse companions should be capped at {MAX_REVERSE_COMPANION_CARDS_PER_LESSON}, got {reverse_count}"
+        );
+        assert!(reverse_count > 0, "Should have some reverse companions");
+    }
+
+    #[test]
+    fn reverse_uses_forward_vocab_as_source() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+
+        let kanji_info = get_kanji_info("日").unwrap();
+
+        let popular_word = kanji_info
+            .popular_words()
+            .iter()
+            .find(|w| w.chars().any(|c| c.is_kanji() && c != '日'))
+            .expect("日 should have a popular word with a different kanji")
+            .clone();
+
+        let extra_kanji: char = popular_word
+            .chars()
+            .find(|c| c.is_kanji() && *c != '日')
+            .unwrap();
+        let extra_kanji_sc = ks
+            .create_card(create_kanji_card(&extra_kanji.to_string()))
+            .unwrap();
+
+        let _vocab_sc = ks.create_card(create_vocab_card(&popular_word)).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(&ks, &[*kanji_nichi_sc.card_id()]);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        assert!(
+            result.contains_key(extra_kanji_sc.card_id()),
+            "Kanji {extra_kanji} should be added via reverse from forward companion vocab '{popular_word}'"
         );
     }
 }

--- a/origa/src/domain/knowledge/lesson_builder.rs
+++ b/origa/src/domain/knowledge/lesson_builder.rs
@@ -8,7 +8,7 @@ use super::{Card, CardType, KnowledgeSet, StudyCard};
 use crate::domain::{JapaneseLevel, JlptContent};
 
 const MIN_LESSON_SIZE: usize = 15;
-const MAX_LESSON_SIZE: usize = 50;
+pub(crate) const MAX_LESSON_SIZE: usize = 50;
 const PHRASE_NEW_RATIO: usize = 2;
 
 /// Приоритет карточек без определённого JLPT уровня — ниже всех известных уровней (N1=1)

--- a/origa/src/domain/knowledge/mod.rs
+++ b/origa/src/domain/knowledge/mod.rs
@@ -29,7 +29,7 @@ use ulid::Ulid;
 
 use crate::dictionary::kanji::get_kanji_info;
 use crate::domain::{
-    JlptContent, NativeLanguage, OrigaError, RateMode, Rating, ReviewLog,
+    JapaneseLevel, JlptContent, NativeLanguage, OrigaError, RateMode, Rating, ReviewLog,
     srs::{NextReview, rate_memory},
 };
 
@@ -247,9 +247,10 @@ impl KnowledgeSet {
         &self,
         daily_new_limit: usize,
         jlpt_content: &JlptContent,
+        user_level: JapaneseLevel,
     ) -> LessonData {
         let lesson = lesson_builder::build_lesson(self, daily_new_limit, jlpt_content);
-        kanji_companions::add_kanji_companions(lesson, self)
+        kanji_companions::add_kanji_companions(lesson, self, user_level)
     }
 
     pub(crate) fn rate_card(

--- a/origa/src/domain/knowledge/tests.rs
+++ b/origa/src/domain/knowledge/tests.rs
@@ -28,7 +28,7 @@ fn cards_to_lesson_includes_favorite_cards() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
     assert!(result.contains_key(&card_id));
 }
 
@@ -50,7 +50,7 @@ fn cards_to_lesson_includes_high_difficulty_cards() {
         .rate_card(*study2.card_id(), Rating::Easy, RateMode::StandardLesson)
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(result.contains_key(study1.card_id()));
 }
@@ -473,7 +473,7 @@ fn recalculate_daily_stats_preserves_new_cards_on_create_card() {
             .unwrap();
     }
 
-    let lesson_cards = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let lesson_cards = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
     let new_in_lesson = lesson_cards
         .iter()
         .filter(|(id, _)| knowledge_set.get_card(**id).unwrap().memory().is_new())
@@ -537,7 +537,7 @@ fn new_cards_sorted_by_jlpt_level() {
         .create_card(create_vocab_card("走る"))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(2, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(2, &jlpt_content, JapaneseLevel::N5);
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -569,7 +569,7 @@ fn new_cards_unknown_level_go_last() {
         .create_card(create_vocab_card("食べる"))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(1, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(1, &jlpt_content, JapaneseLevel::N5);
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -614,7 +614,7 @@ fn new_cards_jlpt_sort_does_not_affect_other_categories() {
         .toggle_favorite(*study_nichi.card_id())
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(10, &jlpt_content, JapaneseLevel::N5);
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -675,7 +675,7 @@ fn new_cards_interleaved_by_type_within_jlpt_level() {
         )))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(5, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(5, &jlpt_content, JapaneseLevel::N5);
 
     assert_eq!(result.len(), 5, "Should return exactly 5 cards (limit=5)");
 
@@ -715,7 +715,7 @@ fn new_cards_interleave_handles_missing_type() {
         knowledge_set.create_card(create_vocab_card(word)).unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(5, &jlpt_content, JapaneseLevel::N5);
 
     assert_eq!(
         result.len(),
@@ -764,7 +764,7 @@ fn new_cards_interleave_across_jlpt_levels() {
         .create_card(Card::Kanji(KanjiCard::new_test("n4k1".to_string())))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(4, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(4, &jlpt_content, JapaneseLevel::N5);
 
     assert_eq!(result.len(), 4, "Should return exactly 4 cards (limit=4)");
 
@@ -823,7 +823,7 @@ fn new_cards_interleave_preserves_jlpt_priority() {
         knowledge_set.create_card(create_vocab_card(word)).unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(3, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(3, &jlpt_content, JapaneseLevel::N5);
 
     assert!(
         result.contains_key(study_n5.card_id()),
@@ -859,7 +859,7 @@ fn phrase_new_cards_limited() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
 
     let phrase_count = result
         .keys()
@@ -937,7 +937,7 @@ fn phrase_new_cards_zero_when_limit_below_ratio() {
     }
 
     // daily_new_limit=0 → phrase_new_limit=0
-    let result = knowledge_set.cards_to_lesson(0, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(0, &JlptContent::new(), JapaneseLevel::N5);
 
     let phrase_count = result
         .keys()
@@ -1006,7 +1006,7 @@ fn limited_types_still_respect_daily_limit() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(
         result.len() <= 5,
@@ -1032,7 +1032,7 @@ fn lesson_size_respects_max_limit() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(100, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(100, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(
         result.len() <= 50,
@@ -1055,7 +1055,7 @@ fn high_difficulty_cards_respect_max_lesson_size() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(
         result.len() <= 50,
@@ -1087,7 +1087,7 @@ fn phrases_added_after_core_cards_learning() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
 
     let core_count = result
         .keys()
@@ -1141,7 +1141,7 @@ fn phrases_added_after_core_cards_review() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
 
     let core_count = result
         .keys()
@@ -1195,7 +1195,7 @@ fn onboarding_scoring_does_not_consume_daily_limit() {
         "OnboardingScoring should not increment new_cards_studied_today"
     );
 
-    let result = knowledge_set.cards_to_lesson(15, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(15, &JlptContent::new(), JapaneseLevel::N5);
 
     let new_in_lesson = result
         .iter()
@@ -1221,7 +1221,7 @@ fn favorite_card_appears_once_when_due_high_difficulty() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     let count = result
         .card_ids()
@@ -1250,7 +1250,7 @@ fn favorite_card_appears_once_when_new() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     let count = result
         .card_ids()
@@ -1276,7 +1276,7 @@ fn favorite_card_appears_once_when_due_known() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     let count = result
         .card_ids()

--- a/origa/src/use_cases/select_cards_to_lesson.rs
+++ b/origa/src/use_cases/select_cards_to_lesson.rs
@@ -22,9 +22,10 @@ impl<'a, R: UserRepository> SelectCardsToLessonUseCase<'a, R> {
         debug!(user_id = %user.id(), "Selecting cards to lesson");
 
         let daily_new_limit = user.daily_load().new_cards_per_day();
-        let lesson_data = user
-            .knowledge_set()
-            .cards_to_lesson(daily_new_limit, jlpt_content);
+        let user_level = user.current_japanese_level();
+        let lesson_data =
+            user.knowledge_set()
+                .cards_to_lesson(daily_new_limit, jlpt_content, user_level);
 
         info!(user_id = %user.id(), count = lesson_data.total_count(), "Cards selected for lesson");
 


### PR DESCRIPTION
## Summary

Closes #37

Implements reverse kanji companion logic: when a vocab card appears in a lesson and contains kanji that exist in the user's deck, automatically add those kanji cards to the lesson.

### Changes
- **Reverse companion logic** in : extracts kanji from vocab words via , finds matching KanjiCard in KnowledgeSet, filters by JLPT level
- **JLPT level filter**: only adds kanji at or below user's current level (via )
- **Deduplication**:  at extraction level +  at lesson level
- **Cap**: min(10 reverse companions, remaining space in MAX_LESSON_SIZE=50)
- **Performance**:  index for O(1) kanji lookup instead of linear scan
- **Wiring**:  now accepts , passed from 
- **CI fix**: restore registry cache in docker.yml

### Test Coverage
- 7 new unit tests (basic, JLPT filter, dedup, limit, forward↔reverse interaction)
- 21 existing test calls updated
- **1189 tests passing, 0 failures, 0 clippy warnings**

### User remarks addressed
1. ✅ Only add kanji ≤ user's current JLPT level
2. ✅ Reverse companions capped, respecting MAX_LESSON_SIZE