### PR TITLE
fix(landing): increase header logo, add CSS auto-rebuild to build.rs

### DIFF
--- a/origa_landing/build.rs
+++ b/origa_landing/build.rs
@@ -19,4 +19,69 @@ fn main() {
             }
         });
     println!("cargo:rustc-env=ORIGA_APP_BASE_URL={app_base_url}");
+
+    build_css();
+}
+
+fn build_css() {
+    println!("cargo:rerun-if-changed=style/landing.css");
+    println!("cargo:rerun-if-changed=style/input.css");
+    println!("cargo:rerun-if-changed=tailwind.config.js");
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let input = std::path::Path::new(&manifest_dir).join("style/landing.css");
+    let output = std::path::Path::new(&manifest_dir).join("style/landing.processed.css");
+
+    let skip = output.exists()
+        && input
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .is_some_and(|input_mtime| {
+                output
+                    .metadata()
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .is_some_and(|output_mtime| output_mtime >= input_mtime)
+            });
+
+    if skip {
+        return;
+    }
+
+    let result = if cfg!(windows) {
+        std::process::Command::new("cmd")
+            .args([
+                "/C",
+                "npx",
+                "tailwindcss",
+                "--input",
+                input.to_str().unwrap(),
+                "--output",
+                output.to_str().unwrap(),
+                "--minify",
+            ])
+            .current_dir(&manifest_dir)
+            .status()
+    } else {
+        std::process::Command::new("npx")
+            .args([
+                "tailwindcss",
+                "--input",
+                input.to_str().unwrap(),
+                "--output",
+                output.to_str().unwrap(),
+                "--minify",
+            ])
+            .current_dir(&manifest_dir)
+            .status()
+    };
+
+    match result {
+        Ok(s) if s.success() => {},
+        Ok(s) => panic!("CSS build failed: npx tailwindcss exited with {s}"),
+        Err(e) => {
+            println!("cargo:warning=npx not available, skipping CSS rebuild: {e}");
+        },
+    }
 }

--- a/origa_landing/style/landing.css
+++ b/origa_landing/style/landing.css
@@ -26,26 +26,26 @@
 .landing-header__logo {
     display: flex;
     align-items: center;
-    gap: var(--space-sm);
+    gap: 6px;
     text-decoration: none;
 }
 
 .landing-header__logo-img {
-    width: 32px;
-    height: 32px;
+    width: 36px;
+    height: 36px;
     image-rendering: pixelated;
 }
 
 .landing-header__logo-name {
     font-family: var(--font-serif);
-    font-size: 1.5rem;
+    font-size: 1.625rem;
     font-weight: 500;
     color: var(--fg-black);
 }
 
 .landing-header__logo-kana {
     font-family: var(--font-mono);
-    font-size: 0.9rem;
+    font-size: 1rem;
     letter-spacing: 0.05em;
     color: var(--fg-muted);
 }


### PR DESCRIPTION
## Changes

- **Header logo**: image 24px→36px, Origa text 1.25rem→1.625rem, オリガ 0.75rem→1rem, gap 8px→6px
- **build.rs**: automatic Tailwind CSS rebuild when source files change (landing.css, input.css, tailwind.config.js)
- Incremental: skips rebuild if landing.processed.css is newer than landing.css
- Cross-platform: cmd /C npx on Windows, npx on Unix
- Graceful: warns instead of panicking if npx is not available

Supersedes CSS sizing fix from #107 (processed CSS was not rebuilt there).