### PR TITLE
feat(docker): split monolithic image into 3 independent services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         name: Lint
         runs-on: ubuntu-24.04
         env:
-            ORIGA_CDN_BASE_URL: ${{ vars.ORIGA_CDN_BASE_URL }}
-            ORIGA_LANDING_BASE_URL: "https://origa.app"
-            TRAILBASE_URL: ${{ vars.TRAILBASE_URL }}
+            ORIGA_CDN_BASE_URL: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
+            ORIGA_LANDING_BASE_URL: "https://${{ vars.ORIGA_BASE_URI }}"
+            TRAILBASE_URL: "https://${{ vars.ORIGA_APP_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
               uses: ./.github/actions/download-cdn
               with:
                   cache-key: cdn-data-v8-${{ hashFiles('end2end/cdn-manifest.txt') }}
-                  cdn-base-url: ${{ vars.ORIGA_CDN_BASE_URL }}
+                  cdn-base-url: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
 
             - name: Upload CDN artifact
               uses: actions/upload-artifact@v4
@@ -81,9 +81,9 @@ jobs:
         needs: cdn-download
         runs-on: ubuntu-24.04
         env:
-            ORIGA_CDN_BASE_URL: ${{ vars.ORIGA_CDN_BASE_URL }}
-            ORIGA_LANDING_BASE_URL: "https://origa.app"
-            TRAILBASE_URL: ${{ vars.TRAILBASE_URL }}
+            ORIGA_CDN_BASE_URL: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
+            ORIGA_LANDING_BASE_URL: "https://${{ vars.ORIGA_BASE_URI }}"
+            TRAILBASE_URL: "https://${{ vars.ORIGA_APP_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -317,7 +317,7 @@ jobs:
                   file: ./origa_landing/Dockerfile
                   push: false
                   build-args: |
-                      ORIGA_LANDING_BASE_URL=https://origa.app
+                      ORIGA_LANDING_BASE_URL=https://${{ vars.ORIGA_BASE_URI }}
 
     docker-build-ui:
         name: Docker Build (ui)
@@ -338,9 +338,9 @@ jobs:
                   push: false
                   cache-from: type=registry,ref=ghcr.io/yurvon-screamo/origa:ui-buildcache
                   build-args: |
-                      ORIGA_CDN_BASE_URL=${{ vars.ORIGA_CDN_BASE_URL }}
+                      ORIGA_CDN_BASE_URL=https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}
                       ORIGA_CDN_REGION=${{ vars.ORIGA_CDN_REGION }}
-                      TRAILBASE_URL=${{ vars.TRAILBASE_URL }}
+                      TRAILBASE_URL=https://${{ vars.ORIGA_APP_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}
 
     check:
         name: CI Gate

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,16 +56,16 @@ jobs:
                     - image: landing
                       dockerfile: ./origa_landing/Dockerfile
                       build_args: |
-                          ORIGA_LANDING_BASE_URL=https://origa.app
+                          ORIGA_LANDING_BASE_URL=https://${{ vars.ORIGA_BASE_URI }}
                     - image: ui
                       dockerfile: ./origa_ui/Dockerfile
                       build_args: |
                           ORIGA_VERSION=${{ needs.version.outputs.version }}
                           ORIGA_COMMIT=${{ needs.version.outputs.commit_sha }}
                           ORIGA_BUILD_DATE=${{ needs.version.outputs.build_date }}
-                          ORIGA_CDN_BASE_URL=${{ vars.ORIGA_CDN_BASE_URL }}
+                          ORIGA_CDN_BASE_URL=https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}
                           ORIGA_CDN_REGION=${{ vars.ORIGA_CDN_REGION }}
-                          TRAILBASE_URL=${{ vars.TRAILBASE_URL }}
+                          TRAILBASE_URL=https://${{ vars.ORIGA_APP_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}
 
         steps:
             - name: Checkout repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 | Workspace      | Rust 2024 edition, id `net.uwuwu.origa`                                   |
 | Бизнес-логика  | `origa/` — Clean Architecture (Use Cases → Domain → Traits)               |
 | Frontend       | `origa_ui/` — Leptos 0.8, CSR/WASM, trunk                                 |
+| Landing        | `origa_landing/` — Leptos 0.8, SSR/Axum, i18n (EN+RU)                    |
 | Desktop        | `tauri/` — Tauri v2 (Windows, Linux, macOS)                               |
 | E2E            | `end2end/` — Playwright (TypeScript)                                      |
 | Утилиты        | `utils/`, `scripts/` (Python)                                             |
