### PR TITLE
feat(landing): add integrations page with word set catalog

### DIFF
--- a/origa_landing/src/app.rs
+++ b/origa_landing/src/app.rs
@@ -40,12 +40,14 @@ pub fn App() -> impl IntoView {
                     <Route path=path!("") view=HomePage />
                     <Route path=path!("features") view=FeaturesPage />
                     <Route path=path!("compare") view=ComparePage />
+                    <Route path=path!("integrations") view=IntegrationsPage />
                     <Route path=path!("download") view=DownloadPage />
                 </ParentRoute>
                 <ParentRoute path=path!("ru") view=move || view! { <Layout locale=Locale::Ru /> }>
                     <Route path=path!("") view=HomePage />
                     <Route path=path!("features") view=FeaturesPage />
                     <Route path=path!("compare") view=ComparePage />
+                    <Route path=path!("integrations") view=IntegrationsPage />
                     <Route path=path!("download") view=DownloadPage />
                 </ParentRoute>
             </Routes>

--- a/origa_landing/src/components/layout.rs
+++ b/origa_landing/src/components/layout.rs
@@ -54,6 +54,9 @@ pub fn Layout(locale: Locale) -> impl IntoView {
                 <NavLink prefix href="download" class="landing-header__link">
                     {c.header_download}
                 </NavLink>
+                <NavLink prefix href="integrations" class="landing-header__link">
+                    {c.header_integrations}
+                </NavLink>
                 <a href=switch_href class="landing-header__link">
                     {switch_label}
                 </a>
@@ -74,6 +77,9 @@ pub fn Layout(locale: Locale) -> impl IntoView {
                     </NavLink>
                     <NavLink prefix href="download" class="landing-footer__link">
                         {c.header_download}
+                    </NavLink>
+                    <NavLink prefix href="integrations" class="landing-footer__link">
+                        {c.header_integrations}
                     </NavLink>
                 </div>
                 <div>

--- a/origa_landing/src/content/en.rs
+++ b/origa_landing/src/content/en.rs
@@ -6,6 +6,7 @@ pub static CONTENT: Content = Content {
     header_features: "Features",
     header_compare: "Compare",
     header_download: "Download",
+    header_integrations: "Integrations",
 
     footer_product: "Product",
     footer_resources: "Resources",
@@ -154,4 +155,44 @@ pub static CONTENT: Content = Content {
     download_button: "Download",
     download_subtitle: "Download Origa to any device — everything works offline.",
     download_try_web: "Open →",
+
+    integrations_meta_title: "Word Sets & Integrations | Origa",
+    integrations_meta_description: "Import vocabulary from Duolingo, Anki, Minna no Nihongo, Irodori, JLPT and more. Pre-built word sets ready to study.",
+    integrations_h1: "Learn from what you already use",
+    integrations_subtitle: "Pre-built vocabulary sets from popular Japanese learning sources. Import and start reviewing instantly.",
+
+    integrations_tag_exam: "Exam",
+    integrations_tag_app: "App",
+    integrations_tag_textbook: "Textbook",
+    integrations_tag_content: "Content",
+    integrations_tag_import: "Import",
+
+    integrations_jlpt_name: "JLPT",
+    integrations_jlpt_desc: "Official vocabulary for the Japanese Language Proficiency Test, organized by level.",
+    integrations_jlpt_detail: "N5 · N4 · N3 · N2 · N1",
+
+    integrations_duolingo_name: "Duolingo",
+    integrations_duolingo_desc: "Vocabulary extracted from Duolingo's Japanese course, available in English and Russian tracks.",
+    integrations_duolingo_detail: "190+ word sets · English & Russian tracks",
+
+    integrations_minna_name: "Minna no Nihongo",
+    integrations_minna_desc: "Word lists from the most popular Japanese textbook series, organized lesson by lesson.",
+    integrations_minna_detail: "みんなの日本語 · N5 · N4 · N3 · N2",
+
+    integrations_irodori_name: "Irodori",
+    integrations_irodori_desc: "Vocabulary from the Japan Foundation's free JLPT-oriented textbook series.",
+    integrations_irodori_detail: "いろどり · 入門 · 初級1 · 初級2 · 54 lessons",
+
+    integrations_migii_name: "Migii",
+    integrations_migii_desc: "JLPT test preparation study sets from the Migii app, organized by level.",
+    integrations_migii_detail: "JLPT prep sets by level",
+
+    integrations_spy_name: "Spy × Family",
+    integrations_spy_desc: "Vocabulary from the popular anime — learn Japanese through content you enjoy.",
+    integrations_spy_detail: "Season 1 vocabulary",
+
+    integrations_anki_name: "Anki Import",
+    integrations_anki_desc: "Import any Anki deck directly into Origa. Supports .anki2, .anki21 and .anki21b formats.",
+    integrations_anki_detail: ".anki2 · .anki21 · .anki21b",
+    integrations_anki_note: "Import any Anki deck and continue learning where you left off — all your progress transfers.",
 };

--- a/origa_landing/src/content/mod.rs
+++ b/origa_landing/src/content/mod.rs
@@ -56,6 +56,7 @@ pub struct Content {
     pub header_features: &'static str,
     pub header_compare: &'static str,
     pub header_download: &'static str,
+    pub header_integrations: &'static str,
 
     // Footer
     pub footer_product: &'static str,
@@ -213,6 +214,55 @@ pub struct Content {
     pub download_button: &'static str,
     pub download_subtitle: &'static str,
     pub download_try_web: &'static str,
+
+    // Integrations page
+    pub integrations_meta_title: &'static str,
+    pub integrations_meta_description: &'static str,
+    pub integrations_h1: &'static str,
+    pub integrations_subtitle: &'static str,
+
+    // Tags
+    pub integrations_tag_exam: &'static str,
+    pub integrations_tag_app: &'static str,
+    pub integrations_tag_textbook: &'static str,
+    pub integrations_tag_content: &'static str,
+    pub integrations_tag_import: &'static str,
+
+    // JLPT card
+    pub integrations_jlpt_name: &'static str,
+    pub integrations_jlpt_desc: &'static str,
+    pub integrations_jlpt_detail: &'static str,
+
+    // Duolingo card
+    pub integrations_duolingo_name: &'static str,
+    pub integrations_duolingo_desc: &'static str,
+    pub integrations_duolingo_detail: &'static str,
+
+    // Minna no Nihongo card
+    pub integrations_minna_name: &'static str,
+    pub integrations_minna_desc: &'static str,
+    pub integrations_minna_detail: &'static str,
+
+    // Irodori card
+    pub integrations_irodori_name: &'static str,
+    pub integrations_irodori_desc: &'static str,
+    pub integrations_irodori_detail: &'static str,
+
+    // Migii card
+    pub integrations_migii_name: &'static str,
+    pub integrations_migii_desc: &'static str,
+    pub integrations_migii_detail: &'static str,
+
+    // Spy x Family card
+    pub integrations_spy_name: &'static str,
+    pub integrations_spy_desc: &'static str,
+    pub integrations_spy_detail: &'static str,
+
+    // Anki card
+    pub integrations_anki_name: &'static str,
+    pub integrations_anki_desc: &'static str,
+    pub integrations_anki_detail: &'static str,
+    pub integrations_anki_note: &'static str,
 }
 
 mod en;

--- a/origa_landing/src/content/ru.rs
+++ b/origa_landing/src/content/ru.rs
@@ -6,6 +6,7 @@ pub static CONTENT: Content = Content {
     header_features: "Функции",
     header_compare: "Сравнение",
     header_download: "Скачать",
+    header_integrations: "Интеграции",
 
     footer_product: "Продукт",
     footer_resources: "Ресурсы",
@@ -154,4 +155,44 @@ pub static CONTENT: Content = Content {
     download_button: "Скачать",
     download_subtitle: "Скачайте Origa на любое устройство — всё работает офлайн.",
     download_try_web: "Открыть →",
+
+    integrations_meta_title: "Наборы слов и интеграции | Origa",
+    integrations_meta_description: "Импортируйте лексику из Duolingo, Anki, Minna no Nihongo, Irodori, JLPT и других. Готовые наборы слов для изучения.",
+    integrations_h1: "Учитесь по своим источникам",
+    integrations_subtitle: "Готовые наборы слов из популярных источников для изучения японского. Импортируйте и начните повторять сразу.",
+
+    integrations_tag_exam: "Экзамен",
+    integrations_tag_app: "Приложение",
+    integrations_tag_textbook: "Учебник",
+    integrations_tag_content: "Контент",
+    integrations_tag_import: "Импорт",
+
+    integrations_jlpt_name: "JLPT",
+    integrations_jlpt_desc: "Официальная лексика для Японского языкового теста (JLPT), организованная по уровням.",
+    integrations_jlpt_detail: "N5 · N4 · N3 · N2 · N1",
+
+    integrations_duolingo_name: "Duolingo",
+    integrations_duolingo_desc: "Лексика из курса японского Duolingo, доступная на английском и русском языках.",
+    integrations_duolingo_detail: "190+ наборов · Английский и русский треки",
+
+    integrations_minna_name: "Minna no Nihongo",
+    integrations_minna_desc: "Списки слов из самого популярного учебника японского, организованные по урокам.",
+    integrations_minna_detail: "みんなの日本語 · N5 · N4 · N3 · N2",
+
+    integrations_irodori_name: "Irodori",
+    integrations_irodori_desc: "Лексика из бесплатной серии учебников JLPT от Японского фонда.",
+    integrations_irodori_detail: "いろどり · 入門 · 初級1 · 初級2 · 54 урока",
+
+    integrations_migii_name: "Migii",
+    integrations_migii_desc: "Учебные наборы для подготовки к JLPT из приложения Migii, организованные по уровням.",
+    integrations_migii_detail: "Наборы для подготовки к JLPT по уровням",
+
+    integrations_spy_name: "Spy × Family",
+    integrations_spy_desc: "Лексика из популярного аниме — учите японский через контент, который вам нравится.",
+    integrations_spy_detail: "Лексика 1 сезона",
+
+    integrations_anki_name: "Импорт Anki",
+    integrations_anki_desc: "Импортируйте любую колоду Anki прямо в Origa. Поддерживаются форматы .anki2, .anki21 и .anki21b.",
+    integrations_anki_detail: ".anki2 · .anki21 · .anki21b",
+    integrations_anki_note: "Импортируйте любую колоду Anki и продолжайте учить с того места, где остановились — весь прогресс переносится.",
 };

--- a/origa_landing/src/pages/integrations.rs
+++ b/origa_landing/src/pages/integrations.rs
@@ -1,0 +1,79 @@
+use leptos::prelude::*;
+use leptos_router::components::A;
+
+use crate::components::seo::PageMeta;
+use crate::content::Locale;
+
+#[component]
+pub fn IntegrationsPage() -> impl IntoView {
+    let locale = use_context::<Locale>().expect("Locale context missing");
+    let c = locale.content();
+    let prefix = locale.path_prefix();
+    let download_href = format!("{prefix}/download");
+
+    view! {
+        <PageMeta locale path="/integrations" title=c.integrations_meta_title description=c.integrations_meta_description/>
+
+        // Hero
+        <section class="intg-hero">
+            <h1 class="intg-hero__title">{c.integrations_h1}</h1>
+            <p class="intg-hero__subtitle">{c.integrations_subtitle}</p>
+            <hr class="intg-hero__rule"/>
+        </section>
+
+        // Catalog
+        <section class="intg-catalog">
+            <IntgCard tag=c.integrations_tag_exam name=c.integrations_jlpt_name desc=c.integrations_jlpt_desc detail=c.integrations_jlpt_detail/>
+            <IntgCard tag=c.integrations_tag_app name=c.integrations_duolingo_name desc=c.integrations_duolingo_desc detail=c.integrations_duolingo_detail/>
+            <IntgCard tag=c.integrations_tag_textbook name=c.integrations_minna_name desc=c.integrations_minna_desc detail=c.integrations_minna_detail/>
+            <IntgCard tag=c.integrations_tag_textbook name=c.integrations_irodori_name desc=c.integrations_irodori_desc detail=c.integrations_irodori_detail/>
+            <IntgCard tag=c.integrations_tag_app name=c.integrations_migii_name desc=c.integrations_migii_desc detail=c.integrations_migii_detail/>
+            <IntgCard tag=c.integrations_tag_content name=c.integrations_spy_name desc=c.integrations_spy_desc detail=c.integrations_spy_detail/>
+
+            // Anki card with editorial note
+            <div class="intg-card">
+                <p class="intg-card__tag">{c.integrations_tag_import}</p>
+                <h3 class="intg-card__name">{c.integrations_anki_name}</h3>
+                <p class="intg-card__desc">{c.integrations_anki_desc}</p>
+                <p class="intg-card__detail">{c.integrations_anki_detail}</p>
+                <IntgEditorialNote text=c.integrations_anki_note/>
+            </div>
+        </section>
+
+        // CTA (reuses home-cta dark olive)
+        <section class="home-cta">
+            <hr class="home-cta__rule"/>
+            <h2 class="home-cta__title">{c.home_cta_title}</h2>
+            <A href=download_href attr:class="btn btn-filled">{c.home_cta_primary}</A>
+            <p class="home-cta__platforms">
+                "Windows · Linux · macOS · Android · iOS · Web"
+            </p>
+        </section>
+    }
+}
+
+#[component]
+fn IntgCard(
+    tag: &'static str,
+    name: &'static str,
+    desc: &'static str,
+    detail: &'static str,
+) -> impl IntoView {
+    view! {
+        <div class="intg-card">
+            <p class="intg-card__tag">{tag}</p>
+            <h3 class="intg-card__name">{name}</h3>
+            <p class="intg-card__desc">{desc}</p>
+            <p class="intg-card__detail">{detail}</p>
+        </div>
+    }
+}
+
+#[component]
+fn IntgEditorialNote(text: &'static str) -> impl IntoView {
+    view! {
+        <div class="intg-editorial-note">
+            <p class="intg-editorial-note__text">{text}</p>
+        </div>
+    }
+}

--- a/origa_landing/src/pages/mod.rs
+++ b/origa_landing/src/pages/mod.rs
@@ -2,8 +2,10 @@ mod compare;
 mod download;
 mod features;
 mod home;
+mod integrations;
 
 pub use compare::ComparePage;
 pub use download::DownloadPage;
 pub use features::FeaturesPage;
 pub use home::HomePage;
+pub use integrations::IntegrationsPage;

--- a/origa_landing/style/landing.css
+++ b/origa_landing/style/landing.css
@@ -1206,3 +1206,115 @@
     margin-right: var(--space-sm);
     margin-bottom: 0;
 }
+
+/* ========================================
+   Integrations Page
+   ======================================== */
+
+/* Hero */
+
+.intg-hero {
+    background: var(--bg-paper);
+    padding: var(--space-xxxl) var(--space-lg) var(--space-xl);
+    text-align: center;
+}
+
+.intg-hero__title {
+    font-family: var(--font-serif);
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 300;
+    margin-bottom: var(--space-md);
+}
+
+.intg-hero__subtitle {
+    font-family: var(--font-mono);
+    font-size: var(--text-body);
+    color: var(--fg-muted);
+    max-width: 600px;
+    margin: 0 auto var(--space-lg);
+    line-height: 1.7;
+}
+
+.intg-hero__rule {
+    width: 80px;
+    height: 1px;
+    background: var(--border-dark);
+    border: none;
+    margin: 0 auto;
+}
+
+/* Catalog */
+
+.intg-catalog {
+    padding: var(--space-xl) var(--space-lg);
+    max-width: 1024px;
+    margin: 0 auto;
+}
+
+.intg-card {
+    background: var(--bg-paper);
+    border: 1px solid var(--border-dark);
+    padding: var(--space-lg);
+    position: relative;
+    margin-bottom: var(--space-lg);
+}
+
+.intg-card::after {
+    content: "";
+    position: absolute;
+    bottom: -6px;
+    right: -6px;
+    width: 100%;
+    height: 100%;
+    border: 1px solid var(--border-dark);
+    background: var(--bg-aged);
+    z-index: -1;
+}
+
+.intg-card__tag {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent-terracotta);
+    margin-bottom: var(--space-sm);
+}
+
+.intg-card__name {
+    font-family: var(--font-serif);
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin-bottom: var(--space-sm);
+}
+
+.intg-card__desc {
+    font-family: var(--font-mono);
+    font-size: var(--text-body);
+    color: var(--fg-muted);
+    line-height: 1.7;
+    margin-bottom: var(--space-md);
+}
+
+.intg-card__detail {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--fg-light);
+}
+
+/* Editorial note */
+
+.intg-editorial-note {
+    border-left: 2px solid var(--border-dark);
+    padding: var(--space-md) var(--space-lg);
+    margin-top: var(--space-md);
+}
+
+.intg-editorial-note__text {
+    font-family: var(--font-serif);
+    font-size: 1.125rem;
+    font-style: italic;
+    color: var(--fg-muted);
+    line-height: 1.5;
+}


### PR DESCRIPTION
## Overview

New `/integrations` page showcasing all 7 available word set integrations in Origa:

- **JLPT** — Official exam vocabulary (N5–N1)
- **Duolingo** — App vocabulary in EN + RU tracks (190+ sets)
- **Minna no Nihongo** — Textbook vocabulary by lesson
- **Irodori** — Japan Foundation textbook (54 lessons)
- **Migii** — JLPT prep app study sets
- **Spy × Family** — Anime vocabulary
- **Anki Import** — Direct .anki2/.anki21b deck import

## Changes

- New page component `pages/integrations.rs` with hero, card catalog, and CTA
- 32 new Content struct fields for full i18n (EN + RU)
- Navigation link in header and footer
- Routes for `/integrations` and `/ru/integrations`
- CSS styles with `intg-` BEM prefix (112 lines)

## Verification

- ✅ `cargo build -p origa_landing`
- ✅ `cargo clippy -p origa_landing -- -D warnings` — 0 warnings
- ✅ `cargo fmt` — clean
- ✅ GATE 3 code quality review — approve (0 high, 0 common, 2 low)