### PR TITLE
feat: add kanji radicals test mode

### DIFF
--- a/origa/src/domain/knowledge/lesson/types.rs
+++ b/origa/src/domain/knowledge/lesson/types.rs
@@ -262,6 +262,7 @@ pub enum LessonCardView {
         options: Vec<QuizOption>,
     },
     KanjiReadingQuiz(QuizCard),
+    KanjiRadicalQuiz(QuizCard),
     GrammarQuiz(GrammarQuizCard),
 }
 
@@ -276,6 +277,7 @@ impl LessonCardView {
             LessonCardView::Quiz(quiz) => quiz.card(),
             LessonCardView::YesNo(yc) => yc.card(),
             LessonCardView::KanjiReadingQuiz(quiz) => quiz.card(),
+            LessonCardView::KanjiRadicalQuiz(quiz) => quiz.card(),
             LessonCardView::GrammarQuiz(gq) => gq.card(),
         }
     }
@@ -290,7 +292,8 @@ impl LessonCardView {
             | LessonCardView::Reversed(_)
             | LessonCardView::Writing(_)
             | LessonCardView::PhraseListen { .. }
-            | LessonCardView::KanjiReadingQuiz(_) => None,
+            | LessonCardView::KanjiReadingQuiz(_)
+            | LessonCardView::KanjiRadicalQuiz(_) => None,
         }
     }
 }

--- a/origa/src/domain/knowledge/lesson/view_generator/generation.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/generation.rs
@@ -286,7 +286,7 @@ fn collect_distractors(
     distractors
 }
 
-fn cached_kanji_info<'a>(
+pub(crate) fn cached_kanji_info<'a>(
     kanji: &str,
     cache: &'a mut HashMap<String, &'static KanjiInfo>,
 ) -> Result<&'a KanjiInfo, OrigaError> {

--- a/origa/src/domain/knowledge/lesson/view_generator/kanji_radical_quiz.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/kanji_radical_quiz.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+
+use rand::seq::SliceRandom;
+
+use crate::dictionary::kanji::KanjiInfo;
+use crate::domain::knowledge::lesson::types::{LessonCardView, QuizCard, QuizMode, QuizOption};
+use crate::domain::{Card, OrigaError};
+
+use super::generation::cached_kanji_info;
+
+pub(crate) fn generate_kanji_radical_quiz(
+    original_card: Card,
+    kanji_cache: &mut HashMap<String, &'static KanjiInfo>,
+) -> Result<LessonCardView, OrigaError> {
+    let kanji_card = match &original_card {
+        Card::Kanji(kc) => kc,
+        Card::Vocabulary(_) | Card::Grammar(_) | Card::Phrase(_) => {
+            return Ok(LessonCardView::Normal(original_card));
+        },
+    };
+
+    let kanji_str = kanji_card.kanji().text();
+    let info = match cached_kanji_info(kanji_str, kanji_cache) {
+        Ok(info) => info,
+        Err(_) => return Ok(LessonCardView::Normal(original_card)),
+    };
+
+    let target_chars = info.radicals_chars();
+    if target_chars.is_empty() {
+        return Ok(LessonCardView::Normal(original_card));
+    }
+
+    if !crate::dictionary::radical::is_radicals_loaded() {
+        return Ok(LessonCardView::Normal(original_card));
+    }
+
+    let radical_list = crate::dictionary::radical::get_radical_list();
+
+    let mut options: Vec<QuizOption> = target_chars
+        .iter()
+        .filter_map(|&radical_char| {
+            let radical_info = crate::dictionary::radical::get_radical_info(radical_char).ok()?;
+            Some(QuizOption::new(
+                radical_char.to_string(),
+                true,
+                Some(radical_info.name().to_string()),
+            ))
+        })
+        .collect();
+
+    let correct_count = options.len();
+    if correct_count == 0 {
+        return Ok(LessonCardView::Normal(original_card));
+    }
+
+    let target_set: std::collections::HashSet<char> = target_chars.iter().copied().collect();
+
+    let mut distractors: Vec<QuizOption> = radical_list
+        .iter()
+        .filter(|r| !target_set.contains(&r.radical()))
+        .map(|r| QuizOption::new_simple(r.radical().to_string(), false))
+        .collect();
+
+    distractors.shuffle(&mut rand::rng());
+    let max_distractors = 8usize.saturating_sub(correct_count);
+    distractors.truncate(max_distractors);
+
+    if distractors.len() < 2 {
+        return Ok(LessonCardView::Normal(original_card));
+    }
+
+    options.extend(distractors);
+    options.shuffle(&mut rand::rng());
+
+    let quiz = QuizCard::new(original_card, options, QuizMode::Multi);
+    Ok(LessonCardView::KanjiRadicalQuiz(quiz))
+}

