### PR TITLE
feat: offline bundle download and auto card pre-cache

### DIFF
--- a/origa/src/dictionary/kanji.rs
+++ b/origa/src/dictionary/kanji.rs
@@ -73,6 +73,13 @@ pub fn get_kanji_list(level: &JapaneseLevel) -> Vec<&'static KanjiInfo> {
         .unwrap_or_default()
 }
 
+pub fn get_all_kanji() -> Vec<char> {
+    KANJI_DICTIONARY
+        .get()
+        .map(|db| db.all_kanji())
+        .unwrap_or_default()
+}
+
 #[derive(Clone)]
 pub struct KanjiDatabase {
     kanji_map: HashMap<String, KanjiInfo>,
@@ -245,6 +252,10 @@ impl KanjiDatabase {
             .values()
             .filter(|x| x.jlpt() == level)
             .collect()
+    }
+
+    pub fn all_kanji(&self) -> Vec<char> {
+        self.kanji_map.values().map(|info| info.kanji).collect()
     }
 }
 

--- a/origa_ui/locales/en.json
+++ b/origa_ui/locales/en.json
@@ -59,7 +59,19 @@
         "password_changed": "Password changed successfully",
         "password_mismatch": "Passwords do not match",
         "password_too_short": "Password must be at least 8 characters",
