### PR TITLE
feat(docker): split monolithic image into 3 independent services

### DIFF
--- a/origa_landing/Dockerfile
+++ b/origa_landing/Dockerfile
@@ -97,4 +97,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD ["wget", "--spider", "-q", "http://localhost:3000/"]
 
-CMD ["origa_landing"]
+CMD ["sh", "-c", "echo '=== Debug ===' && ls -la /usr/local/bin/origa_landing && ls -la /app/origa_landing/ && echo '=== Starting ===' && exec origa_landing"]

--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -125,4 +125,4 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD ["curl", "--fail", "http://localhost:8080/api/healthcheck"]
 
-CMD ["trail", "run", "--address", "0.0.0.0:8080", "--public-dir", "/app/public", "--spa"]
+CMD ["/app/trail", "run", "--address", "0.0.0.0:8080", "--public-dir", "/app/public", "--spa"]


### PR DESCRIPTION
- origa_landing: standalone SSR (alpine + musl binary, port 3000)
- origa_ui: Caddy + SPA static files (caddy:alpine, port 4000)
- trailbase: bare API backend (port 8080)

Caddyfile uses env vars for upstream with localhost defaults. CI builds all 3 images. CD pushes to GHCR with matrix strategy. Removed entrypoint.sh (no longer needed).