### PR TITLE
🐛 fix(phrases): empty phrase cards on first page load

### DIFF
--- a/end2end/tests/phrase.spec.ts
+++ b/end2end/tests/phrase.spec.ts
@@ -150,6 +150,37 @@ async function completeFullOnboarding(page: Page): Promise<void> {
 }
 
 testWithFreshUser.describe("Phrases after full onboarding", () => {
+    testWithFreshUser("phrase cards should have non-empty text on first visit after onboarding", async ({ page }) => {
+        test.setTimeout(300_000);
+
+        await completeFullOnboarding(page);
+        await expect(page).toHaveURL(/\/home$/);
+
+        const phrasesPage = new PhrasesPage(page);
+        await phrasesPage.goto();
+        await page.waitForURL(/\/phrases$/, { timeout: 10_000 });
+        await page.waitForLoadState("networkidle");
+        await page.locator(".loading-spinner").waitFor({ state: "hidden", timeout: 30_000 }).catch(() => {});
+        await phrasesPage.expectPhrasesVisible();
+
+        await expect(phrasesPage.emptyState).not.toBeVisible({ timeout: 30_000 });
+
+        const firstCard = phrasesPage.cardItem.first();
+        await expect(firstCard).toBeVisible({ timeout: 30_000 });
+
+        // BUG: On first load, phrase text is empty because phrase CDN data hasn't loaded
+        // when PhraseCardItem is created, and the For component reuses old views for matching keys
+        const phraseText = firstCard.getByTestId("phrases-card-phrase");
+        await expect(phraseText).toBeAttached({ timeout: 30_000 });
+        const textContent = await phraseText.textContent();
+        expect(textContent?.trim().length, "Phrase text should not be empty on first load").toBeGreaterThan(0);
+
+        // Also verify meaning is non-empty
+        const meaning = firstCard.getByTestId("phrases-card-meaning");
+        const meaningContent = await meaning.textContent();
+        expect(meaningContent?.trim().length, "Phrase meaning should not be empty on first load").toBeGreaterThan(0);
+    });
+
     testWithFreshUser("should show phrase cards after completing onboarding with N5", async ({ page }) => {
         test.setTimeout(300_000);
 

--- a/origa_ui/src/pages/phrases/content.rs
+++ b/origa_ui/src/pages/phrases/content.rs
@@ -17,7 +17,6 @@ pub fn PhrasesContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
         use_context::<HybridUserRepository>().expect("repository context not provided");
 
     let initial_load_done = RwSignal::new(false);
-    let refresh_for_reload = refresh_trigger;
     let on_cards_loaded: CardsLoadedCallback = Arc::new(move |cards: &[StudyCard]| {
         if initial_load_done.get() {
             return;
@@ -35,7 +34,7 @@ pub fn PhrasesContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
             .collect();
 
         if !phrase_ids.is_empty() {
-            let refresh = refresh_for_reload;
+            let refresh = refresh_trigger;
             let done = initial_load_done;
             spawn_local(async move {
                 let results = load_phrase_details_batch(&phrase_ids).await;
@@ -82,6 +81,7 @@ pub fn PhrasesContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
                 on_mark_as_known=Callback::new(move |_| ctx.on_mark_as_known.run(card_id))
                 on_delete=ctx.on_delete
                 is_deleting=ctx.is_deleting
+                phrase_data_trigger=refresh_trigger
             />
         }
         .into_any()

--- a/origa_ui/src/pages/phrases/phrase_card_item.rs
+++ b/origa_ui/src/pages/phrases/phrase_card_item.rs
@@ -4,7 +4,7 @@ use super::super::shared::{CardStatus, DeleteRequest};
 use crate::i18n::use_i18n;
 use crate::ui_components::{
     AudioPlayer, CardActionBar, CardHistoryModal, CollapsibleDescription, DeleteConfirmModal,
-    FsrsMetrics, MarkdownText, Tag, TagVariant, TranslatorText,
+    FsrsMetrics, MarkdownText, Skeleton, Tag, TagVariant, TranslatorText,
 };
 use leptos::prelude::*;
 use origa::domain::{Card as DomainCard, NativeLanguage, StudyCard};
@@ -19,6 +19,7 @@ pub fn PhraseCardItem(
     on_mark_as_known: Callback<()>,
     on_delete: Callback<DeleteRequest>,
     is_deleting: Signal<bool>,
+    phrase_data_trigger: RwSignal<u32>,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let card_id = *study_card.card_id();
@@ -36,20 +37,25 @@ pub fn PhraseCardItem(
         })
     });
 
-    let (phrase_text, audio_src) = match study_card.card() {
-        DomainCard::Phrase(phrase_card) => {
-            let text = phrase_card.question().unwrap_or_default();
-            let src = crate::repository::cdn_provider::resolve_audio_url(&format!(
-                "phrases/audio/{}.opus",
-                phrase_card.phrase_id()
-            ));
-            (text, src)
-        },
-        _ => (String::new(), String::new()),
+    let study_card_for_text = study_card.clone();
+    let phrase_text: Memo<String> = Memo::new(move |_| {
+        let _ = phrase_data_trigger.get();
+        match study_card_for_text.card() {
+            DomainCard::Phrase(phrase_card) => phrase_card.question().unwrap_or_default(),
+            _ => String::new(),
+        }
+    });
+
+    let audio_src = match study_card.card() {
+        DomainCard::Phrase(phrase_card) => crate::repository::cdn_provider::resolve_audio_url(
+            &format!("phrases/audio/{}.opus", phrase_card.phrase_id()),
+        ),
+        _ => String::new(),
     };
 
     let study_card_for_meaning = study_card.clone();
     let meaning = Memo::new(move |_| {
+        let _ = phrase_data_trigger.get();
         let lang = native_language.get();
         match study_card_for_meaning.card() {
             DomainCard::Phrase(phrase_card) => phrase_card.answer(&lang).unwrap_or_default(),
@@ -71,11 +77,28 @@ pub fn PhraseCardItem(
             <div class="phrase-card-body">
                 <div class="phrase-card-header">
                     <div class="phrase-card-phrase" data-testid="phrases-card-phrase">
-                        <TranslatorText
-                            text=phrase_text
-                            native_language=native_language
-                            test_id=Signal::derive(|| "phrases-card-text".to_string())
-                        />
+                        {move || {
+                            let text = phrase_text.get();
+                            if text.is_empty() {
+                                view! {
+                                    <Skeleton
+                                        width="60%".to_string()
+                                        height="1.5em".to_string()
+                                        test_id=Signal::derive(|| "phrases-card-text-skeleton".to_string())
+                                    />
+                                }
+                                .into_any()
+                            } else {
+                                view! {
+                                    <TranslatorText
+                                        text=text
+                                        native_language=native_language
+                                        test_id=Signal::derive(|| "phrases-card-text".to_string())
+                                    />
+                                }
+                                .into_any()
+                            }
+                        }}
                     </div>
                     <Show when=move || has_audio>
                         <div class="phrase-card-audio">


### PR DESCRIPTION
## Problem
When opening the /phrases page for the first time, all phrase cards appear empty. Refreshing or navigating away and back fixes it.

## Root Cause
 stores only . Text/translations come from CDN cache  loaded asynchronously AFTER cards render.  was a one-time , not reactive — Leptos  component reused old views for matching keys, so text stayed empty.

## Fix
- Made  and  reactive  depending on 
- Show  while CDN data loads instead of empty fragment
- Pass  from  to 

## Files Changed
-  — reactive Memos + Skeleton
-  — pass trigger prop
-  — regression test for first-visit text content

## Verification
- ✅ cargo fmt — clean
- ✅ cargo clippy — 0 warnings
- ✅ cargo test — all 1322 tests pass
- ✅ Code quality review — approve