### PR TITLE
feat: prioritize phrases by lesson content overlap

### DIFF
--- a/origa/src/dictionary/phrase.rs
+++ b/origa/src/dictionary/phrase.rs
@@ -215,6 +215,10 @@ pub fn get_chunk_id(id: &Ulid) -> Option<u32> {
         .and_then(|idx| idx.get_entry(id).map(|e| e.chunk_id))
 }
 
+pub fn get_index_entry(id: &Ulid) -> Option<&'static IndexEntry> {
+    PHRASE_INDEX.get().and_then(|idx| idx.get_entry(id))
+}
+
 pub fn iter_index_entries() -> Option<impl Iterator<Item = &'static IndexEntry>> {
     PHRASE_INDEX.get().map(|idx| idx.iter_entries())
 }

--- a/origa/src/domain/knowledge/lesson_builder.rs
+++ b/origa/src/domain/knowledge/lesson_builder.rs
@@ -54,11 +54,21 @@ pub(crate) fn build_lesson(
     let all_selected_ids = build_selected_ids(&selected_cards, &favorite_cards);
     let padding_cards = collect_padding(&all_cards, &all_selected_ids);
 
+    let all_lesson_cards: Vec<_> = selected_cards
+        .iter()
+        .chain(favorite_cards.iter())
+        .chain(padding_cards.iter())
+        .copied()
+        .collect();
+    let (lesson_words, lesson_grammar_ids) = extract_lesson_content(&all_lesson_cards);
+
     let phrase_cards = collect_phrase_cards(
         &all_cards,
         &all_selected_ids,
         knowledge_set,
         daily_new_limit,
+        &lesson_words,
+        &lesson_grammar_ids,
     );
 
     build_lesson_result(
@@ -176,19 +186,91 @@ fn collect_padding<'a>(
     candidates.into_iter().take(needed).collect()
 }
 
+fn extract_lesson_content<'a>(
+    cards: impl IntoIterator<Item = &'a (&'a Ulid, &'a StudyCard)>,
+) -> (HashSet<String>, HashSet<Ulid>) {
+    let mut words = HashSet::new();
+    let mut grammar_ids = HashSet::new();
+
+    for (_, study_card) in cards {
+        match study_card.card() {
+            Card::Vocabulary(vocab) => {
+                words.insert(vocab.word().text().to_string());
+            },
+            Card::Grammar(grammar_card) => {
+                grammar_ids.insert(*grammar_card.rule_id());
+            },
+            Card::Kanji(_) | Card::Phrase(_) => {},
+        }
+    }
+
+    (words, grammar_ids)
+}
+
+fn phrase_lesson_overlap(
+    phrase_id: &Ulid,
+    lesson_words: &HashSet<String>,
+    lesson_grammar_ids: &HashSet<Ulid>,
+) -> usize {
+    let Some(entry) = crate::dictionary::phrase::get_index_entry(phrase_id) else {
+        return 0;
+    };
+
+    let vocab_overlap = entry
+        .tokens()
+        .iter()
+        .filter(|t| lesson_words.contains(*t))
+        .count();
+
+    let grammar_overlap = entry
+        .grammar_rules()
+        .iter()
+        .filter(|g| lesson_grammar_ids.contains(g))
+        .count();
+
+    vocab_overlap + grammar_overlap
+}
+
+fn phrase_overlap_from_card(
+    study_card: &StudyCard,
+    lesson_words: &HashSet<String>,
+    lesson_grammar_ids: &HashSet<Ulid>,
+) -> usize {
+    let Card::Phrase(phrase_card) = study_card.card() else {
+        return 0;
+    };
+    phrase_lesson_overlap(phrase_card.phrase_id(), lesson_words, lesson_grammar_ids)
+}
+
+fn sort_phrases_by_overlap<'a>(
+    phrases: &mut [(&'a Ulid, &'a StudyCard)],
+    lesson_words: &HashSet<String>,
+    lesson_grammar_ids: &HashSet<Ulid>,
+) {
+    phrases.sort_by(|a, b| {
+        let overlap_a = phrase_overlap_from_card(a.1, lesson_words, lesson_grammar_ids);
+        let overlap_b = phrase_overlap_from_card(b.1, lesson_words, lesson_grammar_ids);
+        overlap_b.cmp(&overlap_a).then_with(|| {
+            a.1.memory()
+                .next_review_date()
+                .cmp(&b.1.memory().next_review_date())
+        })
+    });
+}
+
 fn collect_phrase_cards<'a>(
     all_cards: &[(&'a Ulid, &'a StudyCard)],
     all_selected_ids: &HashSet<Ulid>,
     knowledge_set: &KnowledgeSet,
     daily_new_limit: usize,
