### PR TITLE
feat(landing): mobile responsive navigation

### DIFF
--- a/origa_landing/src/components/layout.rs
+++ b/origa_landing/src/components/layout.rs
@@ -55,7 +55,14 @@ pub fn Layout(locale: Locale) -> impl IntoView {
                 <span class="landing-header__logo-name">"Origa"</span>
                 <span class="landing-header__logo-kana">"オリガ"</span>
             </a>
-            <nav class="landing-header__nav">
+            <input type="checkbox" id="nav-toggle" class="landing-header__toggle"
+                   aria-label="Toggle navigation" />
+            <label for="nav-toggle" class="landing-header__hamburger"
+                   tabindex="0" aria-label="Open menu">
+                <span class="landing-header__hamburger-line"></span>
+            </label>
+            <nav class="landing-header__nav" id="main-nav"
+                 aria-label="Main navigation">
                 <NavLink prefix href="features" class="landing-header__link">
                     {c.header_features}
                 </NavLink>

--- a/origa_landing/style/input.css
+++ b/origa_landing/style/input.css
@@ -172,3 +172,9 @@ input[type="submit"] {
     padding: 20px 40px;
     font-size: var(--text-label);
 }
+
+@media (max-width: 768px) {
+    .btn {
+        min-height: 44px;
+    }
+}

--- a/origa_landing/style/landing.css
+++ b/origa_landing/style/landing.css
@@ -110,12 +110,139 @@
     color: var(--fg-light);
 }
 
-@media (max-width: 640px) {
+/* === Mobile Navigation Toggle (CSS-only hamburger) === */
+
+.landing-header__toggle {
+    display: none;
+}
+
+.landing-header__hamburger {
+    display: none;
+    cursor: pointer;
+    width: 44px;
+    height: 44px;
+    align-items: center;
+    justify-content: center;
+}
+
+.landing-header__hamburger:focus-visible {
+    outline: 2px solid var(--fg-black);
+    outline-offset: 2px;
+}
+
+/* Hamburger lines: 3 horizontal bars via pseudo-elements, square ends */
+.landing-header__hamburger-line {
+    display: block;
+    width: 20px;
+    height: 2px;
+    background: var(--fg-black);
+    position: relative;
+    transition: background var(--anima-duration-normal) var(--anima-ease-paper);
+}
+
+.landing-header__hamburger-line::before,
+.landing-header__hamburger-line::after {
+    content: "";
+    position: absolute;
+    width: 20px;
+    height: 2px;
+    background: var(--fg-black);
+    left: 0;
+    transition: top var(--anima-duration-normal) var(--anima-ease-paper), transform var(--anima-duration-normal) var(--anima-ease-paper);
+}
+
+.landing-header__hamburger-line::before {
+    top: -7px;
+}
+
+.landing-header__hamburger-line::after {
+    top: 7px;
+}
+
+@media (max-width: 768px) {
     .landing-header {
+        position: relative;
         padding: var(--space-sm) var(--space-md);
     }
+
+    .landing-header__hamburger {
+        display: flex;
+    }
+
     .landing-header__nav {
-        gap: var(--space-md);
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        flex-direction: column;
+        background: var(--bg-paper);
+        border-bottom: 1px solid var(--border-dark);
+        padding: var(--space-md);
+        z-index: 100;
+    }
+
+    .landing-header__toggle:checked ~ .landing-header__nav {
+        display: flex;
+    }
+
+    /* Hamburger → X animation */
+    .landing-header__toggle:checked ~ .landing-header__hamburger .landing-header__hamburger-line {
+        background: transparent;
+    }
+
+    .landing-header__toggle:checked ~ .landing-header__hamburger .landing-header__hamburger-line::before {
+        top: 0;
+        transform: rotate(45deg);
+    }
+
+    .landing-header__toggle:checked ~ .landing-header__hamburger .landing-header__hamburger-line::after {
+        top: 0;
+        transform: rotate(-45deg);
+    }
+
+    /* Nav links: 44px touch targets */
+    .landing-header__nav .landing-header__link {
+        padding: var(--space-sm) 0;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+    }
+
+    .landing-header__nav-sep {
+        display: none;
+    }
+
+    .landing-header__lang {
+        padding-top: var(--space-sm);
+        border-top: 1px solid var(--border-light);
+        margin-top: var(--space-sm);
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+    }
+
+    .landing-header__lang-link {
+        min-height: 44px;
+        display: inline-flex;
+        align-items: center;
+    }
+}
+
+/* Resize reset — !important overrides :checked state from mobile */
+@media (min-width: 769px) {
+    .landing-header__nav {
+        display: flex !important;
+        position: static;
+        flex-direction: row;
+        background: none;
+        border: none;
+        padding: 0;
+        z-index: auto;
+    }
+
+    .landing-header__hamburger {
+        display: none !important;
     }
 }
 
@@ -160,6 +287,16 @@
 
 .landing-footer__link:hover {
     color: var(--fg-black);
+}
+
+/* Footer links: touch targets on mobile */
+@media (max-width: 768px) {
+    .landing-footer__link {
+        padding: 8px 0;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+    }
 }
 
 /* --- Shared: Feature Cards (Home page link) --- */
@@ -264,6 +401,13 @@
     display: flex;
     gap: var(--space-sm);
     flex-wrap: wrap;
+}
+
+/* Home hero CTA: vertical stacking on narrow screens */
+@media (max-width: 400px) {
+    .home-hero__cta {
+        flex-direction: column;
+    }
 }
 
 .home-hero__tagline {
@@ -841,6 +985,16 @@
     margin-right: 0;
 }
 
