### PR TITLE
fix(docker): replace COPY cdn with CDN download

### DIFF
--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -80,6 +80,11 @@ RUN --mount=type=cache,target=/sccache,sharing=locked \
     cargo build --release -p origa_landing --features ssr --target x86_64-unknown-linux-musl && \
     rm -rf origa origa_ui origa_landing
 
+RUN set -e && mkdir -p cdn/dictionaries && \
+    for file in char_def.bin matrix.mtx dict.da dict.vals unk.bin dict.wordsidx dict.words metadata.json; do \
+      echo "Downloading dictionaries/${file}..." && \
+      curl -fsSL "${ORIGA_CDN_BASE_URL}/dictionaries/${file}" -o "cdn/dictionaries/${file}"; \
+    done
 COPY origa ./origa
 COPY origa_ui ./origa_ui
 COPY origa_landing ./origa_landing


### PR DESCRIPTION
Replace `COPY cdn ./cdn` with curl download of 8 dictionary files from CDN URL.

- cdn/ is in .gitignore so COPY was broken in CI
- Only downloads files needed by origa_ui/build.rs (dictionaries)
- well_known_set not needed (build.rs silently skips it)