+    lesson_words: &HashSet<String>,
+    lesson_grammar_ids: &HashSet<Ulid>,
 ) -> Vec<(&'a Ulid, &'a StudyCard)> {
     let phrase_new_limit = daily_new_limit * PHRASE_NEW_RATIO;
     let phrase_cards_studied = knowledge_set.phrase_cards_studied_today();
     let phrase_new_remaining = phrase_new_limit.saturating_sub(phrase_cards_studied);
 
-    let mut phrase_cards: Vec<_> = Vec::new();
-
-    let due_phrases: Vec<_> = all_cards
+    let mut due_phrases: Vec<_> = all_cards
         .iter()
         .filter(|(id, card)| {
             !all_selected_ids.contains(id)
@@ -198,20 +280,22 @@ fn collect_phrase_cards<'a>(
         })
         .copied()
         .collect();
-    phrase_cards.extend(due_phrases);
+    sort_phrases_by_overlap(&mut due_phrases, lesson_words, lesson_grammar_ids);
 
-    let new_phrases: Vec<_> = all_cards
+    let mut new_phrases: Vec<_> = all_cards
         .iter()
         .filter(|(id, card)| {
             !all_selected_ids.contains(id)
                 && matches!(card.card(), Card::Phrase(_))
                 && card.memory().is_new()
         })
-        .take(phrase_new_remaining)
         .copied()
         .collect();
-    phrase_cards.extend(new_phrases);
+    sort_phrases_by_overlap(&mut new_phrases, lesson_words, lesson_grammar_ids);
+    new_phrases.truncate(phrase_new_remaining);
 
+    let mut phrase_cards = due_phrases;
+    phrase_cards.extend(new_phrases);
     phrase_cards.truncate(PHRASE_MAX_PER_LESSON);
     phrase_cards
 }
@@ -345,4 +429,133 @@ fn distribute_new_cards<'a>(
         .into_values()
         .flat_map(|cards| weighted_interleave_by_type(cards))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::knowledge::{GrammarRuleCard, KanjiCard, PhraseCard, VocabularyCard};
