### PR TITLE
fix(landing): Docker layer cache persistence

### DIFF
--- a/origa_landing/Dockerfile
+++ b/origa_landing/Dockerfile
@@ -69,7 +69,8 @@ WORKDIR /app/origa_landing
 
 RUN --mount=type=cache,target=/root/.npm \
     npm install && \
-    npm run build:css
+    npm run build:css && \
+    ls -la style/landing.processed.css
 
 WORKDIR /app
 
@@ -77,6 +78,7 @@ WORKDIR /app
 RUN --mount=type=cache,target=/sccache,sharing=locked \
     --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
+    rm -f /app/target/x86_64-unknown-linux-musl/release/origa_landing && \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/.fingerprint/origa_landing* && \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/deps/origa_landing* && \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/build/origa_landing* && \

--- a/origa_landing/Dockerfile
+++ b/origa_landing/Dockerfile
@@ -82,14 +82,15 @@ RUN --mount=type=cache,target=/sccache,sharing=locked \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/deps/origa_landing* && \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/deps/liboriga_landing* && \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/build/origa_landing* && \
-    cargo build --release -p origa_landing --features ssr --target x86_64-unknown-linux-musl
+    cargo build --release -p origa_landing --features ssr --target x86_64-unknown-linux-musl && \
+    cp /app/target/x86_64-unknown-linux-musl/release/origa_landing /tmp/origa_landing
 
 # Runtime
 FROM alpine:3.21
 
 WORKDIR /app
 
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/origa_landing /usr/local/bin/origa_landing
+COPY --from=builder /tmp/origa_landing /usr/local/bin/origa_landing
 COPY --from=builder /app/origa_landing/style/landing.processed.css /app/origa_landing/style/landing.processed.css
 COPY --from=builder /app/origa_landing/public /app/origa_landing/public
 COPY --from=builder /app/origa_landing/Cargo.toml /app/origa_landing/Cargo.toml

--- a/origa_landing/Dockerfile
+++ b/origa_landing/Dockerfile
@@ -46,7 +46,7 @@ COPY origa_ui/Cargo.toml ./origa_ui/
 COPY origa_landing/Cargo.toml ./origa_landing/
 COPY .cargo .cargo
 
-# Dummy source for ALL workspace members (workspace resolution requires valid Cargo.toml + source)
+# Dummy source for ALL workspace members
 RUN mkdir -p origa/src && echo "pub fn dummy() {}" > origa/src/lib.rs && \
     mkdir -p origa_ui/src && echo "pub fn dummy() {}" > origa_ui/src/lib.rs && \
     echo "fn main() {}" > origa_ui/src/main.rs && \
@@ -56,31 +56,31 @@ RUN mkdir -p origa/src && echo "pub fn dummy() {}" > origa/src/lib.rs && \
     echo "fn main() {}" > origa_landing/src/main.rs && \
     echo "fn main() {}" > origa_landing/build.rs
 
-# Dummy build - only origa_landing with ssr feature
+# Dummy build - cache deps
 RUN --mount=type=cache,target=/sccache,sharing=locked \
     --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     cargo build --release -p origa_landing --features ssr --target x86_64-unknown-linux-musl && \
     rm -rf origa_landing
 
-# Real source + CSS build
+# Real source
 COPY origa_landing ./origa_landing
 
+# CSS build
 WORKDIR /app/origa_landing
 
 RUN --mount=type=cache,target=/root/.npm \
     npm install && \
-    npm run build:css && \
-    ls -la style/landing.processed.css
+    npm run build:css
 
 WORKDIR /app
 
-# Real build
+# Real build - same pattern as origa_ui Dockerfile
 RUN --mount=type=cache,target=/sccache,sharing=locked \
     --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
-    rm -f /app/target/x86_64-unknown-linux-musl/release/origa_landing && \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/.fingerprint/origa_landing* && \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/deps/origa_landing* && \
+    rm -rf /app/target/x86_64-unknown-linux-musl/release/deps/liboriga_landing* && \
     rm -rf /app/target/x86_64-unknown-linux-musl/release/build/origa_landing* && \
     cargo build --release -p origa_landing --features ssr --target x86_64-unknown-linux-musl
 
@@ -99,4 +99,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD ["wget", "--spider", "-q", "http://localhost:3000/"]
 
-CMD ["sh", "-c", "echo '=== Binary ===' && ls -la /usr/local/bin/origa_landing && echo '=== Files ===' && ls -laR /app/origa_landing/ && echo '=== Run ===' && RUST_LOG=info RUST_BACKTRACE=1 origa_landing; echo \"EXIT CODE: $?\""]
+CMD ["origa_landing"]


### PR DESCRIPTION
## Summary

Copy the landing binary to  after build (outside the sccache cache mount) so the runtime layer can reliably  it. Without this fix the binary could be missing if cache mounts are shared or cleaned.

## Commits

- `3923c602` fix(docker): remove cached dummy binary before real build
- `4ae82a3d` fix(landing): rewrite Dockerfile with proper cache invalidation
- `228238ce` fix(landing): copy binary outside cache mount for Docker layer persistence