### PR TITLE
✅ test(home): use kanji cards for JLPT progress E2E test

### DIFF
--- a/end2end/tests/home.spec.ts
+++ b/end2end/tests/home.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { testWithFreshUser } from "../fixtures";
 import { skipOnboarding } from "../helpers/navigation";
 import { HomePage, WordsPage, GrammarPage, KanjiPage } from "../pages";
@@ -107,4 +107,38 @@ testWithFreshUser.describe("Home Page", () => {
     const homePage = await setupHomePage(page);
     await expect(homePage.recentStudy).toBeVisible({ timeout: 10_000 });
   });
+
+  testWithFreshUser(
+    "should update JLPT progress after marking kanji as known",
+    async ({ page }) => {
+      test.setTimeout(120_000);
+      await skipOnboarding(page);
+
+      const homePage = new HomePage(page);
+      await expect(homePage.jlptProgress).toBeVisible({ timeout: 15_000 });
+
+      const jlptPct = page.getByTestId("home-jlpt-progress-pct");
+      await expect(jlptPct).toHaveText("0%", { timeout: 10_000 });
+
+      // Add N5 kanji and mark as known (N5 has ~80 kanji, so 5 gives ~6%)
+      const kanjiPage = new KanjiPage(page);
+      await kanjiPage.goto();
+      await kanjiPage.expectKanjiVisible();
+      await kanjiPage.openAddModal();
+      await kanjiPage.selectLevel("N5");
+      await kanjiPage.selectAllKanji();
+      await kanjiPage.addSelectedKanji();
+
+      const count = Math.min(5, await kanjiPage.getCardCount());
+      for (let i = 0; i < count; i++) {
+        await kanjiPage.markCardAsKnownByIndex(i);
+        await page.waitForTimeout(300);
+      }
+
+      // Navigate to home and verify JLPT progress updated
+      await homePage.goto();
+      await expect(homePage.jlptProgress).toBeVisible({ timeout: 15_000 });
+      await expect(jlptPct).not.toHaveText("0%", { timeout: 10_000 });
+    },
+  );
 });

--- a/end2end/tests/lesson.spec.ts
+++ b/end2end/tests/lesson.spec.ts
@@ -130,37 +130,4 @@ testWithFreshUser.describe("Lesson Page", () => {
         await page.waitForURL(/\/home$/, { timeout: 10_000 });
     });
 
-    testWithFreshUser(
-        "should update JLPT progress after marking words as known",
-        async ({ page }) => {
-            test.setTimeout(120_000);
-
-            await skipOnboarding(page);
-
-            const homePage = new HomePage(page);
-            await homePage.goto();
-            await expect(homePage.jlptProgress).toBeVisible({ timeout: 15_000 });
-
-            const jlptPct = page.getByTestId("home-jlpt-progress-pct");
-            await expect(jlptPct).toHaveText("0%", { timeout: 10_000 });
-
-            // Add words and mark as known (mark_as_known bypasses FSRS stability check)
-            const wordsPage = new WordsPage(page);
-            await wordsPage.goto();
-            await wordsPage.expectWordsVisible();
-            await wordsPage.openAddModal();
-            await wordsPage.enterText("私は本を読みます");
-            await wordsPage.analyzeText();
-            await wordsPage.selectFirstWord();
-            await wordsPage.addSelectedWords();
-            await expect(wordsPage.wordsGrid).toBeVisible({ timeout: 10_000 });
-
-            await wordsPage.markAllCardsAsKnown();
-
-            // Navigate to home and verify JLPT progress updated
-            await homePage.goto();
-            await expect(homePage.jlptProgress).toBeVisible({ timeout: 15_000 });
-            await expect(jlptPct).not.toHaveText("0%", { timeout: 10_000 });
-        },
-    );
 });

--- a/origa_ui/src/pages/home/jlpt_progress_card.rs
+++ b/origa_ui/src/pages/home/jlpt_progress_card.rs
@@ -43,28 +43,14 @@ pub fn JlptProgressCard(
                 <div class="flex-1 progress-track">
                     <div
                         class="progress-fill"
-                        style=move || {
-                            let pct = overall_pct.get().min(100.0);
-                            if pct > 0.0 && pct < 1.0 {
-                                "width: 1%".to_string()
-                            } else {
-                                format!("width: {:.0}%", pct)
-                            }
-                        }
+                        style=move || format!("width: {:.0}%", overall_pct.get().min(100.0))
                     ></div>
                 </div>
                 <DisplayText
                     class=Signal::derive(|| "text-sm".to_string())
                     test_id=Signal::derive(move || format!("{}-pct", test_id.get()))
                 >
-                    {move || {
-                        let pct = overall_pct.get();
-                        if pct > 0.0 && pct < 1.0 {
-                            "<1%".to_string()
-                        } else {
-                            format!("{:.0}%", pct)
-                        }
-                    }}
+                    {move || format!("{:.0}%", overall_pct.get())}
                 </DisplayText>
             </div>
 


### PR DESCRIPTION
- Revert <1% display over-engineering back to simple {:.0}%
- Move JLPT progress test from lesson.spec.ts to home.spec.ts
- Use KanjiPage (N5 kanji, ~80 items) instead of WordsPage (616 items)
- 5 marked kanji gives ~6% kanji progress → visible in overall %