### PR TITLE
✨(grammar): clean emoji headers and add More details expand

### DIFF
--- a/origa/src/dictionary/grammar.rs
+++ b/origa/src/dictionary/grammar.rs
@@ -423,20 +423,6 @@ impl GrammarRuleContent {
     pub fn related_patterns(&self) -> Option<&str> {
         self.related_patterns.as_deref()
     }
-
-    pub fn full_description(&self) -> String {
-        let mut parts = vec![
-            format!("### {}", self.explanation),
-            format!("### {}", self.how_to_form),
-            format!("### {}", self.examples),
-            format!("### {}", self.nuances),
-            format!("### {}", self.pro_tip),
-        ];
-        if let Some(ref rp) = self.related_patterns {
-            parts.push(format!("### {}", rp));
-        }
-        parts.join("\n\n")
-    }
 }
 
 #[cfg(test)]

--- a/origa/src/domain/knowledge/grammar.rs
+++ b/origa/src/domain/knowledge/grammar.rs
@@ -47,19 +47,7 @@ impl GrammarRuleCard {
     }
 
     pub fn description(&self, lang: &NativeLanguage) -> Result<CardAnswer, OrigaError> {
-        let rule = get_rule_by_id(&self.rule_id).ok_or(OrigaError::GrammarRuleNotFound {
-            rule_id: self.rule_id,
-        })?;
-        let text = rule.content(lang).full_description();
-        if text.is_empty() {
-            return Err(OrigaError::GrammarContentNotFound {
-                rule_id: self.rule_id,
-                lang: *lang,
-            });
-        }
-        CardAnswer::text(text.to_string()).map_err(|e| OrigaError::InvalidAnswer {
-            reason: e.to_string(),
-        })
+        self.short_description(lang)
     }
 
     pub fn short_description(&self, lang: &NativeLanguage) -> Result<CardAnswer, OrigaError> {
@@ -263,15 +251,15 @@ mod tests {
             let card = GrammarRuleCard::new(rule_id).expect("Failed to create card");
 
             let desc = card.description(&NativeLanguage::Russian);
+            let short = card.short_description(&NativeLanguage::Russian);
 
             assert!(desc.is_ok());
-            match desc.unwrap() {
-                CardAnswer::Text(s) => {
-                    assert!(!s.is_empty());
-                    assert!(s.contains("です"));
-                },
-                other => panic!("Expected Text variant, got {:?}", other),
-            }
+            assert!(short.is_ok());
+            assert_eq!(
+                desc.unwrap(),
+                short.unwrap(),
+                "description() should delegate to short_description()"
+            );
         }
 
         #[test]
@@ -282,30 +270,33 @@ mod tests {
             let card = GrammarRuleCard::new(rule_id).expect("Failed to create card");
 
             let desc = card.description(&NativeLanguage::English);
+            let short = card.short_description(&NativeLanguage::English);
 
             assert!(desc.is_ok());
-            match desc.unwrap() {
-                CardAnswer::Text(s) => {
-                    assert!(!s.is_empty());
-                    assert!(s.contains("です"));
-                },
-                other => panic!("Expected Text variant, got {:?}", other),
-            }
+            assert!(short.is_ok());
+            assert_eq!(
+                desc.unwrap(),
+                short.unwrap(),
+                "description() should delegate to short_description()"
+            );
         }
 
         #[test]
-        fn description_is_longer_than_title() {
+        fn description_equals_short_description() {
             init_test_grammar();
 
             let rule_id = get_first_rule_id();
             let card = GrammarRuleCard::new(rule_id).expect("Failed to create card");
 
-            let title = card.title(&NativeLanguage::Russian).unwrap();
-            let desc = card.description(&NativeLanguage::Russian).unwrap();
-
-            match desc {
-                CardAnswer::Text(s) => assert!(s.len() > title.text().len()),
-                other => panic!("Expected Text variant, got {:?}", other),
+            for lang in [NativeLanguage::Russian, NativeLanguage::English] {
+                let desc = card.description(&lang).expect("description should work");
+                let short = card
+                    .short_description(&lang)
+                    .expect("short_description should work");
+                assert_eq!(
+                    desc, short,
+                    "description() should equal short_description() for {lang:?}"
+                );
             }
         }
     }
@@ -360,22 +351,6 @@ mod tests {
             match short_desc.unwrap() {
                 CardAnswer::Text(s) => assert!(!s.is_empty()),
                 other => panic!("Expected Text variant, got {:?}", other),
-            }
-        }
-
-        #[test]
-        fn short_description_is_shorter_than_full_description() {
-            init_test_grammar();
-
-            let rule_id = get_first_rule_id();
-            let card = GrammarRuleCard::new(rule_id).expect("Failed to create card");
-
-            let short_desc = card.short_description(&NativeLanguage::Russian).unwrap();
-            let full_desc = card.description(&NativeLanguage::Russian).unwrap();
-
-            match (short_desc, full_desc) {
-                (CardAnswer::Text(s), CardAnswer::Text(f)) => assert!(s.len() < f.len()),
-                _ => panic!("Expected Text variants"),
             }
         }
 

--- a/origa_ui/locales/en.json
+++ b/origa_ui/locales/en.json
@@ -25,7 +25,8 @@
         "processing": "Processing...",
         "tooltip_known": "Already in dictionary",
         "tooltip_new": "New word",
-        "language_aria_label": "Select language"
+        "language_aria_label": "Select language",
+        "more_details": "More details"
     },
     "app": {
         "logging_in": "Logging in..."

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -25,7 +25,8 @@
     "processing": "Обработка...",
     "tooltip_known": "Уже в словаре",
     "tooltip_new": "Новое слово",
-    "language_aria_label": "Выберите язык"
+    "language_aria_label": "Выберите язык",
+    "more_details": "Подробнее"
   },
   "app": {
     "logging_in": "Вход..."

--- a/origa_ui/src/pages/lesson/grammar_details_expand.rs
+++ b/origa_ui/src/pages/lesson/grammar_details_expand.rs
@@ -1,0 +1,133 @@
+use crate::i18n::*;
+use crate::ui_components::MarkdownText;
+use leptos::prelude::*;
+use origa::dictionary::grammar::get_rule_by_id;
+use std::collections::HashSet;
+use ulid::Ulid;
+
+use super::lesson_state::LessonContext;
+
+#[component]
+pub fn GrammarDetailsExpand(
+    rule_id: Ulid,
+    is_expanded: RwSignal<bool>,
+    known_kanji: HashSet<char>,
+    #[prop(optional, into)] test_id: Signal<String>,
+) -> impl IntoView {
+    let i18n = use_i18n();
+    let lesson_ctx = use_context::<LessonContext>().expect("LessonContext");
+    let native_lang = lesson_ctx.native_language;
+    let known_kanji_stored = StoredValue::new(known_kanji);
+
+    let rule = StoredValue::new(get_rule_by_id(&rule_id));
+
+    let more_text =
+        Signal::derive(move || i18n.get_keys().common().more_details().inner().to_string());
+    let collapse_text =
+        Signal::derive(move || i18n.get_keys().common().collapse().inner().to_string());
+
+    let explanation_title = Signal::derive(move || {
+        i18n.get_keys()
+            .grammar_page()
+            .explanation()
+            .inner()
+            .to_string()
+    });
+    let how_to_form_title = Signal::derive(move || {
+        i18n.get_keys()
+            .grammar_page()
+            .how_to_form()
+            .inner()
+            .to_string()
+    });
+    let examples_title = Signal::derive(move || {
+        i18n.get_keys()
+            .grammar_page()
+            .examples()
+            .inner()
+            .to_string()
+    });
+    let nuances_title =
+        Signal::derive(move || i18n.get_keys().grammar_page().nuances().inner().to_string());
+    let pro_tip_title =
+        Signal::derive(move || i18n.get_keys().grammar_page().pro_tip().inner().to_string());
+
+    view! {
+        <div class="mt-3" data-testid=move || test_id.get()>
+            <button
+                class="font-mono text-sm text-[var(--fg-muted)] cursor-pointer hover:text-[var(--fg-black)] underline underline-offset-4 decoration-[var(--border-light)]"
+                on:click=move |_| is_expanded.update(|v| *v = !*v)
+            >
+                {move || if is_expanded.get() { collapse_text.get() } else { more_text.get() }}
+            </button>
+
+            <Show when=move || is_expanded.get()>
+                {move || {
+                    match rule.get_value() {
+                        Some(r) => {
+                            let lang = native_lang.get();
+                            let content = r.content(&lang);
+                            let kanji = known_kanji_stored.get_value();
+
+                            view! {
+                                <div class="mt-3 space-y-3 text-left">
+                                    <GrammarSection
+                                        title=explanation_title.get()
+                                        content=content.explanation().to_string()
+                                        known_kanji=kanji.clone()
+                                    />
+                                    <GrammarSection
+                                        title=how_to_form_title.get()
+                                        content=content.how_to_form().to_string()
+                                        known_kanji=kanji.clone()
+                                    />
+                                    <GrammarSection
+                                        title=examples_title.get()
+                                        content=content.examples().to_string()
+                                        known_kanji=kanji.clone()
+                                    />
+                                    <GrammarSection
+                                        title=nuances_title.get()
+                                        content=content.nuances().to_string()
+                                        known_kanji=kanji.clone()
+                                    />
+                                    <GrammarSection
+                                        title=pro_tip_title.get()
+                                        content=content.pro_tip().to_string()
+                                        known_kanji=kanji
+                                    />
+                                </div>
+                            }
+                                .into_any()
+                        },
+                        None => {
+                            tracing::warn!("GrammarDetailsExpand: rule not found for id {}", rule_id);
+                            view! { <div /> }.into_any()
+                        },
+                    }
+                }}
+            </Show>
+        </div>
+    }
+}
+
+#[component]
+fn GrammarSection(title: String, content: String, known_kanji: HashSet<char>) -> impl IntoView {
+    let title_stored = StoredValue::new(title);
+    let content_stored = StoredValue::new(content);
+    let kanji_stored = StoredValue::new(known_kanji);
+
+    view! {
+        <Show when=move || !content_stored.get_value().is_empty()>
+            <div class="grammar-detail-section">
+                <div class="grammar-detail-section-card">
+                    <div class="grammar-detail-section-title">{title_stored.get_value()}</div>
+                    <MarkdownText
+                        content=Signal::derive(move || content_stored.get_value())
+                        known_kanji=kanji_stored.get_value()
+                    />
+                </div>
+            </div>
+        </Show>
+    }
+}

--- a/origa_ui/src/pages/lesson/lesson_card_answer.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_answer.rs
@@ -1,3 +1,4 @@
+use super::grammar_details_expand::GrammarDetailsExpand;
 use super::kanji_card_details::{KanjiCardDetails, RadicalDisplay};
 use crate::i18n::*;
 use crate::ui_components::{
@@ -34,6 +35,8 @@ pub fn LessonCardAnswer(
     let radicals_stored = StoredValue::new(radicals);
     let examples_stored = StoredValue::new(example_words);
     let grammar_info_stored = StoredValue::new(grammar_info);
+    // Only meaningful when grammar_info contains a rule_id — controls "More details" expand
+    let is_grammar_expanded = RwSignal::new(false);
 
     view! {
         <div class="text-center">
@@ -81,7 +84,13 @@ pub fn LessonCardAnswer(
             >
                 <div class="max-w-max mx-auto space-y-4">
                     <Show
-                        when=move || grammar_info_stored.get_value().is_some() && !is_kanji
+                        when=move || {
+                            grammar_info_stored
+                                .get_value()
+                                .as_ref()
+                                .is_some_and(|info| !info.description().is_empty())
+                                && !is_kanji
+                        }
                     >
                         {move || {
                             grammar_info_stored
@@ -140,6 +149,30 @@ pub fn LessonCardAnswer(
                     </Show>
                 </div>
             </div>
+
+            <Show
+                when=move || grammar_info_stored
+                    .get_value()
+                    .as_ref()
+                    .is_some_and(|info| info.rule_id().is_some())
+                    && !is_kanji
+            >
+                {move || {
+                    grammar_info_stored
+                        .get_value()
+                        .as_ref()
+                        .map(|info| {
+                            let rule_id = info.rule_id().unwrap();
+                            view! {
+                                <GrammarDetailsExpand
+                                    rule_id
+                                    is_expanded=is_grammar_expanded
+                                    known_kanji=known_kanji.get()
+                                />
+                            }
+                        })
+                }}
+            </Show>
 
             <Show when=move || needs_collapse.get()>
                 <div class="mt-2">

--- a/origa_ui/src/pages/lesson/lesson_card_container.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_container.rs
@@ -355,10 +355,27 @@ fn render_lesson_card(
     native_language: RwSignal<NativeLanguage>,
 ) -> impl IntoView {
     let params = match lesson_card.into_view() {
-        LessonCardView::Normal(card) => LessonCardParams {
-            card,
-            is_reversed: false,
-            grammar_info: None,
+        LessonCardView::Normal(card) => {
+            let grammar_info = match &card {
+                Card::Grammar(grc) => {
+                    let lang = native_language.get();
+                    let title = grc
+                        .title(&lang)
+                        .ok()
+                        .map(|q| q.text().to_string())
+                        .unwrap_or_default();
+                    // description left empty: answer_text already shows short_description
+                    // via Card::answer(). GrammarInfo carries rule_id for the
+                    // "More details" expand button in LessonCardAnswer.
+                    Some(GrammarInfo::new(Some(*grc.rule_id()), title, String::new()))
+                },
+                _ => None,
+            };
+            LessonCardParams {
+                card,
+                is_reversed: false,
+                grammar_info,
+            }
         },
         LessonCardView::Reversed(card) => LessonCardParams {
             card,

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -1,6 +1,7 @@
 pub mod card_type;
 mod complete_screen;
 mod content;
+mod grammar_details_expand;
 mod grammar_info_badge;
 mod header;
 mod kanji_card_details;

--- a/scripts/cleanup_grammar_headers.py
+++ b/scripts/cleanup_grammar_headers.py
@@ -1,0 +1,137 @@
+"""Clean emoji-headers and trailing --- from grammar.json section fields.
+
+Removes:
+  - First-line emoji headers (e.g. "📖 What is it?\\n\\n") from section fields
+  - Trailing "---" separators at end of section fields (preserving --- inside markdown tables)
+
+Usage:
+  python scripts/cleanup_grammar_headers.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+EMOJI_PATTERN = re.compile(
+    r"^[\U0001f4d6\U0001f527\U0001f5e3\U0001f5e3\ufe0f\U0001f4a1\U0001f338\U0001f504][^\n]*\n+"
+)
+TRAILING_DASHES = re.compile(r"\n+---\s*$")
+
+SECTION_FIELDS: frozenset[str] = frozenset(
+    ["explanation", "how_to_form", "examples", "nuances", "pro_tip", "related_patterns"]
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+GRAMMAR_PATH = PROJECT_ROOT / "cdn" / "grammar" / "grammar.json"
+
+
+def clean_field(value: str) -> tuple[str, bool, bool]:
+    """Clean a single section field.
+
+    Returns (cleaned_value, stripped_header, stripped_trailing).
+    """
+    if not value:
+        return value, False, False
+
+    stripped_header = False
+    stripped_trailing = False
+
+    cleaned = EMOJI_PATTERN.sub("", value, count=1)
+    if cleaned != value:
+        stripped_header = True
+
+    prev = cleaned
+    cleaned = TRAILING_DASHES.sub("", cleaned)
+    if cleaned != prev:
+        stripped_trailing = True
+
+    return cleaned, stripped_header, stripped_trailing
+
+
+def show_diff(rule_id: str, lang: str, field: str, before: str, after: str) -> None:
+    """Print a before/after diff for one field."""
+    before_preview = before[:120].replace("\n", "\\n")
+    after_preview = after[:120].replace("\n", "\\n")
+    print(f"  [{rule_id}] {lang}.{field}:")
+    print(f"    BEFORE: {before_preview}{'...' if len(before) > 120 else ''}")
+    print(f"    AFTER:  {after_preview}{'...' if len(after) > 120 else ''}")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Clean grammar.json emoji-headers and trailing ---")
+    parser.add_argument("--dry-run", action="store_true", help="Show diff for first 10 rules, don't write")
+    args = parser.parse_args()
+
+    if not GRAMMAR_PATH.exists():
+        print(f"ERROR: {GRAMMAR_PATH} not found", file=sys.stderr)
+        sys.exit(1)
+
+    raw = GRAMMAR_PATH.read_text(encoding="utf-8")
+    data = json.loads(raw)
+
+    rules: list[dict] = data.get("grammar", [])
+    total_rules = len(rules)
+
+    total_headers_stripped = 0
+    total_trailing_stripped = 0
+    diff_shown = 0
+
+    for rule in rules:
+        content = rule.get("content", {})
+        rule_id = rule.get("rule_id", "unknown")
+
+        for lang_key in ("English", "Russian"):
+            lang_section = content.get(lang_key)
+            if not isinstance(lang_section, dict):
+                continue
+
+            for field in SECTION_FIELDS:
+                if field not in lang_section:
+                    continue
+
+                value = lang_section[field]
+                if not isinstance(value, str):
+                    continue
+
+                cleaned, stripped_header, stripped_trailing = clean_field(value)
+
+                if stripped_header:
+                    total_headers_stripped += 1
+                if stripped_trailing:
+                    total_trailing_stripped += 1
+
+                if stripped_header or stripped_trailing:
+                    if args.dry_run and diff_shown < 10:
+                        show_diff(rule_id, lang_key, field, value, cleaned)
+                        diff_shown += 1
+                    lang_section[field] = cleaned
+
+    if args.dry_run:
+        print(f"DRY RUN: {total_rules} rules, {total_headers_stripped} headers, "
+              f"{total_trailing_stripped} trailing --- would be stripped")
+        return
+
+    output = json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+    GRAMMAR_PATH.write_text(output, encoding="utf-8")
+
+    print(f"Validation report:")
+    print(f"  Total rules:       {total_rules}")
+    print(f"  Headers stripped:  {total_headers_stripped}")
+    print(f"  Trailing ---:      {total_trailing_stripped}")
+
+    verification = json.loads(GRAMMAR_PATH.read_text(encoding="utf-8"))
+    verified_count = len(verification.get("grammar", []))
+    print(f"  Verified rules:    {verified_count}")
+    if verified_count != total_rules:
+        print(f"  ERROR: rule count mismatch!", file=sys.stderr)
+        sys.exit(1)
+    print("  OK: JSON parses correctly")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/src/api/prompts/grammar.md
+++ b/utils/src/api/prompts/grammar.md
@@ -21,7 +21,7 @@
   <success_brief>
     <output_format>
       Return ONLY valid JSON (no markdown wrappers). Each field contains
-      a Markdown section starting with an emoji header (e.g. 📖 What is it?).
+      Markdown content with no emoji headers or trailing separators.
       Do NOT include a ## Title preamble in any field — the title is already
       in the separate "title" field.
       Format:
@@ -29,86 +29,76 @@
         "en": {
           "title": "grammar pattern",
           "short_description": "brief description",
-          "explanation": "📖 What is it?\n\n[content]\n\n---",
-          "how_to_form": "🔧 How to form it?\n\n[content]\n\n---",
-          "examples": "🗣️ Examples in Context\n\n[content]\n\n---",
-          "nuances": "💡 Nuances & Common Mistakes\n\n[content]\n\n---",
-          "pro_tip": "🌸 Pro Tip\n\n[content]"
+          "explanation": "[content]",
+          "how_to_form": "[content]",
+          "examples": "[content]",
+          "nuances": "[content]",
+          "pro_tip": "[content]"
         },
         "ru": {
           "title": "grammar pattern",
           "short_description": "краткое описание",
-          "explanation": "📖 Что это и зачем?\n\n[контент]\n\n---",
-          "how_to_form": "🔧 Как образуется?\n\n[контент]\n\n---",
-          "examples": "🗣️ Примеры в контексте\n\n[контент]\n\n---",
-          "nuances": "💡 Нюансы и типичные ошибки\n\n[контент]\n\n---",
-          "pro_tip": "🌸 Лайфхак\n\n[контент]"
+          "explanation": "[контент]",
+          "how_to_form": "[контент]",
+          "examples": "[контент]",
+          "nuances": "[контент]",
+          "pro_tip": "[контент]"
         }
       }
     </output_format>
 
     <md_structure_en>
-      explanation field — starts with the header "📖 What is it?":
+      explanation field:
       [1-2 sentences: clear explanation of meaning, function, and usage context. Mention politeness, register, or restrictions if applicable.]
       > ⚠️ **Important:** [Key warning or commonly missed detail.]
-      End with --- on its own line.
 
-      how_to_form field — starts with the header "🔧 How to form it?":
+      how_to_form field:
       [Rule/formula. Use a table or list for different word/verb types.]
       | Word type | Rule | Example |
       |-----------|------|---------|
       | ... | ... | ... |
-      End with --- on its own line.
 
-      examples field — starts with the header "🗣️ Examples in Context":
+      examples field:
       ```
       [Japanese sentence]
       [English translation]
       ```
       [2-3 more examples with varied contexts or politeness levels]
-      End with --- on its own line.
 
-      nuances field — starts with the header "💡 Nuances & Common Mistakes":
+      nuances field:
       - ❌ [Common error/incorrect usage]
       - ✅ [Correct form/explanation]
       - 🔄 [Comparison with a similar pattern, if applicable]
-      End with --- on its own line.
 
-      pro_tip field — starts with the header "🌸 Pro Tip":
+      pro_tip field:
       [Extra info on speech style, usage situations, or a memory trick.]
-      No trailing ---.
     </md_structure_en>
 
     <md_structure_ru>
-      explanation field — starts with the header "📖 Что это и зачем?":
+      explanation field:
       [1-2 предложения: чёткое объяснение значения, функции и контекста использования. Укажите уровень вежливости, стиль или ограничения, если есть.]
       > ⚠️ **Важно:** [Ключевое предупреждение или особенность, которую часто упускают.]
-      End with --- on its own line.
 
-      how_to_form field — starts with the header "🔧 Как образуется?":
+      how_to_form field:
       [Правило/формула. Используйте таблицу или список для разных типов слов/глаголов.]
       | Тип слова | Правило | Пример |
       |-----------|---------|--------|
       | ... | ... | ... |
-      End with --- on its own line.
 
-      examples field — starts with the header "🗣️ Примеры в контексте":
+      examples field:
       ```
       [Японское предложение]
       [Перевод на русский]
       ```
       [Ещё 2-3 примера с разными контекстами или уровнями вежливости]
-      End with --- on its own line.
 
-      nuances field — starts with the header "💡 Нюансы и типичные ошибки":
+      nuances field:
       - ❌ [Частая ошибка/неправильное использование]
       - ✅ [Правильный вариант/объяснение]
       - 🔄 [Сравнение с похожей конструкцией, если применимо]
-      End with --- on its own line.
 
-      pro_tip field — starts with the header "🌸 Лайфхак":
+      pro_tip field:
       [Дополнительная информация о стиле речи, ситуациях использования или мнемоника для запоминания.]
-      No trailing ---.
     </md_structure_ru>
 
     <quality_criteria>
@@ -138,7 +128,6 @@
         Use markdown tables for formation rules and paradigms
       </criterion>
       <criterion name="structure">
-        Each field starts with its emoji header (e.g. 📖 What is it?).
         Do NOT include a ## Title line — it is already in the title field.
         Fields explanation, how_to_form, examples are REQUIRED.
         Fields nuances and pro_tip are optional but recommended.
@@ -161,20 +150,20 @@
       "en": {
         "title": "～ます",
         "short_description": "Polite present tense form",
-        "explanation": "📖 What is it?\n\n`～ます` is the **polite verb form** for present and future tense. Used with strangers, coworkers, and superiors in any situation requiring politness.\n> ⚠️ **Important:** Japanese has no separate future tense. Context determines if the action happens now or later.\n\n---",
-        "how_to_form": "🔧 How to form it?\n\n| Verb Group | Rule | Example |\n|------------|------|--------|\n| Group 1 (う-verbs) | Last う-row sound → い-row + ます | 書く → 書きます |\n| Group 2 (る-verbs) | Remove る + ます | 食べる → 食べます |\n| Group 3 (irregular) | する → します / くる → 来ます | する → します |\n\n---",
-        "examples": "🗣️ Examples in Context\n\n```\n毎朝コーヒーを飲みます。\nI drink coffee every morning.\n```\n\n```\n明日東京へ行きます。\nI will go to Tokyo tomorrow.\n```\n\n---",
-        "nuances": "💡 Nuances & Common Mistakes\n\n- ❌ Reading `来ます` as `くます` → ✅ Correct: `きます`\n- ❌ Confusing verb groups (not all る-verbs are Group 2) → ✅ Remember exceptions: `知る`, `帰る`, `切る` are Group 1\n- 🔄 With friends, use plain form (`飲む`, `食べる`), but in office/school always use `～ます`\n\n---",
-        "pro_tip": "🌸 Pro Tip\n\nWhen you hear `～ます` at the end of a sentence, you're in a polite or formal context. The more `ます`-forms, the more respectful the speech sounds."
+        "explanation": "`～ます` is the **polite verb form** for present and future tense. Used with strangers, coworkers, and superiors in any situation requiring politness.\n> ⚠️ **Important:** Japanese has no separate future tense. Context determines if the action happens now or later.",
+        "how_to_form": "| Verb Group | Rule | Example |\n|------------|------|--------|\n| Group 1 (う-verbs) | Last う-row sound → い-row + ます | 書く → 書きます |\n| Group 2 (る-verbs) | Remove る + ます | 食べる → 食べます |\n| Group 3 (irregular) | する → します / くる → 来ます | する → します |",
+        "examples": "```\n毎朝コーヒーを飲みます。\nI drink coffee every morning.\n```\n\n```\n明日東京へ行きます。\nI will go to Tokyo tomorrow.\n```",
+        "nuances": "- ❌ Reading `来ます` as `くます` → ✅ Correct: `きます`\n- ❌ Confusing verb groups (not all る-verbs are Group 2) → ✅ Remember exceptions: `知る`, `帰る`, `切る` are Group 1\n- 🔄 With friends, use plain form (`飲む`, `食べる`), but in office/school always use `～ます`",
+        "pro_tip": "When you hear `～ます` at the end of a sentence, you're in a polite or formal context. The more `ます`-forms, the more respectful the speech sounds."
       },
       "ru": {
         "title": "～ます",
         "short_description": "Вежливая форма настоящего времени",
-        "explanation": "📖 Что это и зачем?\n\n`～ます` — стандартная вежливая форма глагола для настоящего и будущего времени. Используется с незнакомыми, коллегами, старшими и в любой ситуации, где нужна вежливость.\n> ⚠️ **Важно:** В японском нет отдельного будущего времени. Контекст определяет, происходит действие сейчас или позже.\n\n---",
-        "how_to_form": "🔧 Как образуется?\n\n| Группа глаголов | Правило | Пример |\n|-----------------|---------|--------|\n| Группа 1 (う-глаголы) | Последний звук у-ряда → и-ряд + ます | 書く → 書きます |\n| Группа 2 (る-глаголы) | Убрать る + ます | 食べる → 食べます |\n| Группа 3 (исключения) | する → します / くる → 来ます | する → します |\n\n---",
-        "examples": "🗣️ Примеры в контексте\n\n```\n毎朝コーヒーを飲みます。\nКаждое утро я пью кофе.\n```\n\n```\n明日東京へ行きます。\nЗавтра я поеду в Токио.\n```\n\n---",
-        "nuances": "💡 Нюансы и типичные ошибки\n\n- ❌ Читать `来ます` как `くます` → ✅ Правильно: `きます`\n- ❌ Путать группы глаголов (не все る-глаголы относятся ко 2-й группе) → ✅ Запомните исключения: `知る`, `帰る`, `切る` — это Группа 1\n- 🔄 С друзьями можно использовать простую форму (`飲む`, `食べる`), но в офисе/учебе всегда `～ます`\n\n---",
-        "pro_tip": "🌸 Лайфхак\n\nЕсли слышите `～ます` в конце предложения — вы находитесь в вежливом или официальном контексте. Чем больше `ます`-форм, тем уважительнее звучит речь."
+        "explanation": "`～ます` — стандартная вежливая форма глагола для настоящего и будущего времени. Используется с незнакомыми, коллегами, старшими и в любой ситуации, где нужна вежливость.\n> ⚠️ **Важно:** В японском нет отдельного будущего времени. Контекст определяет, происходит действие сейчас или позже.",
+        "how_to_form": "| Группа глаголов | Правило | Пример |\n|-----------------|---------|--------|\n| Группа 1 (う-глаголы) | Последний звук у-ряда → и-ряд + ます | 書く → 書きます |\n| Группа 2 (る-глаголы) | Убрать る + ます | 食べる → 食べます |\n| Группа 3 (исключения) | する → します / くる → 来ます | する → します |",
+        "examples": "```\n毎朝コーヒーを飲みます。\nКаждое утро я пью кофе.\n```\n\n```\n明日東京へ行きます。\nЗавтра я поеду в Токио.\n```",
+        "nuances": "- ❌ Читать `来ます` как `くます` → ✅ Правильно: `きます`\n- ❌ Путать группы глаголов (не все る-глаголы относятся ко 2-й группе) → ✅ Запомните исключения: `知る`, `帰る`, `切る` — это Группа 1\n- 🔄 С друзьями можно использовать простую форму (`飲む`, `食べる`), но в офисе/учебе всегда `～ます`",
+        "pro_tip": "Если слышите `～ます` в конце предложения — вы находитесь в вежливом или официальном контексте. Чем больше `ます`-форм, тем уважительнее звучит речь."
       }
     }
   </example_output>
@@ -187,8 +176,7 @@
     <rule id="5">Use markdown tables for conjugation/formation rules</rule>
     <rule id="6">Both language versions must have the same structure (same fields)</rule>
     <rule id="7">The title field must be identical for both EN and RU (the grammar pattern itself)</rule>
-    <rule id="8">Each field starts with its emoji header (e.g. 📖 What is it?), no ## Title preamble</rule>
-    <rule id="9">Fields explanation, how_to_form, examples are mandatory. nuances and pro_tip are optional but recommended. Use empty string if not applicable.</rule>
+    <rule id="8">Fields explanation, how_to_form, examples are mandatory. nuances and pro_tip are optional but recommended. Use empty string if not applicable.</rule>
   </rules>
 
   <conversation>


### PR DESCRIPTION
Closes #48

## Changes

### Data cleanup
- Updated LLM generation prompt (grammar.md) — removed emoji-headers and trailing ---
- Added Python cleanup script with --dry-run support
- 2382 emoji-headers + 1906 trailing --- removed from grammar.json

### Domain
- GrammarRuleCard.description() now delegates to short_description()
- Deleted full_description() method (dead code)
- Updated domain tests

### UI
- New GrammarDetailsExpand component — inline-expand for grammar sections in lesson
- GrammarInfo with rule_id passed for Card::Grammar
- Show condition fixed for empty description
- i18n: common.more_details (en/ru)

## Verification
- 1313 tests pass (origa: 1211, origa_ui: 102)
- cargo clippy --workspace --all-targets — -D warnings: clean
- cargo fmt --check: clean