--- a/origa/src/domain/knowledge/lesson/view_generator/mod.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/mod.rs
@@ -9,6 +9,7 @@ use rand::Rng;
 use super::types::LessonCardView;
 
 mod generation;
+mod kanji_radical_quiz;
 #[cfg(test)]
 mod tests;
 mod transforms;
@@ -20,10 +21,11 @@ const PROB_QUIZ_VIEW: f32 = 0.30;
 const PROB_YESNO_VIEW: f32 = 0.50;
 const PROB_REVERSED_VIEW: f32 = 0.75;
 
-const PROB_KANJI_NORMAL: f32 = 0.20;
-const PROB_KANJI_READING_QUIZ: f32 = 0.40;
-const PROB_KANJI_QUIZ: f32 = 0.55;
-const PROB_KANJI_YESNO: f32 = 0.75;
+const PROB_KANJI_NORMAL: f32 = 1.0 / 6.0;
+const PROB_KANJI_READING_QUIZ: f32 = 2.0 / 6.0;
+const PROB_KANJI_RADICAL_QUIZ: f32 = 3.0 / 6.0;
+const PROB_KANJI_QUIZ: f32 = 4.0 / 6.0;
+const PROB_KANJI_YESNO: f32 = 5.0 / 6.0;
 
 const PROB_NEW_KANJI_NORMAL: f32 = 0.33;
 const PROB_NEW_KANJI_QUIZ: f32 = 0.66;
