### PR TITLE
fix(docker): capture origa_landing crash output

### DIFF
--- a/origa_ui/entrypoint.sh
+++ b/origa_ui/entrypoint.sh
@@ -2,11 +2,20 @@
 set -e
 
 cd /app/origa_landing
+echo "Starting origa_landing..."
 ORIGA_LANDING_BASE_URL=${ORIGA_LANDING_BASE_URL:-https://origa.app} \
-    /usr/local/bin/origa_landing &
-
+    /usr/local/bin/origa_landing 2>&1 &
+LANDING_PID=$!
 cd /app
 
 caddy run --config /app/Caddyfile &
+
+# Wait a moment and check if landing is still alive
+sleep 2
+if ! kill -0 "$LANDING_PID" 2>/dev/null; then
+    echo "origa_landing CRASHED (PID $LANDING_PID)"
+    wait "$LANDING_PID" 2>/dev/null
+    echo "Exit code: $?"
+fi
 
 exec /app/trail run --address 127.0.0.1:8080 --public-dir /app/public --spa


### PR DESCRIPTION
Diagnostic: log binary startup and capture crash exit code in entrypoint.sh

- Redirect stderr to stdout with `2>&1`
- Add startup echo before binary launch
- Save PID and perform 2-second health check
- Print crash message and exit code if binary died