### PR TITLE
🐛(docker): fix WASM cache headers and enable compression

### DIFF
--- a/origa_ui/Caddyfile
+++ b/origa_ui/Caddyfile
@@ -5,16 +5,12 @@
 :4000 {
     reverse_proxy localhost:8080
 
-    @compressible {
-        not path *.wasm
-    }
-    encode @compressible gzip zstd
+    encode gzip zstd
 
     @static_files {
         path *.js *.css *.json *.png *.jpg *.jpeg *.gif *.svg *.woff *.woff2 *.ttf *.eot *.ico *.webmanifest *.wasm
     }
-    header @static_files Cache-Control "public, max-age=2592000, must-revalidate"
-    header @static_files ETag ""
+    header @static_files Cache-Control "public, max-age=2592000, immutable"
 
     @html {
         path *.html /

--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -74,7 +74,8 @@ RUN --mount=type=cache,target=/sccache,sharing=locked \
 COPY origa ./origa
 COPY origa_ui ./origa_ui
 
-RUN --mount=type=cache,target=/root/.cargo/registry \
+RUN --mount=type=cache,target=/sccache \
+    --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/app/target \
     rm -rf origa_ui/public/dictionaries/unidic && \
     rm -rf /app/target/wasm32-unknown-unknown/release/.fingerprint/origa* && \


### PR DESCRIPTION
## Problem

WASM cache doesn't work in production — files are re-downloaded instead of being served from browser cache.

## Root cause

1. **ETag removed** — `header @static_files ETag ""` deletes ETags, preventing 304 Not Modified responses
2. **WASM excluded from compression** — `not path *.wasm` in @compressible matcher skips gzip/zstd for WASM (which compresses 60-80%)
3. **must-revalidate without ETag** — after max-age expiry, browser must full-download instead of conditional request
4. **sccache not mounted in second build step** — Dockerfile sets RUSTC_WRAPPER=sccache but doesn't mount /sccache in the second RUN, negating the cache

## Changes

- **Caddyfile**: Removed `header @static_files ETag ""` — ETags now preserved for efficient 304 responses
- **Caddyfile**: Removed `@compressible { not path *.wasm }` — WASM now compressed via `encode gzip zstd`
- **Caddyfile**: Changed `must-revalidate` → `immutable` for static assets
- **Dockerfile**: Added `--mount=type=cache,target=/sccache` to second build step for faster CI builds

## Files changed

- `origa_ui/Caddyfile`
- `origa_ui/Dockerfile`
