### PR TITLE
fix: shuffle lesson cards + grammar modal keyboard hints

### DIFF
--- a/origa/src/domain/knowledge/lesson/types.rs
+++ b/origa/src/domain/knowledge/lesson/types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
@@ -411,6 +412,7 @@ impl LessonData {
         }
 
         let core_count = core.len();
+        core.shuffle(&mut rand::rng());
         core.extend(phrases);
 
         Self {
@@ -426,5 +428,89 @@ impl IntoIterator for LessonData {
 
     fn into_iter(self) -> Self::IntoIter {
         self.cards.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::knowledge::{PhraseCard, VocabularyCard};
+    use crate::domain::value_objects::Question;
+    use crate::domain::Card;
+
+    fn make_vocabulary_lesson_card(id: Ulid) -> (Ulid, LessonCard) {
+        let card = Card::Vocabulary(VocabularyCard::new(Question::new("test".to_string()).unwrap()));
+        (id, LessonCard::new(LessonCardView::Normal(card), false))
+    }
+
+    fn make_phrase_lesson_card(id: Ulid) -> (Ulid, LessonCard) {
+        let card = Card::Phrase(PhraseCard::new_test_with_id(id));
+        (id, LessonCard::new(LessonCardView::Normal(card), false))
+    }
+
+    #[test]
+    fn reorder_core_first_phrases_last_preserves_all_cards() {
+        let vocab_1 = Ulid::new();
+        let vocab_2 = Ulid::new();
+        let phrase_1 = Ulid::new();
+        let phrase_2 = Ulid::new();
+
+        let input = vec![
+            make_phrase_lesson_card(phrase_1),
+            make_vocabulary_lesson_card(vocab_1),
+            make_phrase_lesson_card(phrase_2),
+            make_vocabulary_lesson_card(vocab_2),
+        ];
+
+        let result = LessonData::reorder_core_first_phrases_last(input);
+        let result_ids: Vec<Ulid> = result.card_ids();
+
+        assert_eq!(result.total_count(), 4);
+        assert_eq!(result.core_count, 2);
+        assert_eq!(result.phrase_count(), 2);
+
+        assert!(result_ids.contains(&vocab_1));
+        assert!(result_ids.contains(&vocab_2));
+        assert!(result_ids.contains(&phrase_1));
+        assert!(result_ids.contains(&phrase_2));
+
+        let core_ids: Vec<Ulid> = result_ids[..result.core_count].to_vec();
+        let phrase_ids: Vec<Ulid> = result_ids[result.core_count..].to_vec();
+
+        assert!(core_ids.iter().all(|id| !matches!(result.get(id), Some(lc) if lc.card_type() == CardType::Phrase)));
+        assert!(phrase_ids.iter().all(|id| matches!(result.get(id), Some(lc) if lc.card_type() == CardType::Phrase)));
+    }
+
+    #[test]
+    fn reorder_core_first_phrases_last_handles_empty() {
+        let result = LessonData::reorder_core_first_phrases_last(vec![]);
+
+        assert!(result.is_empty());
+        assert_eq!(result.core_count, 0);
+        assert_eq!(result.total_count(), 0);
+    }
+
+    #[test]
+    fn reorder_core_first_phrases_last_only_core() {
+        let vocab_1 = Ulid::new();
+        let vocab_2 = Ulid::new();
+        let vocab_3 = Ulid::new();
+
+        let input = vec![
+            make_vocabulary_lesson_card(vocab_1),
+            make_vocabulary_lesson_card(vocab_2),
+            make_vocabulary_lesson_card(vocab_3),
+        ];
+
+        let result = LessonData::reorder_core_first_phrases_last(input);
+        let result_ids: Vec<Ulid> = result.card_ids();
+
+        assert_eq!(result.total_count(), 3);
+        assert_eq!(result.core_count, 3);
+        assert_eq!(result.phrase_count(), 0);
+
+        assert!(result_ids.contains(&vocab_1));
+        assert!(result_ids.contains(&vocab_2));
+        assert!(result_ids.contains(&vocab_3));
     }
 }

--- a/origa/src/domain/knowledge/lesson/types.rs
+++ b/origa/src/domain/knowledge/lesson/types.rs
@@ -434,12 +434,14 @@ impl IntoIterator for LessonData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::Card;
     use crate::domain::knowledge::{PhraseCard, VocabularyCard};
     use crate::domain::value_objects::Question;
-    use crate::domain::Card;
 
     fn make_vocabulary_lesson_card(id: Ulid) -> (Ulid, LessonCard) {
-        let card = Card::Vocabulary(VocabularyCard::new(Question::new("test".to_string()).unwrap()));
+        let card = Card::Vocabulary(VocabularyCard::new(
+            Question::new("test".to_string()).unwrap(),
+        ));
         (id, LessonCard::new(LessonCardView::Normal(card), false))
     }
 
@@ -477,8 +479,16 @@ mod tests {
         let core_ids: Vec<Ulid> = result_ids[..result.core_count].to_vec();
         let phrase_ids: Vec<Ulid> = result_ids[result.core_count..].to_vec();
 
-        assert!(core_ids.iter().all(|id| !matches!(result.get(id), Some(lc) if lc.card_type() == CardType::Phrase)));
-        assert!(phrase_ids.iter().all(|id| matches!(result.get(id), Some(lc) if lc.card_type() == CardType::Phrase)));
+        assert!(
+            core_ids.iter().all(
+                |id| !matches!(result.get(id), Some(lc) if lc.card_type() == CardType::Phrase)
+            )
+        );
+        assert!(
+            phrase_ids
+                .iter()
+                .all(|id| matches!(result.get(id), Some(lc) if lc.card_type() == CardType::Phrase))
+        );
     }
 
     #[test]

--- a/origa_ui/src/pages/grammar/grammar_practice_modal.rs
+++ b/origa_ui/src/pages/grammar/grammar_practice_modal.rs
@@ -301,7 +301,7 @@ pub fn GrammarPracticeModal(
                                 data-testid="grammar-practice-close-btn"
                                 on:click=move |_| on_close.run(())
                             >
-                                {close_text}
+                                {close_text} <span class="hidden sm:inline">"[Esc]"</span>
                             </button>
                         </div>
                     </div>
@@ -381,6 +381,7 @@ pub fn GrammarPracticeModal(
                                     known_kanji=known_kanji.get_value()
                                 />
                             }}
+                            <span class="hidden sm:inline ml-1">"[1]"</span>
                         </button>
                         <button
                             class=move || option_class(1)
@@ -393,6 +394,7 @@ pub fn GrammarPracticeModal(
                                     known_kanji=known_kanji.get_value()
                                 />
                             }}
+                            <span class="hidden sm:inline ml-1">"[2]"</span>
                         </button>
                         <button
                             class=move || option_class(2)
@@ -405,6 +407,7 @@ pub fn GrammarPracticeModal(
                                     known_kanji=known_kanji.get_value()
                                 />
                             }}