@@ -102,13 +104,7 @@ impl<'a> LessonViewGenerator<'a> {
                     .get(&card_type)
                     .map(|v| v.as_slice())
                     .unwrap_or(&[]);
-                Self::select_review_kanji_view(
-                    card,
-                    same_type_cards,
-                    study_card.memory(),
-                    &mut self.kanji_cache,
-                    rng,
-                )
+                Self::select_review_kanji_view(card, same_type_cards, &mut self.kanji_cache, rng)
             },
             CardType::Vocabulary if is_new => {
                 let same_type_cards = self.same_type_cards(&card_type);
@@ -145,20 +141,22 @@ impl<'a> LessonViewGenerator<'a> {
     fn select_review_kanji_view<R: Rng>(
         card: &Card,
         same_type_cards: &[Card],
-        memory: &MemoryHistory,
         kanji_cache: &mut HashMap<String, &'static KanjiInfo>,
         rng: &mut R,
     ) -> LessonCardView {
         let rand_val = rng.random::<f32>();
         if rand_val < PROB_KANJI_NORMAL {
             LessonCardView::Normal(card.clone())
-        } else if !memory.is_high_difficulty() && rand_val < PROB_KANJI_READING_QUIZ {
+        } else if rand_val < PROB_KANJI_READING_QUIZ {
             generation::generate_kanji_reading_quiz(card.clone(), same_type_cards, kanji_cache)
+                .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
+        } else if rand_val < PROB_KANJI_RADICAL_QUIZ {
+            kanji_radical_quiz::generate_kanji_radical_quiz(card.clone(), kanji_cache)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         } else if rand_val < PROB_KANJI_QUIZ {
             generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
-        } else if !memory.is_high_difficulty() && rand_val < PROB_KANJI_YESNO {
+        } else if rand_val < PROB_KANJI_YESNO {
             generation::generate_yesno(card.clone(), same_type_cards, &DEFAULT_LANG, rng)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         } else {

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/card_views.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/card_views.rs
@@ -108,11 +108,10 @@ mod kanji_view_tests {
     }
 
     #[test]
-    fn review_kanji_not_high_difficulty_produces_yesno() {
+    fn review_kanji_produces_yesno() {
         init_real_dictionaries();
         let ks = make_ks();
         let sc = make_reviewed_kanji("日", 5.0, 3.0, Rating::Good);
-        assert!(!sc.memory().is_high_difficulty());
         let mut generator = LessonViewGenerator::new(&ks);
 
         let mut yesno_count = 0;
@@ -129,24 +128,6 @@ mod kanji_view_tests {
             yesno_count > 0,
             "review kanji (not high diff) should get YesNo sometimes"
         );
-    }
-
-    #[test]
-    fn review_kanji_high_difficulty_never_yesno() {
-        init_real_dictionaries();
-        let ks = make_ks();
-        let sc = make_reviewed_kanji("日", 3.0, 7.0, Rating::Hard);
-        assert!(sc.memory().is_high_difficulty());
-        let mut generator = LessonViewGenerator::new(&ks);
-
-        for seed in 0..300 {
-            let mut rng = StdRng::seed_from_u64(seed);
-            let view = generator.apply_view(&sc, false, &mut rng);
-            assert!(
-                !matches!(view, LessonCardView::YesNo(_)),
-                "high-diff kanji should never get YesNo"
-            );
-        }
     }
 
     #[test]

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/kanji_radical_quiz.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/kanji_radical_quiz.rs
@@ -1,0 +1,307 @@
+use super::*;
+use crate::dictionary::kanji::KanjiInfo;
+use crate::domain::knowledge::KanjiCard;
+use crate::domain::knowledge::lesson::types::{LessonCardView, QuizMode};
+use crate::domain::memory::{Difficulty, MemoryState, Rating, ReviewLog, Stability};
+use crate::use_cases::init_real_dictionaries;
+use chrono::{Duration, Utc};
+use rand::{SeedableRng, rngs::StdRng};
+use std::collections::HashMap;
+
+use super::super::LessonViewGenerator;
+
+fn create_kanji_cards(kanji_list: &[&str]) -> Vec<Card> {
+    kanji_list
+        .iter()
+        .map(|k| Card::Kanji(KanjiCard::new_test(k.to_string())))
+        .collect()
+}
+
+fn make_kanji_knowledge_set(kanji_list: &[&str]) -> KnowledgeSet {
+    let mut ks = KnowledgeSet::new();
+    for k in kanji_list {
+        ks.create_card(Card::Kanji(KanjiCard::new_test(k.to_string())))
+            .unwrap();
+    }
+    ks
+}
+
+fn make_reviewed_kanji(kanji: &str, stability: f64, difficulty: f64, rating: Rating) -> StudyCard {
+    let card = Card::Kanji(KanjiCard::new_test(kanji.to_string()));
+    let mut sc = StudyCard::new(card);
+    let mem = MemoryState::new(
+        Stability::new(stability).unwrap(),
+        Difficulty::new(difficulty).unwrap(),
+        Utc::now(),
+    );
+    sc.add_review(mem, ReviewLog::new(rating, Duration::days(5)));
+    sc
+}
+
+fn generate_radical_quiz_for(
+    kanji: &str,
+    _same_type: &[&str],
+) -> Result<LessonCardView, crate::domain::OrigaError> {
+    let cards = create_kanji_cards(&[kanji]);
+    let mut kanji_cache: HashMap<String, &'static KanjiInfo> = HashMap::new();
+    super::super::kanji_radical_quiz::generate_kanji_radical_quiz(
+        cards[0].clone(),
+        &mut kanji_cache,
+    )
+}
+
+fn extract_quiz(view: LessonCardView) -> crate::domain::knowledge::lesson::types::QuizCard {
+    match view {
+        LessonCardView::KanjiRadicalQuiz(quiz) => quiz,
+        other => panic!("Expected KanjiRadicalQuiz, got {:?}", other),
+    }
+}
+
+fn get_target_radicals(kanji: &str) -> std::collections::HashSet<char> {
+    let info = crate::dictionary::kanji::get_kanji_info(kanji).unwrap();
+    info.radicals_chars().iter().copied().collect()
+}
+
+#[test]
+fn all_correct_radicals_are_options() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+
+    let target_radicals = get_target_radicals("日");
+
+    for &radical in &target_radicals {
+        assert!(
+            quiz.options()
+                .iter()
+                .any(|o| o.text() == radical.to_string() && o.is_correct()),
+            "radical '{}' must be a correct option",
+            radical
+        );
+    }
+}
+
+#[test]
+fn no_target_radicals_in_distractors() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+    let target_radicals = get_target_radicals("日");
+
+    for opt in quiz.options().iter().filter(|o| !o.is_correct()) {
+        let distractor_char = opt.text().chars().next().unwrap();
+        assert!(
+            !target_radicals.contains(&distractor_char),
+            "distractor '{}' must not be a target radical",
+            opt.text()
+        );
+    }
+}
+
+#[test]
+fn mode_is_multi() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+    assert_eq!(quiz.mode(), QuizMode::Multi);
+}
+
+#[test]
+fn max_eight_options() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+    assert!(quiz.options().len() <= 8);
+}
+
+#[test]
+fn fallback_when_zero_radicals() {
+    init_real_dictionaries();
+
+    let card = Card::Kanji(KanjiCard::new_test("𛀀".to_string()));
+    let mut kanji_cache: HashMap<String, &'static KanjiInfo> = HashMap::new();
+
+    let result = super::super::kanji_radical_quiz::generate_kanji_radical_quiz(
+        card.clone(),
+        &mut kanji_cache,
+    );
+
+    match result.unwrap() {
+        LessonCardView::Normal(c) => assert_eq!(c, card),
+        other => panic!(
+            "Expected Normal fallback for kanji with no radicals, got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
+fn fallback_when_radical_dictionary_not_loaded() {
+    let card = Card::Kanji(KanjiCard::new_test("日".to_string()));
+    let mut kanji_cache: HashMap<String, &'static KanjiInfo> = HashMap::new();
+
+    if !crate::dictionary::radical::is_radicals_loaded() {
+        let result = super::super::kanji_radical_quiz::generate_kanji_radical_quiz(
+            card.clone(),
+            &mut kanji_cache,
+        );
+        match result.unwrap() {
+            LessonCardView::Normal(c) => assert_eq!(c, card),
+            other => panic!(
+                "Expected Normal fallback when radical dict not loaded, got {:?}",
+                other
+            ),
+        }
+    }
+}
+
+#[test]
+fn check_multi_answers_perfect() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+
+    let correct_indices: Vec<usize> = quiz
+        .options()
+        .iter()
+        .enumerate()
+        .filter(|(_, o)| o.is_correct())
+        .map(|(i, _)| i)
+        .collect();
+
+    let result = quiz.check_multi_answers(&correct_indices);
+    assert!(result.is_perfect);
+    assert!(result.missed.is_empty());
+    assert!(result.wrong_selections.is_empty());
+    assert_eq!(result.correct_selections.len(), correct_indices.len());
+}
+
+#[test]
+fn check_multi_answers_partial() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+
+    let correct_indices: Vec<usize> = quiz
+        .options()
+        .iter()
+        .enumerate()
+        .filter(|(_, o)| o.is_correct())
+        .map(|(i, _)| i)
+        .collect();
+
+    if correct_indices.len() > 1 {
+        let partial_selection = vec![correct_indices[0]];
+        let result = quiz.check_multi_answers(&partial_selection);
+        assert!(!result.is_perfect);
+        assert!(result.correct_selections.contains(&correct_indices[0]));
+        assert!(!result.missed.is_empty());
+        assert!(result.wrong_selections.is_empty());
+    }
+}
+
+#[test]
+fn correct_radicals_have_name_as_tag() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+
+    for opt in quiz.options().iter().filter(|o| o.is_correct()) {
+        assert!(
+            opt.tag().is_some(),
+            "correct radical '{}' must have a name tag",
+            opt.text()
+        );
+    }
+}
+
+#[test]
+fn distractors_have_no_tags() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+
+    for opt in quiz.options().iter().filter(|o| !o.is_correct()) {
+        assert!(
+            opt.tag().is_none(),
+            "distractor '{}' must have no tag",
+            opt.text()
+        );
+    }
+}
+
+#[test]
+fn review_kanji_produces_radical_quiz() {
+    init_real_dictionaries();
+
+    let ks = make_kanji_knowledge_set(&["日", "月", "水", "火", "木"]);
+    let sc = make_reviewed_kanji("日", 5.0, 3.0, Rating::Good);
+    let mut generator = LessonViewGenerator::new(&ks);
+
+    let mut count = 0;
+    for seed in 0..300 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        if matches!(
+            generator.apply_view(&sc, false, &mut rng),
+            LessonCardView::KanjiRadicalQuiz(_)
+        ) {
+            count += 1;
+        }
+    }
+    assert!(count > 0, "review kanji should produce KanjiRadicalQuiz");
+}
+
+#[test]
+fn new_kanji_never_radical_quiz() {
+    init_real_dictionaries();
+
+    let ks = make_kanji_knowledge_set(&["日", "月", "水", "火", "木"]);
+    let sc = StudyCard::new(Card::Kanji(KanjiCard::new_test("日".to_string())));
+    let mut generator = LessonViewGenerator::new(&ks);
+
+    for seed in 0..300 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let view = generator.apply_view(&sc, true, &mut rng);
+        assert!(
+            !matches!(view, LessonCardView::KanjiRadicalQuiz(_)),
+            "new kanji should never get KanjiRadicalQuiz"
+        );
+    }
+}
+
+#[test]
+fn multi_rating_good_for_perfect() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+    let correct_indices: Vec<usize> = quiz
+        .options()
+        .iter()
+        .enumerate()
+        .filter(|(_, o)| o.is_correct())
+        .map(|(i, _)| i)
+        .collect();
+
+    let result = quiz.check_multi_answers(&correct_indices);
+    assert_eq!(result.rating(), Rating::Good);
+}
+
+#[test]
+fn multi_rating_again_for_partial() {
+    init_real_dictionaries();
+
+    let quiz = extract_quiz(generate_radical_quiz_for("日", &["月", "水", "火"]).unwrap());
+    let correct_indices: Vec<usize> = quiz
+        .options()
+        .iter()
+        .enumerate()
+        .filter(|(_, o)| o.is_correct())
+        .map(|(i, _)| i)
+        .collect();
+
+    if correct_indices.len() > 1 {
+        let partial = vec![correct_indices[0]];
+        let result = quiz.check_multi_answers(&partial);
+        assert_eq!(result.rating(), Rating::Again);
+    }
+}

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/kanji_reading_quiz.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/kanji_reading_quiz.rs
@@ -346,25 +346,6 @@ fn new_kanji_never_reading_quiz() {
 }
 
 #[test]