-        "password_change_error": "Failed to change password"
+        "password_change_error": "Failed to change password",
+        "offline_bundle": "Offline Bundle",
+        "offline_bundle_desc": "Download all resources for offline use",
+        "download_bundle": "Download Bundle",
+        "downloading_bundle": "Downloading...",
+        "cancel_download": "Cancel",
+        "bundle_downloaded": "Bundle downloaded",
+        "bundle_download_failed": "Download failed",
+        "files_progress": "{completed} / {total} files",
+        "retry_download": "Retry",
+        "checking_cache": "Checking cache...",
+        "card_cache_running": "Caching card resources...",
+        "card_cache_complete": "Card resources cached"
     },
     "onboarding": {
         "steps": {

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -59,7 +59,19 @@
     "password_changed": "Пароль успешно изменён",
     "password_mismatch": "Пароли не совпадают",
     "password_too_short": "Пароль должен быть не менее 8 символов",
-    "password_change_error": "Не удалось сменить пароль"
+    "password_change_error": "Не удалось сменить пароль",
+    "offline_bundle": "Оффлайн-пакет",
+    "offline_bundle_desc": "Скачать все ресурсы для работы без интернета",
+    "download_bundle": "Скачать пакет",
+    "downloading_bundle": "Скачивание...",
+    "cancel_download": "Отмена",
+    "bundle_downloaded": "Пакет скачан",
+    "bundle_download_failed": "Ошибка скачивания",
+    "files_progress": "{completed} / {total} файлов",
+    "retry_download": "Повторить",
+    "checking_cache": "Проверка кэша...",
+    "card_cache_running": "Кэширование карточек...",
+    "card_cache_complete": "Ресурсы карточек закэшированы"
   },
   "onboarding": {
     "steps": {

--- a/origa_ui/src/app.rs
+++ b/origa_ui/src/app.rs
@@ -8,6 +8,7 @@ use crate::pages::login::oauth_listeners::{check_url_oauth_callback, setup_oauth
 use crate::routes::AppRoutes;
 use crate::store::auth_store::AuthStore;
 use crate::store::connectivity::ConnectivityStore;
+use crate::store::offline_bundle_store::OfflineBundleStore;
 use crate::ui_components::{
     ConnectivityBanner, LoadingOverlay, ToastContainer, ToastData, UpdateDrawer,
 };
@@ -16,12 +17,14 @@ use crate::ui_components::{
 pub fn App() -> impl IntoView {
     let auth_store = AuthStore::new();
     let connectivity = ConnectivityStore::new();
+    let offline_bundle_store = OfflineBundleStore::new();
     let toasts: RwSignal<Vec<ToastData>> = RwSignal::new(Vec::new());
     let disposed = StoredValue::new(());
 
     provide_context(auth_store.repository().clone());
     provide_context(auth_store.clone());
     provide_context(connectivity);
+    provide_context(offline_bundle_store);
 
     let i18n = use_i18n();
 

--- a/origa_ui/src/loaders/card_precache_loader.rs
+++ b/origa_ui/src/loaders/card_precache_loader.rs
@@ -1,0 +1,158 @@
+use origa::dictionary::pitch_audio::get_audio_for_reading;
+use origa::domain::{Card, JapaneseChar, OrigaError, StudyCard};
+
+use leptos::prelude::Set;
+
+use crate::loaders::precache_loader::{DownloadResult, PreCacheProgress, batch_download};
+use crate::ui_components::get_reading_from_text;
+
+fn kata_to_hira(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            if ('\u{30A1}'..='\u{30F6}').contains(&c) {
+                char::from_u32(c as u32 - 0x60).unwrap_or(c)
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+fn kanji_svg_resources(kanji_text: &str) -> Vec<String> {
+    kanji_text
+        .chars()
+        .filter(|c| c.is_kanji())
+        .flat_map(|c| {
+            let kanji_str = c.to_string();
+            let encoded = urlencoding::encode(&kanji_str);
+            [
+                format!("kanji_animations/{encoded}.svg"),
+                format!("kanji_frames/{encoded}.svg"),
+            ]
+        })
+        .collect()
+}
+
+fn vocabulary_resources(word: &str) -> Vec<String> {
+    let mut resources = Vec::new();
+
+    let reading = get_reading_from_text(word);
+    let reading_hira = kata_to_hira(&reading);
+    if let Some(entry) = get_audio_for_reading(word, &reading_hira) {
+        resources.push(entry.cdn_path());
+    }
+
+    resources.extend(kanji_svg_resources(word));
+
+    resources
+}
+
+fn phrase_resources(phrase_id: &ulid::Ulid) -> Vec<String> {
+    vec![format!("phrases/audio/{phrase_id}.opus")]
+}
+
+fn get_card_cdn_resources(card: &StudyCard) -> Vec<String> {
+    match card.card() {
+        Card::Vocabulary(v) => vocabulary_resources(v.word().text()),
+        Card::Phrase(p) => phrase_resources(p.phrase_id()),
+        Card::Kanji(k) => kanji_svg_resources(k.kanji().text()),
+        Card::Grammar(_) => vec![],
+    }
+}
+
+pub fn start_card_precache(
+    cards: Vec<StudyCard>,
+    offline_store: crate::store::offline_bundle_store::OfflineBundleStore,
+) {
+    use crate::store::offline_bundle_store::CardCacheState;
+
+    offline_store.card_cache_state.set(CardCacheState::Running);
+    let store_clone = offline_store.clone();
+
+    leptos::task::spawn_local(async move {
+        match precache_all_cards(&cards, move |p| store_clone.card_cache_progress.set(p)).await {
+            Ok(result) => {
+                tracing::info!(
+                    succeeded = result.succeeded,
+                    total = result.total,
+                    "Card pre-cache complete"
+                );
+                store_clone.card_cache_state.set(CardCacheState::Complete);
+            },
+            Err(e) => {
+                tracing::warn!("Card pre-cache failed: {e}");
+                store_clone.card_cache_state.set(CardCacheState::Idle);
+            },
+        }
+    });
+}
+
+pub async fn precache_all_cards(
+    cards: &[StudyCard],
+    on_progress: impl Fn(PreCacheProgress) + Clone + 'static,
+) -> Result<DownloadResult, OrigaError> {
+    let all_paths: Vec<String> = cards.iter().flat_map(get_card_cdn_resources).collect();
+
+    let mut unique_paths = all_paths;
+    unique_paths.sort();
+    unique_paths.dedup();
+
+    tracing::info!(
+        card_count = cards.len(),
+        resource_count = unique_paths.len(),
+        "Pre-caching card resources"
+    );
+
+    batch_download(unique_paths, on_progress).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kata_to_hira_converts_standard_katakana() {
+        assert_eq!(kata_to_hira("ヤク"), "やく");
+        assert_eq!(kata_to_hira("ア"), "あ");
+        assert_eq!(kata_to_hira("ン"), "ん");
+    }
+
+    #[test]
+    fn kata_to_hira_preserves_hiragana() {
+        assert_eq!(kata_to_hira("やく"), "やく");
+    }
+
+    #[test]
+    fn kata_to_hira_preserves_other() {
+        assert_eq!(kata_to_hira("hello"), "hello");
+        assert_eq!(kata_to_hira("123"), "123");
+    }
+
+    #[test]
+    fn kata_to_hira_empty() {
+        assert_eq!(kata_to_hira(""), "");
+    }
+
+    #[test]
+    fn kanji_svg_resources_extracts_kanji_chars() {
+        let resources = kanji_svg_resources("日本語");
+        assert!(resources.contains(&"kanji_animations/%E6%97%A5.svg".to_string()));
+        assert!(resources.contains(&"kanji_frames/%E6%97%A5.svg".to_string()));
+        assert!(resources.contains(&"kanji_animations/%E6%9C%AC.svg".to_string()));
+        assert!(resources.contains(&"kanji_frames/%E6%9C%AC.svg".to_string()));
+        assert!(resources.contains(&"kanji_animations/%E8%AA%9E.svg".to_string()));
+        assert!(resources.contains(&"kanji_frames/%E8%AA%9E.svg".to_string()));
+    }
+
+    #[test]
+    fn kanji_svg_resources_skips_hiragana() {
+        let resources = kanji_svg_resources("ねこ");
+        assert!(resources.is_empty());
+    }
+
+    #[test]
+    fn kanji_svg_resources_skips_katakana() {
+        let resources = kanji_svg_resources("ネコ");
+        assert!(resources.is_empty());
+    }
+}

--- a/origa_ui/src/loaders/mod.rs
+++ b/origa_ui/src/loaders/mod.rs
@@ -1,3 +1,4 @@
+pub mod card_precache_loader;
 pub mod data_loader;
 pub mod dictionary;
 pub mod furigana_dict_loader;
@@ -7,6 +8,7 @@ pub mod ocr_model_loader;
 pub mod phrase_data_loader;
 pub mod phrase_loader;
 pub mod pitch_audio_loader;
+pub mod precache_loader;
 pub mod well_known_set_loader;
 #[cfg(target_arch = "wasm32")]
 pub mod whisper_model_loader;

--- a/origa_ui/src/loaders/precache_loader.rs
+++ b/origa_ui/src/loaders/precache_loader.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use futures::stream::{self, StreamExt};
+use origa::dictionary::kanji::get_all_kanji;
+use origa::dictionary::phrase::index_version;
+use origa::domain::OrigaError;
+
+use crate::repository::cdn_provider;
+
+const BUNDLE_DOWNLOADED_KEY: &str = "/__origa_bundle_downloaded__";
+const CONCURRENCY: usize = 20;
+
+#[derive(Clone, Default)]
+pub struct PreCacheProgress {
+    pub completed: usize,
+    pub total: usize,
+    pub current_file: String,
+}
+
+#[derive(Clone, Default)]
+pub struct DownloadResult {
+    pub total: usize,
+    pub succeeded: usize,
+}
+
+pub fn get_base_bundle_resources() -> Vec<String> {
+    let mut resources: Vec<String> = Vec::new();
+
+    resources.extend([
+        "dictionaries/char_def.bin".to_string(),
+        "dictionaries/matrix.mtx".to_string(),
+        "dictionaries/dict.da".to_string(),
+        "dictionaries/dict.vals".to_string(),
+        "dictionaries/unk.bin".to_string(),
+        "dictionaries/dict.wordsidx".to_string(),
+        "dictionaries/dict.words".to_string(),
+        "dictionaries/metadata.json".to_string(),
+        "dictionaries/JmdictFurigana.txt".to_string(),
+    ]);
+
+    for i in 1..=11 {
+        resources.push(format!("dictionary/chunk_{:02}.json", i));
+    }
+
+    resources.extend([
+        "dictionary/kanji.json".to_string(),
+        "dictionary/radicals.json".to_string(),
+    ]);
+
+    resources.push("grammar/grammar.json".to_string());
+    resources.push("phrases/phrase_index.json".to_string());
+
+    let (_, hash) = index_version();
+    for i in 0..=197 {
+        resources.push(format!("phrases/data/p{:04}.json?v={}", i, hash));
+    }
+
+    resources.push("pitch/index.json".to_string());
+
+    resources.extend([
+        "well_known_set/well_known_sets_meta.json".to_string(),
+        "well_known_set/well_known_types_meta.json".to_string(),
+        "well_known_set/jlpt_n1.json".to_string(),
+        "well_known_set/jlpt_n2.json".to_string(),
+        "well_known_set/jlpt_n3.json".to_string(),
+        "well_known_set/jlpt_n4.json".to_string(),
+        "well_known_set/jlpt_n5.json".to_string(),
+    ]);
+
+    for kanji in get_all_kanji() {
+        let kanji_str = kanji.to_string();
+        let encoded = urlencoding::encode(&kanji_str);
+        resources.push(format!("kanji_animations/{}.svg", encoded));
+        resources.push(format!("kanji_frames/{}.svg", encoded));
+    }
+
+    resources
+}
+
+pub async fn batch_download(
+    paths: Vec<String>,
+    on_progress: impl Fn(PreCacheProgress) + Clone + 'static,
+) -> Result<DownloadResult, OrigaError> {
+    let total = paths.len();
+    let completed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let succeeded = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    stream::iter(paths)
+        .map(|path| {
+            let completed = completed.clone();
+            let succeeded = succeeded.clone();
+            let on_progress = on_progress.clone();
+            async move {
+                match cdn_provider::prefetch_to_cache(&path).await {
+                    Ok(()) => {
+                        succeeded.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    },
+                    Err(e) => {
+                        tracing::warn!(path = %path, error = ?e, "Failed to prefetch");
+                    },
+                }
+                let done = completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                on_progress(PreCacheProgress {
+                    completed: done,
+                    total,
+                    current_file: path,
+                });
+            }
+        })
+        .buffer_unordered(CONCURRENCY)
+        .collect::<Vec<()>>()
+        .await;
+
+    Ok(DownloadResult {
+        total,
+        succeeded: succeeded.load(std::sync::atomic::Ordering::Relaxed),
+    })
+}
+
+async fn mark_bundle_downloaded() -> Result<(), OrigaError> {
+    cdn_provider::store_cache_marker(BUNDLE_DOWNLOADED_KEY, "ok").await
+}
+
+pub async fn is_bundle_downloaded() -> bool {
+    cdn_provider::is_cached(BUNDLE_DOWNLOADED_KEY).await
+}
+
+pub async fn precache_base_bundle(
+    on_progress: impl Fn(PreCacheProgress) + Clone + 'static,
+) -> Result<DownloadResult, OrigaError> {
+    let resources = get_base_bundle_resources();
+    tracing::info!("Starting base bundle download: {} files", resources.len());
+    let result = batch_download(resources, on_progress).await?;
+
+    let success_rate = if result.total > 0 {
+        result.succeeded as f64 / result.total as f64
+    } else {
+        0.0
+    };
+
+    if success_rate >= 0.95 {
+        mark_bundle_downloaded().await?;
+        tracing::info!(
+            "Bundle downloaded: {}/{} succeeded",
+            result.succeeded,
+            result.total
+        );
+    } else {
+        tracing::warn!(
+            "Bundle download incomplete: {}/{} succeeded",
+            result.succeeded,
+            result.total
+        );
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_bundle_includes_dictionaries() {
+        let resources = get_base_bundle_resources();
+
+        assert!(resources.contains(&"dictionaries/char_def.bin".to_string()));
+        assert!(resources.contains(&"dictionaries/matrix.mtx".to_string()));
+        assert!(resources.contains(&"dictionaries/JmdictFurigana.txt".to_string()));
+        assert!(resources.contains(&"dictionary/kanji.json".to_string()));
+        assert!(resources.contains(&"dictionary/radicals.json".to_string()));
+        assert!(resources.contains(&"grammar/grammar.json".to_string()));
+        assert!(resources.contains(&"phrases/phrase_index.json".to_string()));
+        assert!(resources.contains(&"pitch/index.json".to_string()));
+        assert!(resources.contains(&"well_known_set/jlpt_n5.json".to_string()));
+    }
+
+    #[test]
+    fn base_bundle_includes_vocabulary_chunks() {
+        let resources = get_base_bundle_resources();
+        for i in 1..=11 {
+            assert!(resources.contains(&format!("dictionary/chunk_{:02}.json", i)));
+        }
+    }
+
+    #[test]
+    fn base_bundle_includes_well_known_sets() {
+        let resources = get_base_bundle_resources();
+        assert!(resources.contains(&"well_known_set/well_known_sets_meta.json".to_string()));
+        assert!(resources.contains(&"well_known_set/well_known_types_meta.json".to_string()));
+        for level in ["n1", "n2", "n3", "n4", "n5"] {
+            assert!(resources.contains(&format!("well_known_set/jlpt_{}.json", level)));
+        }
+    }
+}

--- a/origa_ui/src/pages/profile/content.rs
+++ b/origa_ui/src/pages/profile/content.rs
@@ -1,6 +1,7 @@
 use super::{ActionButtons, PasswordCard, PersonalDataCard, SettingsCard};
 use crate::i18n::{native_language_to_locale, use_i18n};
 use crate::store::AuthStore;
+use crate::ui_components::OfflineBundleCard;
 use leptos::prelude::*;
 use leptos::task::spawn_local;
 use leptos_router::hooks::use_navigate;
@@ -131,6 +132,8 @@ pub fn ProfileContent() -> impl IntoView {
                 <PasswordCard test_id="profile-password" />
                 <div class="divider"></div>
                 <SettingsCard test_id="profile-settings" />
+                <div class="divider"></div>
+                <OfflineBundleCard test_id="profile-offline-bundle" />
                 <div class="divider"></div>
                 <ActionButtons
                     on_save={save_profile}

--- a/origa_ui/src/repository/cdn_provider.rs
+++ b/origa_ui/src/repository/cdn_provider.rs
@@ -49,6 +49,25 @@ async fn open_cache() -> Result<web_sys::Cache, OrigaError> {
     })
 }
 
+/// Store a simple marker value in the CDN cache.
+pub async fn store_cache_marker(key: &str, value: &str) -> Result<(), OrigaError> {
+    let cache = open_cache().await?;
+    let response = web_sys::Response::new_with_opt_str(Some(value)).map_err(|e| {
+        OrigaError::RepositoryError {
+            reason: format!("Failed to create marker response: {:?}", e),
+        }
+    })?;
+    let request = web_sys::Request::new_with_str(key).map_err(|e| OrigaError::RepositoryError {
+        reason: format!("Failed to create marker request: {:?}", e),
+    })?;
+    JsFuture::from(cache.put_with_request(&request, &response))
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to store marker: {:?}", e),
+        })?;
+    Ok(())
+}
+
 fn ensure_leading_slash(path: &str) -> String {
     if path.starts_with('/') {
         path.to_string()
@@ -314,4 +333,70 @@ pub fn resolve_audio_url(path: &str) -> String {
     });
 
     cdn_url(&key)
+}
+
+pub async fn prefetch_to_cache(path: &str) -> Result<(), OrigaError> {
+    let cache = open_cache().await?;
+    let key = ensure_leading_slash(path);
+
+    let existing = JsFuture::from(cache.match_with_str(&key))
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Cache match failed: {:?}", e),
+        })?;
+    if !existing.is_null() && !existing.is_undefined() {
+        return Ok(());
+    }
+
+    let url = cdn_url(&key);
+    let window = web_sys::window().ok_or_else(|| OrigaError::NetworkError {
+        url: url.clone(),
+        reason: "No window found".to_string(),
+    })?;
+
+    let resp_value = JsFuture::from(window.fetch_with_str(&url))
+        .await
+        .map_err(|e| OrigaError::NetworkError {
+            url: url.clone(),
+            reason: format!("Failed to fetch: {:?}", e),
+        })?;
+
+    let response: web_sys::Response =
+        resp_value
+            .dyn_into()
+            .map_err(|e| OrigaError::NetworkError {
+                url: url.clone(),
+                reason: format!("Failed to cast response: {:?}", e),
+            })?;
+
+    if !response.ok() {
+        return Err(OrigaError::NetworkError {
+            url,
+            reason: format!("HTTP {}", response.status()),
+        });
+    }
+
+    let request =
+        web_sys::Request::new_with_str(&key).map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to create request: {:?}", e),
+        })?;
+
+    JsFuture::from(cache.put_with_request(&request, &response))
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to cache: {:?}", e),
+        })?;
+
+    Ok(())
+}
+
+pub async fn is_cached(path: &str) -> bool {
+    let Ok(cache) = open_cache().await else {
+        return false;
+    };
+    let key = ensure_leading_slash(path);
+    let Ok(result) = JsFuture::from(cache.match_with_str(&key)).await else {
+        return false;
+    };
+    !result.is_null() && !result.is_undefined()
 }

