### PR TITLE
fix(ui): translations display, phrase splitting, audio unification, badge overlap

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -3362,10 +3362,6 @@ input[type="submit"],
     opacity: 0.3;
 }
 
-.audio-btn-spin {
-    animation: spin 1.5s linear infinite;
-}
-
 .card-history-modal {
     display: flex;
     flex-direction: column;
@@ -5211,6 +5207,13 @@ input[type="submit"],
     gap: 8px;
 }
 
+.phrase-card-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
 .phrase-card-phrase {
     font-family: var(--font-serif);
     font-size: var(--text-lg, 20px);
@@ -5253,9 +5256,6 @@ input[type="submit"],
 }
 
 .phrase-card-badge {
-    position: absolute;
-    top: 6px;
-    right: 4px;
     z-index: 10;
 }
 

--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -54,7 +54,10 @@ pub fn LessonCard(
     });
 
     let answer_text = match card.answer(&lang) {
-        Ok(CardAnswer::Vocabulary { translations, .. }) => translations.join(", "),
+        Ok(CardAnswer::Vocabulary {
+            translations,
+            description,
+        }) => crate::utils::text_format::format_vocabulary_answer(&translations, &description),
         Ok(CardAnswer::Text(s)) => s,
         Err(e) => {
             tracing::warn!(

--- a/origa_ui/src/pages/lesson/lesson_card_container.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_container.rs
@@ -238,10 +238,12 @@ pub fn LessonCardContainer() -> impl IntoView {
                                 let card_type = CardType::from(&card);
                                 let phrase_text = card.question(&native_language.get()).ok().map(|q| q.text().to_string());
                                 let phrase_translation = Some(match card.answer(&native_language.get()).ok() {
-                                    Some(CardAnswer::Vocabulary { translations, .. }) => {
-                                        translations.join(", ")
+                                    Some(CardAnswer::Vocabulary { translations, description }) => {
+                                        crate::utils::text_format::format_vocabulary_answer(&translations, &description)
                                     },
-                                    Some(CardAnswer::Text(s)) => s,
+                                    Some(CardAnswer::Text(s)) => {
+                                        crate::utils::text_format::split_sentences_to_markdown(&s)
+                                    },
                                     None => String::new(),
                                 });
 

--- a/origa_ui/src/pages/lesson/phrase_card.rs
+++ b/origa_ui/src/pages/lesson/phrase_card.rs
@@ -165,11 +165,16 @@ pub fn PhraseCardView(
 
                 <Show when=move || show_result>
                     {move || match phrase_text_stored.get_value() {
-                        Some(text) => view! {
-                            <div class="mt-4 p-3 bg-[var(--bg-secondary)] text-center">
-                                <TranslatorText text=text />
-                            </div>
-                        }.into_any(),
+                        Some(text) => {
+                            let sentences = crate::utils::text_format::split_japanese_sentences(&text);
+                            view! {
+                                <div class="mt-4 p-3 bg-[var(--bg-secondary)] text-center flex flex-col gap-1">
+                                    {sentences.into_iter().map(|s| view! {
+                                        <div><TranslatorText text=s /></div>
+                                    }).collect::<Vec<_>>()}
+                                </div>
+                            }.into_any()
+                        },
                         None => view! { <div/> }.into_any(),
                     }}
                 </Show>

--- a/origa_ui/src/pages/phrases/phrase_card_item.rs
+++ b/origa_ui/src/pages/phrases/phrase_card_item.rs
@@ -69,11 +69,6 @@ pub fn PhraseCardItem(
 
     view! {
         <div class="phrase-card anima-lift" data-testid="phrases-card-item">
-            <div class="phrase-card-badge">
-                <Tag variant=Signal::derive(move || status.tag_variant())>
-                    {move || status.label(&i18n)}
-                </Tag>
-            </div>
             <div class="phrase-card-body">
                 <div class="phrase-card-header">
                     <div class="phrase-card-phrase" data-testid="phrases-card-phrase">
@@ -89,31 +84,45 @@ pub fn PhraseCardItem(
                                 }
                                 .into_any()
                             } else {
+                                let sentences = crate::utils::text_format::split_japanese_sentences(&text);
                                 view! {
-                                    <TranslatorText
-                                        text=text
-                                        native_language=native_language
-                                        test_id=Signal::derive(|| "phrases-card-text".to_string())
-                                    />
+                                    <div class="flex flex-col gap-1">
+                                        {sentences.into_iter().map(|s| view! {
+                                            <TranslatorText
+                                                text=s
+                                                native_language=native_language
+                                                test_id=Signal::derive(|| "phrases-card-text".to_string())
+                                            />
+                                        }).collect::<Vec<_>>()}
+                                    </div>
                                 }
                                 .into_any()
                             }
                         }}
                     </div>
-                    <Show when=move || has_audio>
-                        <div class="phrase-card-audio">
-                            <AudioPlayer
-                                src=audio_src.clone()
-                                autoplay=false
-                                test_id=Signal::derive(|| "phrases-card-audio".to_string())
-                            />
+                    <div class="phrase-card-meta">
+                        <div class="phrase-card-badge">
+                            <Tag variant=Signal::derive(move || status.tag_variant())>
+                                {move || status.label(&i18n)}
+                            </Tag>
                         </div>
-                    </Show>
+                        <Show when=move || has_audio>
+                            <div class="phrase-card-audio">
+                                <AudioPlayer
+                                    src=audio_src.clone()
+                                    autoplay=false
+                                    test_id=Signal::derive(|| "phrases-card-audio".to_string())
+                                />
+                            </div>
+                        </Show>
+                    </div>
                 </div>
                 <div class="phrase-card-content">
                     <CollapsibleDescription>
                         <MarkdownText
-                            content=Signal::derive(move || meaning.get())
+                            content=Signal::derive(move || {
+                                crate::utils::text_format::split_sentences_to_markdown(&meaning.get())
+                            })
                             known_kanji=known_kanji_for_markdown
                             test_id=Signal::derive(|| "phrases-card-meaning".to_string())
                         />

--- a/origa_ui/src/ui_components/audio_buttons.rs
+++ b/origa_ui/src/ui_components/audio_buttons.rs
@@ -63,11 +63,9 @@ pub fn AudioButtons(
                     disabled=move || is_playing.get() || (!has_audio_src && !is_speech_supported())
                 >
                     <Show when=move || is_playing.get() fallback=|| view! {
-                        <Icon icon=icondata::LuVolume width="1em" height="1em" />
+                        <Icon icon=icondata::LuPlay width="1em" height="1em" />
                     }>
-                        <span class="audio-btn-spin">
-                            <Icon icon=icondata::LuLoader width="1em" height="1em" />
-                        </span>
+                        <Icon icon=icondata::LuPause width="1em" height="1em" />
                     </Show>
                 </button>
             </div>

--- a/origa_ui/src/ui_components/markdown.rs
+++ b/origa_ui/src/ui_components/markdown.rs
@@ -261,4 +261,15 @@ mod tests {
         assert!(output.contains("<code>code</code>"));
         assert!(output.contains("more"));
     }
+
+    #[test]
+    fn test_render_hard_break() {
+        let input = "line1  \nline2";
+        let output = render_markdown(input);
+        assert!(
+            output.contains("<br"),
+            "Expected hard break, got: {}",
+            output
+        );
+    }
 }

--- a/origa_ui/src/utils/mod.rs
+++ b/origa_ui/src/utils/mod.rs
@@ -1,6 +1,7 @@
 mod drag_drop;
 mod fetch;
 pub mod file;
+pub mod text_format;
 pub mod time;
 mod yield_;
 

--- a/origa_ui/src/utils/text_format.rs
+++ b/origa_ui/src/utils/text_format.rs
@@ -1,0 +1,166 @@
+/// Format vocabulary answer with translations on separate lines + optional italic description.
+/// Translations joined via markdown hard-breaks (`  \n`).
+/// Description rendered as italic markdown paragraph below.
+pub fn format_vocabulary_answer(translations: &[String], description: &Option<String>) -> String {
+    let mut text = translations.join("  \n");
+    if let Some(desc) = description {
+        if !desc.is_empty() {
+            text = format!("{}\n\n*{}*", text, desc);
+        }
+    }
+    text
+}
+
+/// Split Japanese text by sentence delimiter `。`, preserving the delimiter.
+/// Returns empty Vec if input is empty/whitespace-only.
+pub fn split_japanese_sentences(text: &str) -> Vec<String> {
+    text.split_inclusive('。')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Split text by sentence-ending punctuation (. ! ?) followed by whitespace,
+/// format with markdown hard-breaks between sentences.
+/// Note: Does not handle abbreviations (e.g., "Dr. Smith" will be split).
+/// Returns original text unchanged if no sentence boundaries found.
+pub fn split_sentences_to_markdown(text: &str) -> String {
+    let mut sentences = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        current.push(chars[i]);
+        if matches!(chars[i], '.' | '!' | '?')
+            && i + 1 < chars.len()
+            && chars[i + 1].is_whitespace()
+        {
+            let trimmed = current.trim();
+            if !trimmed.is_empty() {
+                sentences.push(trimmed.to_string());
+            }
+            current.clear();
+            i += 1;
+            while i < chars.len() && chars[i].is_whitespace() {
+                i += 1;
+            }
+            continue;
+        }
+        i += 1;
+    }
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        sentences.push(trimmed.to_string());
+    }
+    if sentences.len() <= 1 {
+        return text.to_string();
+    }
+    sentences.join("  \n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_vocabulary_answer_basic() {
+        let translations = vec!["hello".into(), "hi".into()];
+        let desc = None;
+        assert_eq!(
+            format_vocabulary_answer(&translations, &desc),
+            "hello  \nhi"
+        );
+    }
+
+    #[test]
+    fn test_format_vocabulary_answer_with_description() {
+        let translations = vec!["hello".into()];
+        let desc = Some("informal greeting".into());
+        let result = format_vocabulary_answer(&translations, &desc);
+        assert!(result.contains("hello"));
+        assert!(result.contains("*informal greeting*"));
+    }
+
+    #[test]
+    fn test_format_vocabulary_answer_no_description() {
+        let translations = vec!["hello".into()];
+        let desc = None;
+        assert_eq!(format_vocabulary_answer(&translations, &desc), "hello");
+    }
+
+    #[test]
+    fn test_format_vocabulary_answer_empty_description() {
+        let translations = vec!["hello".into()];
+        let desc = Some("".into());
+        assert_eq!(format_vocabulary_answer(&translations, &desc), "hello");
+    }
+
+    #[test]
+    fn test_split_japanese_sentences() {
+        let text = "今日はいい天気。散歩に行こう。";
+        let sentences = split_japanese_sentences(text);
+        assert_eq!(sentences, vec!["今日はいい天気。", "散歩に行こう。"]);
+    }
+
+    #[test]
+    fn test_split_japanese_sentences_single() {
+        let text = "こんにちは";
+        let sentences = split_japanese_sentences(text);
+        assert_eq!(sentences, vec!["こんにちは"]);
+    }
+
+    #[test]
+    fn test_split_japanese_sentences_empty() {
+        let sentences = split_japanese_sentences("");
+        assert!(sentences.is_empty());
+    }
+
+    #[test]
+    fn test_split_japanese_sentences_single_with_delimiter() {
+        let text = "今日は。";
+        let sentences = split_japanese_sentences(text);
+        assert_eq!(sentences, vec!["今日は。"]);
+    }
+
+    #[test]
+    fn test_split_sentences_to_markdown() {
+        let text = "First sentence. Second sentence. Third one.";
+        let result = split_sentences_to_markdown(text);
+        assert!(
+            result.contains("  \n"),
+            "Expected hard breaks, got: {}",
+            result
+        );
+        assert!(result.contains("First sentence."));
+        assert!(result.contains("Second sentence."));
+    }
+
+    #[test]
+    fn test_split_sentences_exclamation() {
+        let text = "Hello! How are you?";
+        let result = split_sentences_to_markdown(text);
+        assert!(
+            result.contains("  \n"),
+            "Expected hard breaks, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_split_sentences_no_split_needed() {
+        let text = "Single sentence";
+        let result = split_sentences_to_markdown(text);
+        assert_eq!(result, "Single sentence");
+    }
+
+    #[test]
+    fn test_split_sentences_trailing_period() {
+        let text = "First. Second.";
+        let result = split_sentences_to_markdown(text);
+        assert!(
+            result.contains("  \n"),
+            "Expected hard break, got: {}",
+            result
+        );
+    }
+}


### PR DESCRIPTION
## Changes

### Bug fixes
- **Translations in lesson**: each translation on separate line (was inline via join(", ")). Vocabulary description now shown as italic note below translations.
- **Phrase sentence splitting**: Japanese text split by 。(preserving delimiter), translations split by .!? — each sentence on its own line. Affects both lesson PhraseListen and /phrases page.
- **Audio icon unification**: AudioButtons now uses LuPlay/LuPause (matching AudioPlayer pattern). Was LuVolume/LuLoader.
- **Badge overlap fix**: Badge "Новое" no longer overlaps audio button on /phrases page. Moved from position:absolute to inline flex-flow via .phrase-card-meta wrapper.

### New module
- `origa_ui/src/utils/text_format.rs` — 3 helper functions + 12 unit tests:
  - `format_vocabulary_answer()` — markdown hard-breaks between translations + italic description
  - `split_japanese_sentences()` — split by 。 via split_inclusive
  - `split_sentences_to_markdown()` — split by sentence endings, markdown hard-breaks

### Files changed (9)
- NEW: `origa_ui/src/utils/text_format.rs`
- MOD: `origa_ui/src/utils/mod.rs`
- MOD: `origa_ui/src/pages/lesson/lesson_card.rs`
- MOD: `origa_ui/src/pages/lesson/lesson_card_container.rs`
- MOD: `origa_ui/src/pages/lesson/phrase_card.rs`
- MOD: `origa_ui/src/pages/phrases/phrase_card_item.rs`
- MOD: `origa_ui/src/ui_components/audio_buttons.rs`
- MOD: `origa_ui/src/ui_components/markdown.rs`
- MOD: `origa_ui/input.css`

### Verification
- 1406/1406 tests pass (workspace), 134 in origa_ui (13 new)
- 0 clippy warnings
- fmt clean
- Code review: approve (0 HIGH)