### PR TITLE
fix(precache): remove kanji SVG prefetch from base bundle

### DIFF
--- a/origa_ui/src/loaders/precache_loader.rs
+++ b/origa_ui/src/loaders/precache_loader.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use futures::stream::{self, StreamExt};
-use origa::dictionary::kanji::get_all_kanji;
 use origa::dictionary::phrase::index_version;
 use origa::domain::OrigaError;
 
@@ -67,12 +66,10 @@ pub fn get_base_bundle_resources() -> Vec<String> {
         "well_known_set/jlpt_n5.json".to_string(),
     ]);
 
-    for kanji in get_all_kanji() {
-        let kanji_str = kanji.to_string();
-        let encoded = urlencoding::encode(&kanji_str);
-        resources.push(format!("kanji_animations/{}.svg", encoded));
-        resources.push(format!("kanji_frames/{}.svg", encoded));
-    }
+    // Kanji SVGs are pre-cached on demand via card_precache_loader
+    // for only the kanji the user actually studies.
+    // Pre-fetching all ~6000+ kanji from the dictionary generates
+    // many 404s for rare kanji that have no SVG files on the CDN.
 
     resources
 }


### PR DESCRIPTION
## Problem

Browser console showed dozens of 404 errors for kanji SVG files on the CDN:

```
GET https://s3.origa.uwuwu.net/kanji_frames/%E9%BA%9F.svg 404 (Not Found)
GET https://s3.origa.uwuwu.net/kanji_frames/%E9%A9%95.svg 404 (Not Found)
```

These came from `precache_loader::get_base_bundle_resources()` which iterated over **all ~6000+ kanji** from the dictionary and pre-fetched both `kanji_animations/*.svg` and `kanji_frames/*.svg` for each one. Roughly 146 of these kanji have no SVG files on the CDN, producing noisy 404 warnings.

## Fix

Removed the kanji SVG pre-fetch loop from `get_base_bundle_resources()`. These files are already cached on-demand by `card_precache_loader` which only fetches SVGs for kanji the user actually studies (`Card::Kanji` and `Card::Vocabulary`).

### Why this is safe

- **Card precache covers all needed kanji**: `vocabulary_resources()` extracts kanji from words, `Card::Kanji` handles standalone kanji cards
- **UI has fallback**: `KanjiAnimation` component shows fallback text when SVG is unavailable — no crashes
- **Reduces base bundle from ~12000+ HTTP requests to just essential resources** (dictionaries, grammar, phrases, pitch, well-known sets)