@@ -17,9 +18,10 @@
 ## Структура проекта
 
 ```text
-origa/       — domain, use_cases, traits, ocr, stt, dictionary
-origa_ui/    — Leptos 0.8 frontend (WASM)
-tauri/       — Tauri v2 desktop app
+origa/          — domain, use_cases, traits, ocr, stt, dictionary
+origa_ui/       — Leptos 0.8 frontend (WASM)
+origa_landing/  — SSR landing site (Leptos 0.8 + Axum)
+tauri/          — Tauri v2 desktop app
 end2end/     — Playwright E2E тесты
 utils/       — CLI утилиты
 cdn/         — статический контент (dictionaries, grammar, kanji_animations, ndlocr, phrases, pitch, well_known_set)
@@ -37,8 +39,18 @@ cd tauri && cargo tauri dev
 
 ### Переменные окружения (compile-time, `build.rs`)
 
-Обязательная: `ORIGA_CDN_BASE_URL`. Опциональные: `ORIGA_CDN_REGION`, `ORIGA_VERSION`,
-`ORIGA_COMMIT`, `ORIGA_BUILD_DATE`, `ORIGA_PUBLIC_BASE_URL`, `TRAILBASE_URL`.
+Обязательные: `ORIGA_CDN_BASE_URL`.
+Опциональные: `ORIGA_CDN_REGION`, `ORIGA_VERSION`, `ORIGA_COMMIT`, `ORIGA_BUILD_DATE`, `TRAILBASE_URL`.
+
+**DNS naming scheme** (CI/CD production):
+
+- `ORIGA_BASE_URI` — base domain (e.g. `origa.uwuwu.net`)
+- `ORIGA_CDN_URI_PREFIX` — CDN subdomain prefix (e.g. `s3` → `s3.origa.uwuwu.net`)
+- `ORIGA_APP_URI_PREFIX` — app subdomain prefix (e.g. `app` → `app.origa.uwuwu.net`)
+- Landing = base domain (no prefix)
+
+**Local dev:** `$env:ORIGA_CDN_BASE_URL = "https://s3-proxy-production-52e3.up.railway.app"`
+**Landing dev:** `$env:ORIGA_LANDING_BASE_URL = "https://origa.app"`
 
 ## Команды
 
@@ -81,7 +93,9 @@ aws s3 cp s3://adaptable-foodbox-ucep7wx/ s3://adaptable-foodbox-ucep7wx/ --prof
 
 ## CI/CD
 
-Workflows: `tauri.yml`, `mobile.yml`, `docker.yml`, `cleanup-cache.yml`.
+Workflows: `ci.yml`, `docker.yml`, `tauri.yml`, `cleanup-cache.yml`.
+CI: lint + test + e2e + docker build (2 images: landing + ui).
+CD: 2 Docker images (GHCR) + Railway deploy (2 services).
 Targets: Windows x86_64, Linux x86_64, macOS aarch64. Релиз при push `master` + tag `v*.*.*`.
 
 ## Границы

--- a/origa_landing/Dockerfile
+++ b/origa_landing/Dockerfile
@@ -97,4 +97,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD ["wget", "--spider", "-q", "http://localhost:3000/"]
 
-CMD ["origa_landing"]
+CMD ["sh", "-c", "echo '=== Debug ===' && ls -la /usr/local/bin/origa_landing && ls -la /app/origa_landing/ && echo '=== Starting ===' && exec origa_landing"]

--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -125,4 +125,4 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD ["curl", "--fail", "http://localhost:8080/api/healthcheck"]
 
-CMD ["trail", "run", "--address", "0.0.0.0:8080", "--public-dir", "/app/public", "--spa"]
+CMD ["/app/trail", "run", "--address", "0.0.0.0:8080", "--public-dir", "/app/public", "--spa"]


### PR DESCRIPTION
- origa_landing: standalone SSR (alpine + musl binary, port 3000)
- origa_ui: Caddy + SPA static files (caddy:alpine, port 4000)
- trailbase: bare API backend (port 8080)

Caddyfile uses env vars for upstream with localhost defaults. CI builds all 3 images. CD pushes to GHCR with matrix strategy. Removed entrypoint.sh (no longer needed).