--- a/origa_ui/src/routes.rs
+++ b/origa_ui/src/routes.rs
@@ -11,6 +11,8 @@ use crate::pages::{
     Sets, Words,
 };
 use crate::store::auth_store::AuthStore;
+use crate::store::connectivity::ConnectivityStore;
+use crate::store::offline_bundle_store::OfflineBundleStore;
 use crate::ui_components::{BottomTabBar, LoadingOverlay, Sidebar};
 use futures::Future;
 use leptos::prelude::*;
@@ -44,7 +46,12 @@ where
     Err(last_err.expect("at least one attempt was made"))
 }
 
-pub fn start_dictionary_loading(auth_store: AuthStore, repository: HybridUserRepository) {
+pub fn start_dictionary_loading(
+    auth_store: AuthStore,
+    repository: HybridUserRepository,
+    connectivity: ConnectivityStore,
+    offline_store: OfflineBundleStore,
+) {
     spawn_local(async move {
         // Phase A: manifest check
         if let Err(e) = crate::repository::cache_manager::check_and_invalidate().await {
@@ -128,6 +135,22 @@ pub fn start_dictionary_loading(auth_store: AuthStore, repository: HybridUserRep
             tracing::warn!("Failed to migrate kanji companions: {e}");
         }
 
+        // Phase E: auto per-card pre-cache (background, only when online)
+        if connectivity.is_online.get() {
+            if let Some(user) = auth_store.user.get() {
+                let cards: Vec<origa::domain::StudyCard> = user
+                    .knowledge_set()
+                    .study_cards()
+                    .values()
+                    .cloned()
+                    .collect();
+
+                if !cards.is_empty() {
+                    crate::loaders::card_precache_loader::start_card_precache(cards, offline_store);
+                }
+            }
+        }
+
         // Signal completion only after all migrations finish
         auth_store.is_jlpt_content_loaded.set(true);
     });
@@ -153,6 +176,8 @@ pub fn ProtectedRoute(children: ChildrenFn) -> impl IntoView {
                 start_dictionary_loading(
                     auth_store.clone(),
                     use_context::<HybridUserRepository>().expect("repository context not provided"),
+                    use_context::<ConnectivityStore>().expect("ConnectivityStore not provided"),
+                    use_context::<OfflineBundleStore>().expect("OfflineBundleStore not provided"),
                 );
             }
         }

--- a/origa_ui/src/store/mod.rs
+++ b/origa_ui/src/store/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth_store;
 pub mod connectivity;
+pub mod offline_bundle_store;
 
 pub use auth_store::AuthStore;
 pub use connectivity::ConnectivityStore;

--- a/origa_ui/src/store/offline_bundle_store.rs
+++ b/origa_ui/src/store/offline_bundle_store.rs
@@ -1,0 +1,33 @@
+use leptos::prelude::*;
+
+use crate::loaders::precache_loader::PreCacheProgress;
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum CardCacheState {
+    Idle,
+    Running,
+    Complete,
+}
+
+/// Manages card cache state. Bundle download state is managed locally
+/// in OfflineBundleCard since it's only needed in the profile page.
+#[derive(Clone)]
+pub struct OfflineBundleStore {
+    pub card_cache_state: RwSignal<CardCacheState>,
+    pub card_cache_progress: RwSignal<PreCacheProgress>,
+}
+
+impl OfflineBundleStore {
+    pub fn new() -> Self {
+        Self {
+            card_cache_state: RwSignal::new(CardCacheState::Idle),
+            card_cache_progress: RwSignal::new(PreCacheProgress::default()),
+        }
+    }
+}
+
+impl Default for OfflineBundleStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/origa_ui/src/ui_components/mod.rs
+++ b/origa_ui/src/ui_components/mod.rs
@@ -34,6 +34,7 @@ mod modal;
 mod multi_line_chart;
 mod nav_config;
 mod ocr_loading_stage;
+mod offline_bundle_card;
 mod page_header;
 mod progress;
 mod reading_group;
@@ -95,6 +96,7 @@ pub use nav_config::NavRoute;
 pub use ocr_loading_stage::{
     LoadingStageItem, OcrLoadingStage, OcrLoadingState, ProgressInfo, StageType, get_stage_info,
 };
+pub use offline_bundle_card::OfflineBundleCard;
 pub use page_header::PageHeader;
 pub use progress::ProgressBar;
 pub use reading_group::ReadingGroup;

--- a/origa_ui/src/ui_components/offline_bundle_card.rs
+++ b/origa_ui/src/ui_components/offline_bundle_card.rs
@@ -1,0 +1,207 @@
+use futures::future::{AbortHandle, abortable};
+use leptos::prelude::*;
+use leptos::task::spawn_local;
+
+use crate::i18n::*;
+use crate::loaders::precache_loader::{self, PreCacheProgress};
+use crate::store::offline_bundle_store::{CardCacheState, OfflineBundleStore};
+use crate::ui_components::{Divider, ProgressBar, Text, TextSize, TypographyVariant};
+
+#[derive(Clone, Copy, PartialEq)]
+enum BundleState {
+    Idle,
+    CheckingCache,
+    Downloading,
+    Downloaded,
+    Error,
+}
+
+#[component]
+pub fn OfflineBundleCard(#[prop(optional, into)] test_id: Signal<String>) -> impl IntoView {
+    let i18n = use_i18n();
+    let state = RwSignal::new(BundleState::CheckingCache);
+    let progress = RwSignal::new(PreCacheProgress::default());
+    let abort_handle = RwSignal::new(None::<AbortHandle>);
+    let progress_percent = RwSignal::new(0u32);
+
+    let card_cache_state: Option<RwSignal<CardCacheState>> =
+        use_context::<OfflineBundleStore>().map(|s| s.card_cache_state);
+    let card_cache_progress: Option<RwSignal<PreCacheProgress>> =
+        use_context::<OfflineBundleStore>().map(|s| s.card_cache_progress);
+
+    Effect::new(move |_| {
+        spawn_local(async move {
+            if precache_loader::is_bundle_downloaded().await {
+                state.set(BundleState::Downloaded);
+            } else {
+                state.set(BundleState::Idle);
+            }
+        });
+    });
+
+    Effect::new(move |_| {
+        let p = progress.get();
+        if p.total > 0 {
+            let pct = (p.completed as f64 / p.total as f64 * 100.0).min(100.0) as u32;
+            progress_percent.set(pct);
+        }
+    });
+
+    let test_id_val = move || {
+        let val = test_id.get();
+        if val.is_empty() { None } else { Some(val) }
+    };
+
+    let is_downloading = Signal::derive(move || state.get() == BundleState::Downloading);
+    let is_downloaded = Signal::derive(move || state.get() == BundleState::Downloaded);
+    let is_error = Signal::derive(move || state.get() == BundleState::Error);
+
+    let has_card_cache = card_cache_state.is_some();
+    let card_state_signal = card_cache_state;
+    let card_progress_signal = card_cache_progress;
+
+    let on_download_click = move |_ev: leptos::ev::MouseEvent| {
+        let state = state;
+        let progress = progress;
+        let abort_handle = abort_handle;
+
+        let (future, handle) = abortable(async move {
+            precache_loader::precache_base_bundle(move |p| progress.set(p)).await
+        });
+        abort_handle.set(Some(handle));
+        state.set(BundleState::Downloading);
+
+        spawn_local(async move {
+            match future.await {
+                Ok(Ok(_result)) => {
+                    state.set(BundleState::Downloaded);
+                },
+                Ok(Err(e)) => {
+                    tracing::error!(error = ?e, "Bundle download failed");
+                    state.set(BundleState::Error);
+                },
+                Err(_) => {
+                    state.set(BundleState::Idle);
+                },
+            }
+        });
+    };
+
+    let on_cancel_click = move |_ev: leptos::ev::MouseEvent| {
+        if let Some(handle) = abort_handle.get() {
+            handle.abort();
+        }
+    };
+
+    view! {
+        <div data-testid=test_id_val class="p-6 space-y-4">
+            <div class="space-y-2">
+                <Text size=TextSize::Large>
+                    {t!(i18n, profile.offline_bundle)}
+                </Text>
+                <Text size=TextSize::Small variant=TypographyVariant::Muted>
+                    {t!(i18n, profile.offline_bundle_desc)}
+                </Text>
+            </div>
+
+            <Show when=move || is_downloading.get()>
+                <div class="space-y-3">
+                    <ProgressBar
+                        value=progress_percent
+                        max=100
+                        label=Signal::derive(move || {
+                            let p = progress.get();
+                            crate::i18n::td_string!(i18n.get_locale(), profile.files_progress)
+                                .replace("{completed}", &p.completed.to_string())
+                                .replace("{total}", &p.total.to_string())
+                        })
+                        test_id="bundle-progress"
+                    />
+                    <p class="text-xs text-[var(--fg-muted)] font-mono truncate">
+                        {move || progress.get().current_file}
+                    </p>
+                </div>
+            </Show>
+
+            <Show when=move || is_downloaded.get()>
+                <div class="flex items-center gap-2 text-sm text-[var(--fg-muted)]">
+                    <span class="font-mono">"\u{2713}"</span>
+                    <span class="font-mono">{t!(i18n, profile.bundle_downloaded)}</span>
+                </div>
+            </Show>
+
+            <div class="flex gap-3">
+                <Show when=move || {
+                    matches!(state.get(), BundleState::Idle | BundleState::Error)
+                }>
+                    <button
+                        class="btn btn-filled anima-press anima-focus-ring"
+                        on:click=on_download_click
+                        data-testid="download-bundle-btn"
+                    >
+                        <span class="btn-text">
+                            {move || if is_error.get() {
+                                t!(i18n, profile.retry_download).into_any()
+                            } else {
+                                t!(i18n, profile.download_bundle).into_any()
+                            }}
+                        </span>
+                    </button>
+                </Show>
+
+                <Show when=move || is_downloading.get()>
+                    <button
+                        class="btn anima-press anima-focus-ring"
+                        on:click=on_cancel_click
+                        data-testid="cancel-bundle-btn"
+                    >
+                        <span class="btn-text">
+                            {t!(i18n, profile.cancel_download)}
+                        </span>
+                    </button>
+                </Show>
+            </div>
+
+            // Card cache status section
+            <Show when=move || has_card_cache>
+                <Divider />
+                <div class="space-y-1">
+                    {move || {
+                        let signal = card_state_signal?;
+                        let progress_signal = card_progress_signal?;
+                        let cache_state = signal.get();
+
+                        match cache_state {
+                            CardCacheState::Running => {
+                                let p = progress_signal.get();
+                                let detail = if p.total > 0 {
+                                    crate::i18n::td_string!(i18n.get_locale(), profile.files_progress)
+                                        .replace("{completed}", &p.completed.to_string())
+                                        .replace("{total}", &p.total.to_string())
+                                } else {
+                                    String::new()
+                                };
+                                Some(view! {
+                                    <div class="flex items-center gap-2 text-sm text-[var(--fg-muted)]">
+                                        <span class="font-mono animate-pulse">"..."</span>
+                                        <span class="font-mono">{t!(i18n, profile.card_cache_running)}</span>
+                                        <span class="font-mono text-xs">{detail}</span>
+                                    </div>
+                                }.into_any())
+                            },
+                            CardCacheState::Complete => {
+                                Some(view! {
+                                    <div class="flex items-center gap-2 text-sm text-[var(--fg-muted)]">
+                                        <span class="font-mono">"\u{2713}"</span>
+                                        <span class="font-mono">{t!(i18n, profile.card_cache_complete)}</span>
+                                    </div>
+                                }.into_any())
+                            },
+                            CardCacheState::Idle => None,
+                        }
+                    }}
+                </div>
+            </Show>
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary

Add offline bundle download mechanism for full offline usage of Origa.

### What
- **Base Bundle (~250MB)**: Download all static CDN resources (dictionaries, grammar, kanji SVG, phrases, pitch index) via one button in profile
- **Auto Per-Card Pre-Cache**: Background download of pitch audio, phrase audio, and kanji SVG for each user's flashcard on app startup
- **Cache API Prefetch**: New `prefetch_to_cache(path)` method that populates Cache API without reading response body into WASM memory

### Files Changed
- `origa/src/dictionary/kanji.rs` — add `all_kanji()` method
- `origa_ui/src/repository/cdn_provider.rs` — add `prefetch_to_cache`, `is_cached`, `store_cache_marker`
- `origa_ui/src/loaders/precache_loader.rs` (NEW) — batch download utility + base bundle resource list
- `origa_ui/src/loaders/card_precache_loader.rs` (NEW) — per-card CDN resource resolver + auto pre-cache
- `origa_ui/src/store/offline_bundle_store.rs` (NEW) — store for card cache state
- `origa_ui/src/ui_components/offline_bundle_card.rs` (NEW) — UI component in profile
- `origa_ui/src/routes.rs` — Phase E: auto per-card pre-cache after dictionary loading
- `origa_ui/src/app.rs` — provide_context(OfflineBundleStore)
- i18n (en.json, ru.json) — new keys

### Architecture
- `prefetch_to_cache()` does `window.fetch() -> cache.put()` WITHOUT reading body into WASM memory
- `batch_download()` uses `futures::stream::buffer_unordered(20)` for concurrent downloads
- Pitch audio resolution uses same tokenizer chain as runtime playback
- 95% success threshold for bundle download completion
- Abortable download with Cancel button

### Testing
- 10 new unit tests (7 card_precache_loader + 3 precache_loader)
- All existing tests pass (1267 origa + 121 origa_ui)
- Clippy clean, fmt clean