+/* Features tag bar: wrap on narrow screens */
+@media (max-width: 480px) {
+    .feat-tag-bar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: var(--space-xs);
+    }
+}
+
 /* Kanji Split */
 
 .feat-kanji {
@@ -1024,6 +1178,33 @@
     max-width: 1024px;
     margin: 0 auto;
     overflow-x: auto;
+}
+
+@media (max-width: 768px) {
+    .cmp-scoreboard {
+        position: relative;
+    }
+
+    .cmp-scoreboard::before,
+    .cmp-scoreboard::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 32px;
+        z-index: 1;
+        pointer-events: none;
+    }
+
+    .cmp-scoreboard::before {
+        left: 0;
+        background: linear-gradient(to right, var(--bg-cream), transparent);
+    }
+
+    .cmp-scoreboard::after {
+        right: 0;
+        background: linear-gradient(to left, var(--bg-cream), transparent);
+    }
 }
 
 .cmp-grid {


### PR DESCRIPTION
## Summary

Fix critical mobile layout issue: header toolbar overflows on mobile screens (375px) because 4 nav links + language switcher (EN·RU·KO·VI) don't fit in a single row.

## Changes

### Header Hamburger Menu (Critical)
- CSS-only hamburger menu via checkbox hack (no JS required)
- `<input type="checkbox">` + `<label>` hamburger between logo and nav in `layout.rs`
- 768px breakpoint: hamburger visible, nav hidden in dropdown
- Hamburger → X animation with 200ms transition
- ARIA accessibility: aria-label, tabindex, :focus-visible
- Resize reset: `@media (min-width: 769px)` with `!important` overrides `:checked` state

### Compare Table Fade Hint
- Gradient fade on `.cmp-scoreboard` edges on ≤768px
- Visual hint that table scrolls horizontally

### Touch Targets & Spacing
- `.btn` min-height: 44px on mobile (WCAG 2.5.5)
- Footer links: 44px touch targets
- Nav links in dropdown: 44px touch targets
- Home hero CTA: vertical stacking on ≤400px
- Features tag bar: flex-wrap on ≤480px

## Files Changed
- `origa_landing/src/components/layout.rs` — +7 lines (checkbox + label hamburger)
- `origa_landing/style/landing.css` — +134 lines (hamburger CSS, fade, touch targets)
- `origa_landing/style/input.css` — +6 lines (.btn min-height)

## Verification
- ✅ `cargo build -p origa_landing`
- ✅ `cargo clippy -p origa_landing -- -D warnings` — 0 warnings
- ✅ `cargo fmt` — passed
- ✅ GATE 3 code quality review — approve (0 HIGH, 0 COMMON)
