### PR TITLE
fix(docker): force PORT=3000 for origa_landing

### DIFF
--- a/origa_ui/entrypoint.sh
+++ b/origa_ui/entrypoint.sh
@@ -3,7 +3,8 @@ set -e
 
 cd /app/origa_landing
 echo "Starting origa_landing..."
-ORIGA_LANDING_BASE_URL=${ORIGA_LANDING_BASE_URL:-https://origa.app} \
+PORT=3000 \
+    ORIGA_LANDING_BASE_URL=${ORIGA_LANDING_BASE_URL:-https://origa.app} \
     /usr/local/bin/origa_landing 2>&1 &
 LANDING_PID=$!
 cd /app


### PR DESCRIPTION
Railway overrides PORT env var. origa_landing reads it in main.rs (defaults to 3000).
If Railway sets PORT=4000, origa_landing conflicts with Caddy.

Fix: explicitly set PORT=3000 in entrypoint.sh before launching origa_landing.