+                            <span class="hidden sm:inline ml-1">"[3]"</span>
                         </button>
                         <button
                             class=move || option_class(3)
@@ -417,6 +420,7 @@ pub fn GrammarPracticeModal(
                                     known_kanji=known_kanji.get_value()
                                 />
                             }}
+                            <span class="hidden sm:inline ml-1">"[4]"</span>
                         </button>
                     </div>
 
@@ -437,7 +441,7 @@ pub fn GrammarPracticeModal(
                                     data-testid="grammar-practice-next-btn"
                                     on:click=move |_| on_next()
                                 >
-                                    {next_text}
+                                    {next_text} <span class="hidden sm:inline">"[Space]"</span>
                                 </button>
                             </Show>
                             <button
@@ -445,7 +449,7 @@ pub fn GrammarPracticeModal(
                                 data-testid="grammar-practice-close-btn"
                                 on:click=move |_| on_close.run(())
                             >
-                                {close_text}
+                                {close_text} <span class="hidden sm:inline">"[Esc]"</span>
                             </button>
                         </div>
                     </Show>
@@ -480,14 +484,14 @@ pub fn GrammarPracticeModal(
                             >
                                 {move || {
                                     i18n.get_keys().grammar_page().practice_again().inner().to_string()
-                                }}
+                                }} <span class="hidden sm:inline">"[Space]"</span>
                             </button>
                             <button
                                 class="px-4 py-2 border rounded hover:opacity-80 transition-opacity cursor-pointer"
                                 data-testid="grammar-practice-close-btn"
                                 on:click=move |_| on_close.run(())
                             >
-                                {close_text}
+                                {close_text} <span class="hidden sm:inline">"[Esc]"</span>
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
## Changes

### 🐛 Shuffle core lesson cards
- Added `core.shuffle(&mut rand::rng())` in `reorder_core_first_phrases_last` so core cards appear in random order each lesson
- Phrases remain at the end in their priority order
- Added 3 unit tests for `reorder_core_first_phrases_last`

### 💄 Grammar practice modal keyboard hints  
- Added keyboard shortcut hints (`[1]`-`[4]`, `[Space]`, `[Esc]`) to practice modal buttons
- Hidden on mobile (`hidden sm:inline`)

## Verification
- `cargo clippy -p origa -- -D warnings` — 0 warnings
- `cargo test -p origa` — 1235 tests pass