-fn high_difficulty_never_reading_quiz() {
-    init_real_dictionaries();
-
-    let ks = make_kanji_knowledge_set(&["日", "月", "水", "火", "木"]);
-    let sc = make_reviewed_kanji("日", 3.0, 7.0, Rating::Hard);
-    assert!(sc.memory().is_high_difficulty());
-    let mut generator = LessonViewGenerator::new(&ks);
-
-    for seed in 0..300 {
-        let mut rng = StdRng::seed_from_u64(seed);
-        let view = generator.apply_view(&sc, false, &mut rng);
-        assert!(
-            !matches!(view, LessonCardView::KanjiReadingQuiz(_)),
-            "high-difficulty kanji should never get KanjiReadingQuiz"
-        );
-    }
-}
-
-#[test]
 fn multi_rating_returns_good_for_perfect() {
     init_real_dictionaries();
 

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/mod.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/mod.rs
@@ -8,6 +8,7 @@ use ulid::Ulid;
 
 mod card_views;
 mod filtering;
+mod kanji_radical_quiz;
 mod kanji_reading_quiz;
 mod quiz;
 mod types;

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/types.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/types.rs
@@ -61,6 +61,10 @@ fn lesson_card_view_card_returns_inner_card() {
     let reading_quiz =
         LessonCardView::KanjiReadingQuiz(QuizCard::new(vocab.clone(), vec![], QuizMode::Single));
     assert_eq!(reading_quiz.card(), &vocab);
+
+    let radical_quiz =
+        LessonCardView::KanjiRadicalQuiz(QuizCard::new(vocab.clone(), vec![], QuizMode::Multi));
+    assert_eq!(radical_quiz.card(), &vocab);
 }
 
 mod quiz_option_and_card_tests {
@@ -180,6 +184,12 @@ mod lesson_card_view_accessors {
         let reading_quiz = QuizCard::new(vocab.clone(), vec![], QuizMode::Single);
         assert!(
             LessonCardView::KanjiReadingQuiz(reading_quiz)
+                .grammar_info()
+                .is_none()
+        );
+        let radical_quiz = QuizCard::new(vocab.clone(), vec![], QuizMode::Multi);
+        assert!(
+            LessonCardView::KanjiRadicalQuiz(radical_quiz)
                 .grammar_info()
                 .is_none()
         );

--- a/origa_ui/locales/en.json
+++ b/origa_ui/locales/en.json
@@ -223,6 +223,7 @@
         "did_not_understand": "Didn't understand",
         "understood": "Understood",
         "choose_all_readings": "Select all readings of this kanji:",
+        "choose_all_radicals": "Select all radicals of this kanji:",
         "check": "Check",
         "multi_perfect": "✓ All readings selected!",
         "multi_partial": "Some readings missed or extra options selected",

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -223,6 +223,7 @@
     "did_not_understand": "Не понял",
     "understood": "Понял",
     "choose_all_readings": "Выберите все чтения этого кандзи:",
+    "choose_all_radicals": "Выберите все радикалы этого кандзи:",
     "check": "Проверить",
     "multi_perfect": "✓ Все чтения выбраны!",
     "multi_partial": "Есть пропущенные или лишние варианты",

--- a/origa_ui/src/pages/lesson/keyboard_handler.rs
+++ b/origa_ui/src/pages/lesson/keyboard_handler.rs
@@ -43,9 +43,8 @@ pub fn create_keyboard_handler(
 
         let is_multi_quiz = current_card
             .map(|c| {
-                matches!(c.view(),
-                    LessonCardView::KanjiReadingQuiz(q) if q.mode() == QuizMode::Multi
-                )
+                matches!(c.view(), LessonCardView::KanjiReadingQuiz(q) if q.mode() == QuizMode::Multi)
+                    || matches!(c.view(), LessonCardView::KanjiRadicalQuiz(q) if q.mode() == QuizMode::Multi)
             })
             .unwrap_or(false);
 
@@ -55,6 +54,7 @@ pub fn create_keyboard_handler(
                     c.view(),
                     LessonCardView::Quiz(_)
                         | LessonCardView::KanjiReadingQuiz(_)
+                        | LessonCardView::KanjiRadicalQuiz(_)
                         | LessonCardView::GrammarQuiz(_)
                 )
             })

--- a/origa_ui/src/pages/lesson/lesson_card_container.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_container.rs
@@ -120,6 +120,13 @@ pub fn LessonCardContainer() -> impl IntoView {
             .unwrap_or(false)
     });
 
+    let is_kanji_radical_quiz_mode = Memo::new(move |_| {
+        current_lesson_card
+            .get()
+            .map(|c| matches!(c.view(), LessonCardView::KanjiRadicalQuiz(_)))
+            .unwrap_or(false)
+    });
+
     let container_ref = NodeRef::<leptos::html::Div>::new();
 
     on_cleanup(move || {
@@ -135,7 +142,7 @@ pub fn LessonCardContainer() -> impl IntoView {
     view! {
         <div class="outline-none" tabindex="0" node_ref=container_ref on:keydown=handle_keydown>
             <Show when=move || current_lesson_card.get().is_some()>
-                <Show when=move || !is_quiz_mode.get() && !is_writing_mode.get() && !is_yesno_mode.get() && !is_phrase_listen_mode.get() && !is_kanji_reading_quiz_mode.get() && !is_grammar_quiz_mode.get()>
+                <Show when=move || !is_quiz_mode.get() && !is_writing_mode.get() && !is_yesno_mode.get() && !is_phrase_listen_mode.get() && !is_kanji_reading_quiz_mode.get() && !is_grammar_quiz_mode.get() && !is_kanji_radical_quiz_mode.get()>
                     {move || {
                         current_lesson_card.get().map(|lesson_card| {
                             render_lesson_card(
@@ -326,6 +333,44 @@ pub fn LessonCardContainer() -> impl IntoView {
                         })
                     }}
                 </Show>
+
+                <Show when=move || is_kanji_radical_quiz_mode.get()>
+                    {move || {
+                        current_lesson_card.get().and_then(|lesson_card| {
+                            if let LessonCardView::KanjiRadicalQuiz(quiz) = lesson_card.into_view() {
+                                let state = lesson_state.get();
+                                let selected_option = state.selected_quiz_option;
+                                let show_result = state.showing_answer;
+                                let selected_options = state.selected_quiz_options.clone();
+                                let multi_submitted = state.multi_quiz_submitted;
+                                let multi_result = state.multi_result;
+
+                                Some(view! {
+                                    <QuizCardView
+                                        quiz_card=quiz
+                                        show_result=show_result
+                                        selected_option=selected_option
+                                        on_select_option=on_quiz_select
+                                        on_dont_know=on_quiz_dont_know
+                                        dont_know_selected=state.dont_know_selected
+                                        native_language=native_language.get()
+                                        known_kanji=Signal::from(known_kanji)
+                                        quiz_variant=QuizVariant::Radicals
+                                        selected_options=Signal::derive(move || selected_options.clone())
+                                        multi_submitted=multi_submitted
+                                        multi_result=multi_result
+                                        on_toggle=on_quiz_toggle
+                                        on_submit=on_quiz_submit
+                                        waiting_for_next=state.waiting_for_next
+                                        on_next_card=on_next_card
+                                    />
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                    }}
+                </Show>
             </Show>
         </div>
     }
@@ -367,6 +412,7 @@ fn render_lesson_card(
         | LessonCardView::YesNo(_)
         | LessonCardView::PhraseListen { .. }
         | LessonCardView::KanjiReadingQuiz(_)
+        | LessonCardView::KanjiRadicalQuiz(_)
         | LessonCardView::GrammarQuiz(_) => {
             return ().into_any();
         },

--- a/origa_ui/src/pages/lesson/on_dont_know.rs
+++ b/origa_ui/src/pages/lesson/on_dont_know.rs
@@ -15,10 +15,8 @@ pub fn create_on_dont_know(
             .get(state.current_index)
             .and_then(|id| state.cards.get(id))
             .map(|c| {
-                matches!(
-                    c.view(),
-                    LessonCardView::KanjiReadingQuiz(q) if q.mode() == QuizMode::Multi
-                )
+                matches!(c.view(), LessonCardView::KanjiReadingQuiz(q) if q.mode() == QuizMode::Multi)
+                    || matches!(c.view(), LessonCardView::KanjiRadicalQuiz(q) if q.mode() == QuizMode::Multi)
             })
             .unwrap_or(false);
 

--- a/origa_ui/src/pages/lesson/on_quiz_select.rs
+++ b/origa_ui/src/pages/lesson/on_quiz_select.rs
@@ -33,6 +33,7 @@ pub fn create_on_quiz_select(
                 LessonCardView::Quiz(q) | LessonCardView::KanjiReadingQuiz(q) => {
                     Some(q.check_answer(option_index))
                 },
+                LessonCardView::KanjiRadicalQuiz(q) => Some(q.check_answer(option_index)),
                 LessonCardView::GrammarQuiz(gq) => Some(gq.quiz().check_answer(option_index)),
                 LessonCardView::PhraseListen { options, .. } => {
                     options.get(option_index).map(|o| o.is_correct())

--- a/origa_ui/src/pages/lesson/on_quiz_submit.rs
+++ b/origa_ui/src/pages/lesson/on_quiz_submit.rs
@@ -25,8 +25,10 @@ pub fn create_on_quiz_submit(
             return;
         };
 
-        let LessonCardView::KanjiReadingQuiz(quiz) = lesson_card.view() else {
-            return;
+        let quiz = match lesson_card.view() {
+            LessonCardView::KanjiReadingQuiz(q) => q,
+            LessonCardView::KanjiRadicalQuiz(q) => q,
+            _ => return,
         };
 
         let is_multi_quiz = quiz.mode() == QuizMode::Multi;

--- a/origa_ui/src/pages/lesson/quiz_card.rs
+++ b/origa_ui/src/pages/lesson/quiz_card.rs
@@ -21,6 +21,7 @@ pub enum QuizVariant {
     Meaning,
     Reading,
     Grammar,
+    Radicals,
 }
 
 #[component]
@@ -162,13 +163,16 @@ pub fn QuizCardView(
                     </Show>
 
                     <Text size=TextSize::Default variant=TypographyVariant::Muted class="mt-4">
-                        {if is_multi {
+                        {if is_multi && quiz_variant == QuizVariant::Reading {
                             t!(i18n, lesson.choose_all_readings).into_any()
+                        } else if is_multi && quiz_variant == QuizVariant::Radicals {
+                            t!(i18n, lesson.choose_all_radicals).into_any()
                         } else {
                             match quiz_variant {
                                 QuizVariant::Meaning => t!(i18n, lesson.choose_answer).into_any(),
                                 QuizVariant::Reading => t!(i18n, lesson.choose_reading).into_any(),
                                 QuizVariant::Grammar => t!(i18n, lesson.choose_grammar).into_any(),
+                                QuizVariant::Radicals => t!(i18n, lesson.choose_all_radicals).into_any(),
                             }
                         }}
                     </Text>

--- a/origa_ui/src/pages/lesson/quiz_card_header.rs
+++ b/origa_ui/src/pages/lesson/quiz_card_header.rs
@@ -34,6 +34,11 @@ pub fn QuizCardHeader(
                             {t!(i18n, lesson.grammar)}
                         </Tag>
                     }.into_any(),
+                    super::quiz_card::QuizVariant::Radicals => view! {
+                        <Tag variant=Signal::derive(move || TagVariant::Filled)>
+                            {t!(i18n, lesson.radicals)}
+                        </Tag>
+                    }.into_any(),
                 }}
             </div>
             <Show when=move || card_type != CardType::Kanji>


### PR DESCRIPTION
Closes #36

## Summary
Add a quiz mode where the user is shown a kanji and a list of radicals, and must select only the radicals that belong to that kanji. Multi-select quiz, analogous to the existing kanji reading quiz.

## Changes

### Domain (origa)
- Add `LessonCardView::KanjiRadicalQuiz(QuizCard)` variant to types
- Add `generate_kanji_radical_quiz()` generator with radical distractors from radical dictionary
- Remove `!high_difficulty` filter from `select_review_kanji_view()` (ReadingQuiz and YesNo)
- Remove `memory` parameter from `select_review_kanji_view()` signature
- Equalize kanji view probabilities: 6 modes × 1/6 each (Normal, ReadingQuiz, RadicalQuiz, Quiz, YesNo, Writing)
- Add 14 unit tests for radical quiz generator
- Remove 2 obsolete high_difficulty tests, rename 1 test

### UI (origa_ui)
- Add `QuizVariant::Radicals` enum variant
- Add Show-block for KanjiRadicalQuiz rendering via existing QuizCardView
- Update all handlers: on_quiz_submit, on_quiz_select, on_dont_know, keyboard_handler
- Add i18n keys: choose_all_radicals (en/ru)
- Reuse lesson.radicals i18n key for header tag

## Test Results
- 1303 tests passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt` — clean