+    use crate::domain::value_objects::Question;
+
+    fn vocab_card(word: &str) -> Card {
+        Card::Vocabulary(VocabularyCard::new(
+            Question::new(word.to_string()).unwrap(),
+        ))
+    }
+
+    fn grammar_card(rule_id: Ulid) -> Card {
+        Card::Grammar(GrammarRuleCard::new_test_with_id(rule_id))
+    }
+
+    fn phrase_card(phrase_id: Ulid) -> Card {
+        Card::Phrase(PhraseCard::new_test_with_id(phrase_id))
+    }
+
+    fn kanji_card(kanji: &str) -> Card {
+        Card::Kanji(KanjiCard::new_test(kanji.to_string()))
+    }
+
+    fn make_study_card(card: Card) -> (Ulid, StudyCard) {
+        (Ulid::new(), StudyCard::new(card))
+    }
+
+    #[test]
+    fn extract_lesson_content_extracts_vocab_and_grammar() {
+        let word = "食べる";
+        let rule_id = Ulid::new();
+        let cards = [
+            make_study_card(vocab_card(word)),
+            make_study_card(grammar_card(rule_id)),
+            make_study_card(phrase_card(Ulid::new())),
+            make_study_card(kanji_card("食")),
+        ];
+        let refs: Vec<(&Ulid, &StudyCard)> = cards.iter().map(|(id, sc)| (id, sc)).collect();
+
+        let (words, grammar_ids) = extract_lesson_content(&refs);
+
+        assert_eq!(words.len(), 1);
+        assert!(words.contains(word));
+        assert_eq!(grammar_ids.len(), 1);
+        assert!(grammar_ids.contains(&rule_id));
+    }
+
+    #[test]
+    fn extract_lesson_content_returns_empty_when_no_vocab_or_grammar() {
+        let cards = [
+            make_study_card(phrase_card(Ulid::new())),
+            make_study_card(kanji_card("日")),
+        ];
+        let refs: Vec<(&Ulid, &StudyCard)> = cards.iter().map(|(id, sc)| (id, sc)).collect();
+
+        let (words, grammar_ids) = extract_lesson_content(&refs);
+
+        assert!(words.is_empty());
+        assert!(grammar_ids.is_empty());
+    }
+
+    #[test]
+    fn extract_lesson_content_empty_input() {
+        let refs: Vec<(&Ulid, &StudyCard)> = vec![];
+        let (words, grammar_ids) = extract_lesson_content(&refs);
+        assert!(words.is_empty());
+        assert!(grammar_ids.is_empty());
+    }
+
+    #[test]
+    fn extract_lesson_content_deduplicates_words() {
+        let cards = [
+            make_study_card(vocab_card("食べる")),
+            make_study_card(vocab_card("食べる")),
+        ];
+        let refs: Vec<(&Ulid, &StudyCard)> = cards.iter().map(|(id, sc)| (id, sc)).collect();
+
+        let (words, _) = extract_lesson_content(&refs);
+
+        assert_eq!(words.len(), 1);
+    }
+
+    #[test]
+    fn phrase_lesson_overlap_returns_zero_when_index_not_loaded() {
+        let phrase_id = Ulid::new();
+        let words: HashSet<String> = ["食べる".to_string()].into_iter().collect();
+
+        let overlap = phrase_lesson_overlap(&phrase_id, &words, &HashSet::new());
+        assert_eq!(overlap, 0);
+    }
+
+    #[test]
+    fn phrase_overlap_from_card_returns_zero_for_non_phrase() {
+        let (_, sc) = make_study_card(vocab_card("食べる"));
+        let words: HashSet<String> = ["食べる".to_string()].into_iter().collect();
+
+        let overlap = phrase_overlap_from_card(&sc, &words, &HashSet::new());
+        assert_eq!(overlap, 0);
+    }
+
+    #[test]
+    fn phrase_overlap_from_card_returns_zero_for_phrase_when_index_not_loaded() {
+        let (_, sc) = make_study_card(phrase_card(Ulid::new()));
+        let words: HashSet<String> = ["食べる".to_string()].into_iter().collect();
+
+        let overlap = phrase_overlap_from_card(&sc, &words, &HashSet::new());
+        assert_eq!(overlap, 0);
+    }
+
+    #[test]
+    fn sort_phrases_by_overlap_preserves_length_when_equal_overlap() {
+        let (id1, sc1) = make_study_card(phrase_card(Ulid::new()));
+        let (id2, sc2) = make_study_card(phrase_card(Ulid::new()));
+
+        let mut phrases = vec![(&id1, &sc1), (&id2, &sc2)];
+        sort_phrases_by_overlap(&mut phrases, &HashSet::new(), &HashSet::new());
+
+        assert_eq!(phrases.len(), 2);
+    }
+
+    #[test]
+    fn sort_phrases_by_overlap_does_not_panic_on_empty() {
+        let mut phrases: Vec<(&Ulid, &StudyCard)> = vec![];
+        sort_phrases_by_overlap(&mut phrases, &HashSet::new(), &HashSet::new());
+        assert!(phrases.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

When selecting phrases for a lesson, sort candidates by overlap with the lesson's vocabulary words and grammar rules. Phrases containing words/grammar from the lesson appear first.

## Changes

- Added `get_index_entry()` public accessor in `dictionary::phrase`
- Added `extract_lesson_content()` — extracts vocab words and grammar IDs from lesson cards
- Added `phrase_lesson_overlap()` — computes token/grammar overlap score
- Modified `collect_phrase_cards()` — sorts due and new phrases by overlap (desc), tiebreaker by next_review_date
- SR discipline preserved: due phrases always come before new phrases
- Graceful fallback: when PhraseIndex not loaded, overlap=0, behavior identical to before

## Test Results

- 1220 tests passed, 0 failed
- clippy clean, fmt clean
- 9 new unit tests added