### PR TITLE
fix(kanji-ui): fix 8 UI issues on kanji pages

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,6 @@ jobs:
         permissions:
             contents: read
             packages: write
-            actions: write
 
         steps:
             - name: Checkout repository
@@ -68,8 +67,8 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
+                  cache-from: type=registry,ref=ghcr.io/yurvon-screamo/origa:buildcache
+                  cache-to: type=registry,ref=ghcr.io/yurvon-screamo/origa:buildcache,mode=max
                   provenance: false
                   build-args: |
                       ORIGA_VERSION=${{ needs.version.outputs.version }}

--- a/end2end/tests/kanji.spec.ts
+++ b/end2end/tests/kanji.spec.ts
@@ -152,32 +152,6 @@ testWithFreshUser.describe("Kanji Page - Navigation", () => {
     });
 });
 
-testWithFreshUser.describe("Kanji Page - Mark as Known", () => {
-    testWithFreshUser("should display mark-as-known button on kanji card", async ({ page }) => {
-        test.setTimeout(60_000);
-        const kanjiPage = await setupKanjiPage(page);
-        await addFirstKanji(kanjiPage);
-        await expect(kanjiPage.kanjiGrid).toBeVisible({ timeout: 10_000 });
-
-        const markKnownBtn = page.getByTestId("kanji-card-item").first().getByTestId("kanji-card-item-mark-known-btn");
-        await expect(markKnownBtn).toBeVisible();
-    });
-
-    testWithFreshUser("should mark kanji as known and show in Learned filter", async ({ page }) => {
-        test.setTimeout(60_000);
-        const kanjiPage = await setupKanjiPage(page);
-        await addFirstKanji(kanjiPage);
-        await expect(kanjiPage.kanjiGrid).toBeVisible({ timeout: 10_000 });
-
-        const markKnownBtn = page.getByTestId("kanji-card-item").first().getByTestId("kanji-card-item-mark-known-btn");
-        await markKnownBtn.click();
-
-        await kanjiPage.selectFilter("Изученные");
-        await expect(kanjiPage.emptyState).not.toBeVisible({ timeout: 5000 });
-        expect(await kanjiPage.getCardCount()).toBeGreaterThanOrEqual(1);
-    });
-});
-
 testWithFreshUser.describe("Kanji Page - Pagination", () => {
     testWithFreshUser("should not show load-more button with few cards", async ({ page }) => {
         test.setTimeout(60_000);

--- a/origa/src/domain/knowledge/kanji_companions.rs
+++ b/origa/src/domain/knowledge/kanji_companions.rs
@@ -1,30 +1,148 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use ulid::Ulid;
 
 use super::lesson::{LessonCard, LessonData, LessonViewGenerator};
+use super::lesson_builder::MAX_LESSON_SIZE;
 use super::{Card, KnowledgeSet, MAX_COMPANION_WORDS};
 use crate::dictionary::kanji::get_kanji_info;
+use crate::domain::japanese::JapaneseChar;
+use crate::domain::value_objects::JapaneseLevel;
 
 const MAX_COMPANION_CARDS_PER_LESSON: usize = 15;
+const MAX_REVERSE_COMPANION_CARDS_PER_LESSON: usize = 10;
 
 pub(crate) fn add_kanji_companions(
     lesson_data: LessonData,
     knowledge_set: &KnowledgeSet,
+    user_level: JapaneseLevel,
 ) -> LessonData {
+    let already_in_lesson: HashSet<Ulid> = lesson_data.cards.iter().map(|(id, _)| *id).collect();
+
+    let (lesson_data, already_in_lesson) =
+        add_forward_companions(lesson_data, knowledge_set, already_in_lesson);
+
+    add_reverse_companions(lesson_data, knowledge_set, user_level, &already_in_lesson)
+}
+
+fn add_forward_companions(
+    lesson_data: LessonData,
+    knowledge_set: &KnowledgeSet,
+    mut already_in_lesson: HashSet<Ulid>,
+) -> (LessonData, HashSet<Ulid>) {
     let kanji_ids = collect_kanji_ids(&lesson_data, knowledge_set);
     if kanji_ids.is_empty() {
-        return lesson_data;
+        return (lesson_data, already_in_lesson);
     }
-
-    let already_in_lesson: HashSet<Ulid> = lesson_data.cards.iter().map(|(id, _)| *id).collect();
 
     let companions = find_companion_cards(&kanji_ids, knowledge_set, &already_in_lesson);
     if companions.is_empty() {
+        return (lesson_data, already_in_lesson);
+    }
+
+    for (id, _) in &companions {
+        already_in_lesson.insert(*id);
+    }
+
+    (
+        append_companions(lesson_data, knowledge_set, &companions),
+        already_in_lesson,
+    )
+}
+
+fn add_reverse_companions(
+    lesson_data: LessonData,
+    knowledge_set: &KnowledgeSet,
+    user_level: JapaneseLevel,
+    already_in_lesson: &HashSet<Ulid>,
+) -> LessonData {
+    let kanji_index: HashMap<char, (&Ulid, &super::StudyCard)> = knowledge_set
+        .study_cards()
+        .iter()
+        .filter_map(|(id, sc)| {
+            let Card::Kanji(k) = sc.card() else {
+                return None;
+            };
+            k.kanji().text().chars().next().map(|ch| (ch, (id, sc)))
+        })
+        .collect();
+
+    let vocab_kanji_chars = collect_kanji_from_vocab(&lesson_data, knowledge_set);
+    if vocab_kanji_chars.is_empty() {
         return lesson_data;
     }
 
-    append_companions(lesson_data, knowledge_set, &companions)
+    let candidates = find_reverse_companions(
+        &vocab_kanji_chars,
+        &kanji_index,
+        already_in_lesson,
+        user_level,
+    );
+    if candidates.is_empty() {
+        return lesson_data;
+    }
+
+    let effective_limit = MAX_REVERSE_COMPANION_CARDS_PER_LESSON
+        .min(MAX_LESSON_SIZE.saturating_sub(lesson_data.cards.len()));
+    let capped: Vec<_> = candidates.into_iter().take(effective_limit).collect();
+
+    append_companions(lesson_data, knowledge_set, &capped)
+}
+
+fn collect_kanji_from_vocab(
+    lesson_data: &LessonData,
+    knowledge_set: &KnowledgeSet,
+) -> HashSet<char> {
+    let mut kanji_chars = HashSet::new();
+
+    for (id, _) in &lesson_data.cards {
+        let study_card = match knowledge_set.get_card(*id) {
+            Some(sc) => sc,
+            None => continue,
+        };
+
+        if let Card::Vocabulary(v) = study_card.card() {
+            for ch in v.word().text().chars() {
+                if ch.is_kanji() {
+                    kanji_chars.insert(ch);
+                }
+            }
+        }
+    }
+
+    kanji_chars
+}
+
+fn find_reverse_companions<'a>(
+    kanji_chars: &HashSet<char>,
+    kanji_index: &HashMap<char, (&'a Ulid, &'a super::StudyCard)>,
+    already_in_lesson: &HashSet<Ulid>,
+    user_level: JapaneseLevel,
+) -> Vec<(Ulid, &'a super::StudyCard)> {
+    let mut companions = Vec::new();
+
+    for &ch in kanji_chars {
+        let (card_id, study_card) = match kanji_index.get(&ch) {
+            Some(&(id, sc)) => (id, sc),
+            None => continue,
+        };
+
+        if already_in_lesson.contains(card_id) {
+            continue;
+        }
+
+        let Card::Kanji(kanji_card) = study_card.card() else {
+            continue;
+        };
+        let kanji_level = kanji_card.jlpt();
+        if kanji_level > user_level {
+            continue;
+        }
+
+        companions.push((*card_id, study_card));
+    }
+
+    companions
 }
 
 fn collect_kanji_ids(lesson_data: &LessonData, knowledge_set: &KnowledgeSet) -> Vec<Ulid> {
@@ -162,7 +280,7 @@ mod tests {
         let vocab_sc = ks.create_card(create_vocab_card(&first_popular)).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*kanji_sc.card_id()]);
-        let result = add_kanji_companions(lesson, &ks);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
 
         assert!(
             result.contains_key(vocab_sc.card_id()),
@@ -212,7 +330,7 @@ mod tests {
         );
 
         let lesson = build_empty_lesson_with_cards(&ks, &lesson_card_ids);
-        let result = add_kanji_companions(lesson, &ks);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
 
         let companion_count = result.len() - lesson_card_ids.len();
         assert!(
@@ -238,7 +356,7 @@ mod tests {
 
         let lesson =
             build_empty_lesson_with_cards(&ks, &[*kanji_sc.card_id(), *vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson.clone(), &ks);
+        let result = add_kanji_companions(lesson.clone(), &ks, JapaneseLevel::N5);
 
         let count = result
             .cards
@@ -259,7 +377,7 @@ mod tests {
         let vocab_sc = ks.create_card(create_vocab_card("猫")).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson.clone(), &ks);
+        let result = add_kanji_companions(lesson.clone(), &ks, JapaneseLevel::N5);
 
         assert_eq!(
             result.len(),
@@ -269,6 +387,215 @@ mod tests {
         assert_eq!(
             result.core_count, lesson.core_count,
             "core_count should remain unchanged"
+        );
+    }
+
+    // --- Reverse companion tests ---
+
+    #[test]
+    fn reverse_adds_kanji_from_vocab() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let vocab_sc = ks.create_card(create_vocab_card("日本")).unwrap();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+        let kanji_hon_sc = ks.create_card(create_kanji_card("本")).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        assert!(
+            result.contains_key(kanji_nichi_sc.card_id()),
+            "Kanji 日 should be added as reverse companion from vocab 日本"
+        );
+        assert!(
+            result.contains_key(kanji_hon_sc.card_id()),
+            "Kanji 本 should be added as reverse companion from vocab 日本"
+        );
+    }
+
+    #[test]
+    fn reverse_respects_jlpt_level_filter() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+        let nichi_level = if let Card::Kanji(k) = kanji_nichi_sc.card() {
+            k.jlpt()
+        } else {
+            panic!("Expected Kanji card");
+        };
+
+        let n1_kanji = "鬱";
+        let kanji_utsu_sc = ks.create_card(create_kanji_card(n1_kanji)).unwrap();
+        let utsu_level = if let Card::Kanji(k) = kanji_utsu_sc.card() {
+            k.jlpt()
+        } else {
+            panic!("Expected Kanji card");
+        };
+
+        assert!(
+            utsu_level > nichi_level,
+            "鬱 ({utsu_level:?}) should be higher JLPT than 日 ({nichi_level:?})"
+        );
+
+        let vocab_with_both = format!("{n1_kanji}日");
+        let vocab_sc = ks.create_card(create_vocab_card(&vocab_with_both)).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
+
+        let user_level = nichi_level;
+        let result = add_kanji_companions(lesson, &ks, user_level);
+
+        assert!(
+            result.contains_key(kanji_nichi_sc.card_id()),
+            "Kanji 日 ({nichi_level:?}) should be included at user_level={user_level:?}"
+        );
+        assert!(
+            !result.contains_key(kanji_utsu_sc.card_id()),
+            "Kanji 鬱 ({utsu_level:?}) should be excluded at user_level={user_level:?}"
+        );
+    }
+
+    #[test]
+    fn reverse_no_duplicate_kanji() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+        let vocab_sc = ks.create_card(create_vocab_card("日本")).unwrap();
+
+        let lesson =
+            build_empty_lesson_with_cards(&ks, &[*kanji_nichi_sc.card_id(), *vocab_sc.card_id()]);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        let count = result
+            .cards
+            .iter()
+            .filter(|(id, _)| *id == *kanji_nichi_sc.card_id())
+            .count();
+        assert_eq!(
+            count, 1,
+            "Kanji 日 already in lesson should not be duplicated by reverse"
+        );
+    }
+
+    #[test]
+    fn reverse_skips_kanji_not_in_deck() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let vocab_sc = ks.create_card(create_vocab_card("日本")).unwrap();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        assert!(
+            result.contains_key(kanji_nichi_sc.card_id()),
+            "Kanji 日 should be added (exists in KnowledgeSet)"
+        );
+
+        let reverse_kanji_count = result
+            .cards
+            .iter()
+            .filter(|(id, _)| *id != *vocab_sc.card_id() && *id != *kanji_nichi_sc.card_id())
+            .count();
+        assert_eq!(
+            reverse_kanji_count, 0,
+            "Kanji 本 should NOT be added (not in KnowledgeSet)"
+        );
+    }
+
+    #[test]
+    fn reverse_intra_dedup_shared_kanji() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let vocab_nihon_sc = ks.create_card(create_vocab_card("日本")).unwrap();
+        let vocab_nichiyoubi_sc = ks.create_card(create_vocab_card("日曜日")).unwrap();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(
+            &ks,
+            &[*vocab_nihon_sc.card_id(), *vocab_nichiyoubi_sc.card_id()],
+        );
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        let count = result
+            .cards
+            .iter()
+            .filter(|(id, _)| *id == *kanji_nichi_sc.card_id())
+            .count();
+        assert_eq!(
+            count, 1,
+            "Kanji 日 shared by two vocab words should be added exactly once"
+        );
+    }
+
+    #[test]
+    fn reverse_respects_max_limit() {
+        init_real_dictionaries();
+
+        let kanji_chars = [
+            "日", "本", "人", "大", "出", "見", "食", "飲", "行", "来", "読",
+        ];
+
+        let mut ks = KnowledgeSet::new();
+        let mut vocab_ids = Vec::new();
+
+        for ch in &kanji_chars {
+            ks.create_card(create_kanji_card(ch)).unwrap();
+        }
+
+        let vocab_word: String = kanji_chars.concat();
+        let vocab_sc = ks.create_card(create_vocab_card(&vocab_word)).unwrap();
+        vocab_ids.push(*vocab_sc.card_id());
+
+        let lesson = build_empty_lesson_with_cards(&ks, &vocab_ids);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        let reverse_count = result.cards.len() - vocab_ids.len();
+        assert!(
+            reverse_count <= MAX_REVERSE_COMPANION_CARDS_PER_LESSON,
+            "Reverse companions should be capped at {MAX_REVERSE_COMPANION_CARDS_PER_LESSON}, got {reverse_count}"
+        );
+        assert!(reverse_count > 0, "Should have some reverse companions");
+    }
+
+    #[test]
+    fn reverse_uses_forward_vocab_as_source() {
+        init_real_dictionaries();
+
+        let mut ks = KnowledgeSet::new();
+        let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
+
+        let kanji_info = get_kanji_info("日").unwrap();
+
+        let popular_word = kanji_info
+            .popular_words()
+            .iter()
+            .find(|w| w.chars().any(|c| c.is_kanji() && c != '日'))
+            .expect("日 should have a popular word with a different kanji")
+            .clone();
+
+        let extra_kanji: char = popular_word
+            .chars()
+            .find(|c| c.is_kanji() && *c != '日')
+            .unwrap();
+        let extra_kanji_sc = ks
+            .create_card(create_kanji_card(&extra_kanji.to_string()))
+            .unwrap();
+
+        let _vocab_sc = ks.create_card(create_vocab_card(&popular_word)).unwrap();
+
+        let lesson = build_empty_lesson_with_cards(&ks, &[*kanji_nichi_sc.card_id()]);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+
+        assert!(
+            result.contains_key(extra_kanji_sc.card_id()),
+            "Kanji {extra_kanji} should be added via reverse from forward companion vocab '{popular_word}'"
         );
     }
 }

--- a/origa/src/domain/knowledge/lesson_builder.rs
+++ b/origa/src/domain/knowledge/lesson_builder.rs
@@ -8,7 +8,7 @@ use super::{Card, CardType, KnowledgeSet, StudyCard};
 use crate::domain::{JapaneseLevel, JlptContent};
 
 const MIN_LESSON_SIZE: usize = 15;
-const MAX_LESSON_SIZE: usize = 50;
+pub(crate) const MAX_LESSON_SIZE: usize = 50;
 const PHRASE_NEW_RATIO: usize = 2;
 
 /// Приоритет карточек без определённого JLPT уровня — ниже всех известных уровней (N1=1)

--- a/origa/src/domain/knowledge/mod.rs
+++ b/origa/src/domain/knowledge/mod.rs
@@ -29,7 +29,7 @@ use ulid::Ulid;
 
 use crate::dictionary::kanji::get_kanji_info;
 use crate::domain::{
-    JlptContent, NativeLanguage, OrigaError, RateMode, Rating, ReviewLog,
+    JapaneseLevel, JlptContent, NativeLanguage, OrigaError, RateMode, Rating, ReviewLog,
     srs::{NextReview, rate_memory},
 };
 
@@ -247,9 +247,10 @@ impl KnowledgeSet {
         &self,
         daily_new_limit: usize,
         jlpt_content: &JlptContent,
+        user_level: JapaneseLevel,
     ) -> LessonData {
         let lesson = lesson_builder::build_lesson(self, daily_new_limit, jlpt_content);
-        kanji_companions::add_kanji_companions(lesson, self)
+        kanji_companions::add_kanji_companions(lesson, self, user_level)
     }
 
     pub(crate) fn rate_card(

--- a/origa/src/domain/knowledge/tests.rs
+++ b/origa/src/domain/knowledge/tests.rs
@@ -28,7 +28,7 @@ fn cards_to_lesson_includes_favorite_cards() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
     assert!(result.contains_key(&card_id));
 }
 
@@ -50,7 +50,7 @@ fn cards_to_lesson_includes_high_difficulty_cards() {
         .rate_card(*study2.card_id(), Rating::Easy, RateMode::StandardLesson)
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(result.contains_key(study1.card_id()));
 }
@@ -473,7 +473,7 @@ fn recalculate_daily_stats_preserves_new_cards_on_create_card() {
             .unwrap();
     }
 
-    let lesson_cards = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let lesson_cards = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
     let new_in_lesson = lesson_cards
         .iter()
         .filter(|(id, _)| knowledge_set.get_card(**id).unwrap().memory().is_new())
@@ -537,7 +537,7 @@ fn new_cards_sorted_by_jlpt_level() {
         .create_card(create_vocab_card("走る"))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(2, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(2, &jlpt_content, JapaneseLevel::N5);
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -569,7 +569,7 @@ fn new_cards_unknown_level_go_last() {
         .create_card(create_vocab_card("食べる"))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(1, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(1, &jlpt_content, JapaneseLevel::N5);
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -614,7 +614,7 @@ fn new_cards_jlpt_sort_does_not_affect_other_categories() {
         .toggle_favorite(*study_nichi.card_id())
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(10, &jlpt_content, JapaneseLevel::N5);
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -675,7 +675,7 @@ fn new_cards_interleaved_by_type_within_jlpt_level() {
         )))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(5, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(5, &jlpt_content, JapaneseLevel::N5);
 
     assert_eq!(result.len(), 5, "Should return exactly 5 cards (limit=5)");
 
@@ -715,7 +715,7 @@ fn new_cards_interleave_handles_missing_type() {
         knowledge_set.create_card(create_vocab_card(word)).unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(5, &jlpt_content, JapaneseLevel::N5);
 
     assert_eq!(
         result.len(),
@@ -764,7 +764,7 @@ fn new_cards_interleave_across_jlpt_levels() {
         .create_card(Card::Kanji(KanjiCard::new_test("n4k1".to_string())))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(4, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(4, &jlpt_content, JapaneseLevel::N5);
 
     assert_eq!(result.len(), 4, "Should return exactly 4 cards (limit=4)");
 
@@ -823,7 +823,7 @@ fn new_cards_interleave_preserves_jlpt_priority() {
         knowledge_set.create_card(create_vocab_card(word)).unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(3, &jlpt_content);
+    let result = knowledge_set.cards_to_lesson(3, &jlpt_content, JapaneseLevel::N5);
 
     assert!(
         result.contains_key(study_n5.card_id()),
@@ -859,7 +859,7 @@ fn phrase_new_cards_limited() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
 
     let phrase_count = result
         .keys()
@@ -937,7 +937,7 @@ fn phrase_new_cards_zero_when_limit_below_ratio() {
     }
 
     // daily_new_limit=0 → phrase_new_limit=0
-    let result = knowledge_set.cards_to_lesson(0, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(0, &JlptContent::new(), JapaneseLevel::N5);
 
     let phrase_count = result
         .keys()
@@ -1006,7 +1006,7 @@ fn limited_types_still_respect_daily_limit() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(
         result.len() <= 5,
@@ -1032,7 +1032,7 @@ fn lesson_size_respects_max_limit() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(100, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(100, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(
         result.len() <= 50,
@@ -1055,7 +1055,7 @@ fn high_difficulty_cards_respect_max_lesson_size() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(
         result.len() <= 50,
@@ -1087,7 +1087,7 @@ fn phrases_added_after_core_cards_learning() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
 
     let core_count = result
         .keys()
@@ -1141,7 +1141,7 @@ fn phrases_added_after_core_cards_review() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
 
     let core_count = result
         .keys()
@@ -1195,7 +1195,7 @@ fn onboarding_scoring_does_not_consume_daily_limit() {
         "OnboardingScoring should not increment new_cards_studied_today"
     );
 
-    let result = knowledge_set.cards_to_lesson(15, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(15, &JlptContent::new(), JapaneseLevel::N5);
 
     let new_in_lesson = result
         .iter()
@@ -1221,7 +1221,7 @@ fn favorite_card_appears_once_when_due_high_difficulty() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     let count = result
         .card_ids()
@@ -1250,7 +1250,7 @@ fn favorite_card_appears_once_when_new() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     let count = result
         .card_ids()
@@ -1276,7 +1276,7 @@ fn favorite_card_appears_once_when_due_known() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new());
+    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     let count = result
         .card_ids()

--- a/origa/src/use_cases/select_cards_to_lesson.rs
+++ b/origa/src/use_cases/select_cards_to_lesson.rs
@@ -22,9 +22,10 @@ impl<'a, R: UserRepository> SelectCardsToLessonUseCase<'a, R> {
         debug!(user_id = %user.id(), "Selecting cards to lesson");
 
         let daily_new_limit = user.daily_load().new_cards_per_day();
-        let lesson_data = user
-            .knowledge_set()
-            .cards_to_lesson(daily_new_limit, jlpt_content);
+        let user_level = user.current_japanese_level();
+        let lesson_data =
+            user.knowledge_set()
+                .cards_to_lesson(daily_new_limit, jlpt_content, user_level);
 
         info!(user_id = %user.id(), count = lesson_data.total_count(), "Cards selected for lesson");
 

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -4307,6 +4307,10 @@ input[type="submit"],
     margin-bottom: 16px;
 }
 
+.kanji-detail-top-bar .fsrs-bar {
+    width: 80px;
+}
+
 .kanji-breadcrumbs {
     display: flex;
     align-items: center;
@@ -4467,6 +4471,10 @@ input[type="submit"],
     border-top: 1px solid var(--border-light);
     justify-content: space-between;
     align-items: center;
+}
+
+.kanji-detail-hero-actions .fsrs-bar {
+    width: 80px;
 }
 
 /* Section Card */
@@ -4753,14 +4761,14 @@ input[type="submit"],
 /* === Kanji Card Badge === */
 .kanji-card-badge {
     position: absolute;
-    top: 8px;
+    top: 12px;
     right: 8px;
     z-index: 10;
 }
 
 .kanji-card-badge .tag {
-    font-size: 10px;
-    padding: 4px 8px;
+    font-size: 9px;
+    padding: 2px 6px;
     letter-spacing: 0.1em;
 }
 
@@ -4809,7 +4817,7 @@ input[type="submit"],
     letter-spacing: 0.1em;
     text-transform: uppercase;
     flex-shrink: 0;
-    min-width: 12px;
+    min-width: 16px;
 }
 
 /* Fill-bar */
@@ -4846,7 +4854,6 @@ input[type="submit"],
 .fsrs-value {
     font-variant-numeric: tabular-nums;
     color: var(--fg-black);
-    min-width: 24px;
     text-align: right;
 }
 

--- a/origa_ui/locales/en.json
+++ b/origa_ui/locales/en.json
@@ -481,6 +481,8 @@
         "fsrs_next_review": "Next review",
         "fsrs_difficulty": "Difficulty",
         "fsrs_stability": "Stability",
+        "fsrs_difficulty_short": "D",
+        "fsrs_stability_short": "S",
         "radicals_label": "Radicals: {}",
         "examples_label": "Examples: {}",
         "user_not_found": "User not found",

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -481,6 +481,8 @@
     "fsrs_next_review": "Следующий повтор",
     "fsrs_difficulty": "Сложность",
     "fsrs_stability": "Стабильность",
+    "fsrs_difficulty_short": "Сл.",
+    "fsrs_stability_short": "Стб.",
     "radicals_label": "Радикалы: {}",
     "examples_label": "Примеры: {}",
     "user_not_found": "Пользователь не найден",

--- a/origa_ui/src/pages/kanji/content.rs
+++ b/origa_ui/src/pages/kanji/content.rs
@@ -1,6 +1,6 @@
 use super::super::shared::{
     CardCounts, CardStatus, Filter, FilterBtn, LoadMoreButton, create_delete_callback,
-    create_mark_as_known_callback, create_toggle_favorite_callback,
+    create_toggle_favorite_callback,
 };
 use super::kanji_card_item::KanjiCardItem;
 use crate::i18n::{t, use_i18n};
@@ -84,8 +84,6 @@ pub fn KanjiContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
 
     let on_toggle_favorite =
         create_toggle_favorite_callback(repository.clone(), current_user, refresh_trigger);
-
-    let on_mark_as_known = create_mark_as_known_callback(repository.clone(), refresh_trigger);
 
     let (is_deleting, on_delete) =
         create_delete_callback(repository.clone(), toasts, refresh_trigger);
@@ -189,13 +187,11 @@ pub fn KanjiContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
                                     each=move || visible_cards.get()
                                     key=|card| format!("{}-{}", card.card_id(), card.is_favorite())
                                     children=move |card| {
-                                        let card_id_for_callbacks = *card.card_id();
                                         view! {
                                             <KanjiCardItem
                                                 study_card=card
                                                 native_language=native_lang
                                                 on_toggle_favorite=on_toggle_favorite
-                                                on_mark_as_known=Callback::new(move |_| on_mark_as_known.run(card_id_for_callbacks))
                                                 on_delete=on_delete
                                                 is_deleting=is_deleting.into()
                                             />

--- a/origa_ui/src/pages/kanji/kanji_card_item.rs
+++ b/origa_ui/src/pages/kanji/kanji_card_item.rs
@@ -1,8 +1,6 @@
 use super::super::shared::{CardStatus, DeleteRequest};
 use crate::i18n::use_i18n;
-use crate::ui_components::{
-    CardActionBar, CardHistoryModal, DeleteConfirmModal, FsrsMetrics, Tag, TagVariant,
-};
+use crate::ui_components::{CardActionBar, DeleteConfirmModal, FsrsMetrics, Tag, TagVariant};
 use leptos::prelude::*;
 use leptos_router::components::A;
 use origa::domain::{Card as DomainCard, NativeLanguage, StudyCard};
@@ -15,7 +13,6 @@ pub fn KanjiCardItem(
     study_card: StudyCard,
     #[prop(into)] native_language: Signal<NativeLanguage>,
     on_toggle_favorite: Callback<Ulid>,
-    on_mark_as_known: Callback<()>,
     on_delete: Callback<DeleteRequest>,
     is_deleting: Signal<bool>,
 ) -> impl IntoView {
@@ -23,9 +20,7 @@ pub fn KanjiCardItem(
     let card_id = *study_card.card_id();
     let is_favorite = study_card.is_favorite();
     let memory = study_card.memory();
-    let memory_clone = memory.clone();
 
-    let is_history_open = RwSignal::new(false);
     let is_delete_modal_open = RwSignal::new(false);
 
     let confirm_delete = Callback::new(move |_| {
@@ -101,9 +96,6 @@ pub fn KanjiCardItem(
                         tag_label=Signal::derive(|| "".to_string())
                         is_favorite=Signal::derive(move || is_favorite)
                         on_toggle_favorite=Callback::new(move |_| on_toggle_favorite.run(card_id))
-                        show_mark_as_known=Signal::derive(move || status != CardStatus::Learned)
-                        on_mark_as_known=Callback::new(move |_| on_mark_as_known.run(()))
-                        on_history=Callback::new(move |_| is_history_open.set(true))
                         on_delete=Callback::new(move |_| is_delete_modal_open.set(true))
                         test_id=Signal::derive(|| "kanji-card-item".to_string())
                         show_tag=Signal::derive(|| false)
@@ -117,11 +109,6 @@ pub fn KanjiCardItem(
             is_deleting=is_deleting
             on_confirm=confirm_delete
             on_close=Callback::new(move |_| is_delete_modal_open.set(false))
-        />
-        <CardHistoryModal
-            is_open=Signal::derive(move || is_history_open.get())
-            memory=memory_clone.clone()
-            on_close=Callback::new(move |_| is_history_open.set(false))
         />
     }
 }

--- a/origa_ui/src/pages/kanji/kanji_detail.rs
+++ b/origa_ui/src/pages/kanji/kanji_detail.rs
@@ -8,8 +8,8 @@ use crate::i18n::use_i18n;
 use crate::repository::HybridUserRepository;
 use crate::ui_components::{
     CardActionBar, CardHistoryModal, DeleteConfirmModal, FsrsMetrics, FsrsMetricsMode,
-    KanjiDrawingPractice, KanjiViewMode, KanjiWritingSection, LoadingOverlay, MarkdownText,
-    TabItem, Tabs, Tag, Text, TextSize, TypographyVariant,
+    FuriganaText, KanjiDrawingPractice, KanjiViewMode, KanjiWritingSection, LoadingOverlay,
+    MarkdownText, TabItem, Tabs, Tag, Text, TextSize, TypographyVariant,
 };
 use leptos::prelude::*;
 use leptos::task::spawn_local;
@@ -371,10 +371,10 @@ pub fn KanjiDetail() -> impl IntoView {
                                                             </div>
                                                             <div>
                                                                 <div class="kanji-vocab-item-reading">
-                                                                    {word}
+                                                                    <FuriganaText text=word.clone() known_kanji=known_kanji.get()/>
                                                                 </div>
                                                                 <div class="kanji-vocab-item-meaning">
-                                                                    {meaning}
+                                                                    <MarkdownText content=Signal::derive(move || meaning.clone()) known_kanji=known_kanji.get()/>
                                                                 </div>
                                                             </div>
                                                         </div>
@@ -617,12 +617,14 @@ fn MobileOverview(
     example_words: Memo<Vec<(String, String)>>,
     known_kanji: HashSet<char>,
 ) -> impl IntoView {
+    let known_kanji_stored = StoredValue::new(known_kanji);
+
     view! {
         <Show when=move || !description.get().is_empty()>
             <div class="kanji-detail-section">
                 <MarkdownText
                     content=Signal::derive(move || description.get())
-                    known_kanji=known_kanji.clone()
+                    known_kanji=known_kanji_stored.get_value()
                 />
             </div>
         </Show>
@@ -650,8 +652,12 @@ fn MobileOverview(
                                         {word.chars().next().unwrap_or('?').to_string()}
                                     </div>
                                     <div>
-                                        <div class="kanji-vocab-item-reading">{word}</div>
-                                        <div class="kanji-vocab-item-meaning">{meaning}</div>
+                                        <div class="kanji-vocab-item-reading">
+                                            <FuriganaText text=word.clone() known_kanji=known_kanji_stored.get_value()/>
+                                        </div>
+                                        <div class="kanji-vocab-item-meaning">
+                                            <MarkdownText content=Signal::derive(move || meaning.clone()) known_kanji=known_kanji_stored.get_value()/>
+                                        </div>
                                     </div>
                                 </div>
                             }

--- a/origa_ui/src/ui_components/fsrs_metrics.rs
+++ b/origa_ui/src/ui_components/fsrs_metrics.rs
@@ -59,8 +59,8 @@ fn stability_fill(s: f64) -> f64 {
     (s / 30.0).min(1.0) * 100.0
 }
 
-fn difficulty_color_class(d: f64, s: f64) -> &'static str {
-    if d >= 7.0 && s < 7.0 {
+fn difficulty_color_class(d: f64) -> &'static str {
+    if d >= 7.0 {
         "fsrs-bar--terracotta"
     } else if d >= 4.0 {
         "fsrs-bar--gold"
@@ -70,7 +70,7 @@ fn difficulty_color_class(d: f64, s: f64) -> &'static str {
 }
 
 fn stability_color_class(s: f64) -> &'static str {
-    if s > 21.0 {
+    if s >= 21.0 {
         "fsrs-bar--olive"
     } else if s >= 7.0 {
         "fsrs-bar--gold"
@@ -94,29 +94,44 @@ pub fn FsrsMetrics(
     };
 
     match mode {
-        FsrsMetricsMode::Compact => view! {
-            <span class="fsrs-metrics" role="group" aria-label="FSRS metrics" data-testid=test_id_val>
-                <CompactMetric
-                    label="D"
-                    value=difficulty
-                    fill_fn=difficulty_fill
-                    color_fn=move |d, s| difficulty_color_class(d, s)
-                    other_value=stability
-                    aria_label="Difficulty"
-                    aria_max="10"
-                />
-                <CompactMetric
-                    label="S"
-                    value=stability
-                    fill_fn=stability_fill
-                    color_fn=move |_, s| stability_color_class(s)
-                    other_value=difficulty
-                    aria_label="Stability"
-                    aria_max="30"
-                />
-            </span>
-        }
-        .into_any(),
+        FsrsMetricsMode::Compact => {
+            let difficulty_short = i18n
+                .get_keys()
+                .shared()
+                .fsrs_difficulty_short()
+                .inner()
+                .to_string();
+            let stability_short = i18n
+                .get_keys()
+                .shared()
+                .fsrs_stability_short()
+                .inner()
+                .to_string();
+
+            view! {
+                <span class="fsrs-metrics" role="group" aria-label="FSRS metrics" data-testid=test_id_val>
+                    <CompactMetric
+                        label=difficulty_short
+                        value=difficulty
+                        fill_fn=difficulty_fill
+                        color_fn=move |d, _| difficulty_color_class(d)
+                        other_value=stability
+                        aria_label="Difficulty"
+                        aria_max="10"
+                    />
+                    <CompactMetric
+                        label=stability_short
+                        value=stability
+                        fill_fn=stability_fill
+                        color_fn=move |_, s| stability_color_class(s)
+                        other_value=difficulty
+                        aria_label="Stability"
+                        aria_max="30"
+                    />
+                </span>
+            }
+                .into_any()
+        },
         FsrsMetricsMode::Expanded => {
             let next_review_label = i18n
                 .get_keys()
@@ -158,7 +173,7 @@ pub fn FsrsMetrics(
                         label=difficulty_label
                         value=difficulty
                         fill_fn=difficulty_fill
-                        color_fn=move |d, s| difficulty_color_class(d, s)
+                        color_fn=move |d, _| difficulty_color_class(d)
                         other_value=stability
                         aria_label="Difficulty"
                         aria_max="10"
@@ -174,14 +189,14 @@ pub fn FsrsMetrics(
                     />
                 </div>
             }
-                .into_any()
-        }
+            .into_any()
+        },
     }
 }
 
 #[component]
 fn CompactMetric(
-    #[prop(into)] label: &'static str,
+    #[prop(into)] label: String,
     value: Option<f64>,
     fill_fn: fn(f64) -> f64,
     color_fn: impl Fn(f64, f64) -> &'static str + 'static,
@@ -205,7 +220,6 @@ fn CompactMetric(
                 class=format!("fsrs-bar {color_class}", color_class = data.color_class)
                 style=format!("--fsrs-fill: {fill_pct:.0}%", fill_pct = data.fill_pct)
             ></span>
-            <span class=data.value_class>{data.value_display}</span>
         </span>
     }
 }
@@ -243,5 +257,46 @@ fn ExpandedMetric(
                 <span class=data.value_class>{data.value_display}</span>
             </div>
         </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_difficulty_color_class() {
+        assert_eq!(difficulty_color_class(8.0), "fsrs-bar--terracotta");
+        assert_eq!(difficulty_color_class(7.0), "fsrs-bar--terracotta");
+        assert_eq!(difficulty_color_class(5.0), "fsrs-bar--gold");
+        assert_eq!(difficulty_color_class(4.0), "fsrs-bar--gold");
+        assert_eq!(difficulty_color_class(2.0), "fsrs-bar--olive");
+        assert_eq!(difficulty_color_class(0.0), "fsrs-bar--olive");
+    }
+
+    #[test]
+    fn test_stability_color_class() {
+        assert_eq!(stability_color_class(25.0), "fsrs-bar--olive");
+        assert_eq!(stability_color_class(21.0), "fsrs-bar--olive");
+        assert_eq!(stability_color_class(10.0), "fsrs-bar--gold");
+        assert_eq!(stability_color_class(7.0), "fsrs-bar--gold");
+        assert_eq!(stability_color_class(3.0), "fsrs-bar--terracotta");
+        assert_eq!(stability_color_class(0.0), "fsrs-bar--terracotta");
+    }
+
+    #[test]
+    fn test_difficulty_fill() {
+        assert_eq!(difficulty_fill(5.0), 50.0);
+        assert_eq!(difficulty_fill(10.0), 100.0);
+        assert_eq!(difficulty_fill(15.0), 100.0);
+        assert_eq!(difficulty_fill(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_stability_fill() {
+        assert_eq!(stability_fill(15.0), 50.0);
+        assert_eq!(stability_fill(30.0), 100.0);
+        assert_eq!(stability_fill(45.0), 100.0);
+        assert_eq!(stability_fill(0.0), 0.0);
     }
 }


### PR DESCRIPTION
Closes #29

## Changes

Fixes all 8 alpha-test blocker UI issues on /kanji and /kanji/{X} pages.

### /kanji (list page)
1. **FSRS labels unclear** → i18n short labels (Сл./Стб. in RU)
2. **Confusing numbers** → removed from compact mode
3. **Color scheme broken** → difficulty color depends only on d value
4. **Buttons overflow + empty space** → only favorite + delete remain
5. **Badge overlaps translation** → moved higher, made smaller

### /kanji/{X} (detail page)
6. Same FSRS fixes as above (shared component)
7. **Progress bar too narrow** → widened to 80px
8. **No furigana/markdown in vocab** → added FuriganaText + MarkdownText

### Files changed
- `fsrs_metrics.rs` — i18n labels, remove values, fix colors, add tests
- `kanji_card_item.rs` — simplify action buttons
- `kanji_detail.rs` — FuriganaText + MarkdownText in vocab
- `content.rs` — remove on_mark_as_known from caller
- `input.css` — badge, progress bar width, fsrs CSS
- `ru.json` / `en.json` — i18n keys

### Verification
- 1291 tests pass (4 new in fsrs_metrics)
- 0 clippy warnings