### PR TITLE
fix(ui): card answer formatting + kanji popup

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -5165,6 +5165,31 @@ input[type="submit"],
     border-top: 1px solid var(--border-light);
 }
 
+/* === Lesson Answer Translations Override === */
+.lesson-answer .word-translations-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.lesson-answer .word-translations-item {
+    font-size: var(--text-lg, 18px);
+    line-height: 1.3;
+    margin-bottom: 2px;
+}
+
+.lesson-answer .word-translations-desc {
+    border-top: none;
+    border-left: 3px solid var(--accent-olive);
+    background: var(--bg-secondary);
+    padding: 8px 12px;
+    margin-top: 8px;
+    font-style: normal;
+    font-family: var(--font-serif);
+    font-size: var(--text-sm, 16px);
+    color: var(--fg-muted);
+}
+
 /* === Phrase Card Item — Redesigned === */
 .phrase-card {
     display: flex;

--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -53,12 +53,15 @@ pub fn LessonCard(
         question_text.clone()
     });
 
-    let answer_text = match card.answer(&lang) {
+    let (answer_translations, answer_description, answer_text) = match card.answer(&lang) {
         Ok(CardAnswer::Vocabulary {
             translations,
             description,
-        }) => crate::utils::text_format::format_vocabulary_answer(&translations, &description),
-        Ok(CardAnswer::Text(s)) => s,
+        }) => {
+            let tts_text = translations.join(", ");
+            (Some(translations), description, tts_text)
+        },
+        Ok(CardAnswer::Text(s)) => (None, None, s),
         Err(e) => {
             tracing::warn!(
                 card_type = ?card_type,
@@ -66,10 +69,12 @@ pub fn LessonCard(
                 error = %e,
                 "Failed to get card answer"
             );
-            String::new()
+            (None, None, String::new())
         },
     };
     let answer = StoredValue::new(answer_text);
+    let answer_translations_stored = StoredValue::new(answer_translations);
+    let answer_description_stored = StoredValue::new(answer_description);
 
     let radicals: Option<Vec<RadicalDisplay>> = match &card {
         DomainCard::Kanji(kanji) => match kanji.radicals_info() {
@@ -264,6 +269,8 @@ pub fn LessonCard(
                     <LessonCardAnswer
                         question_text=display_question.get_value()
                         answer_text=answer.get_value()
+                        answer_translations=answer_translations_stored.get_value()
+                        answer_description=answer_description_stored.get_value()
                         is_expanded=is_expanded
                         needs_collapse=needs_collapse
                         content_ref=content_ref

--- a/origa_ui/src/pages/lesson/lesson_card_answer.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_answer.rs
@@ -3,7 +3,7 @@ use super::kanji_card_details::{KanjiCardDetails, RadicalDisplay};
 use crate::i18n::*;
 use crate::ui_components::{
     Button, ButtonVariant, FuriganaText, Heading, HeadingLevel, MarkdownText, MarkdownVariant,
-    Text, TextSize, TranslatorText, TypographyVariant,
+    Text, TextSize, TranslatorText, TypographyVariant, WordTranslations,
 };
 use leptos::{ev::MouseEvent, prelude::*};
 use origa::domain::GrammarInfo;
@@ -13,6 +13,8 @@ use std::collections::HashSet;
 pub fn LessonCardAnswer(
     question_text: String,
     answer_text: String,
+    answer_translations: Option<Vec<String>>,
+    answer_description: Option<String>,
     is_expanded: RwSignal<bool>,
     needs_collapse: RwSignal<bool>,
     content_ref: NodeRef<leptos::html::Div>,
@@ -30,6 +32,8 @@ pub fn LessonCardAnswer(
     let i18n = use_i18n();
     let question = StoredValue::new(question_text);
     let answer = StoredValue::new(answer_text);
+    let answer_translations_stored = StoredValue::new(answer_translations);
+    let answer_description_stored = StoredValue::new(answer_description);
     let on_readings_stored = StoredValue::new(on_readings);
     let kun_readings_stored = StoredValue::new(kun_readings);
     let radicals_stored = StoredValue::new(radicals);
@@ -119,7 +123,7 @@ pub fn LessonCardAnswer(
                                         </Text>
                                     </div>
                                     <Show
-                                        when=move || is_reversed
+                                        when=move || answer_translations_stored.get_value().is_some()
                                         fallback=move || {
                                             view! {
                                                 <MarkdownText
@@ -130,7 +134,18 @@ pub fn LessonCardAnswer(
                                             }
                                         }
                                     >
-                                        <FuriganaText text=answer.get_value() known_kanji=known_kanji.get()/>
+                                        {move || {
+                                            let trans = answer_translations_stored.get_value().unwrap_or_default();
+                                            let desc = answer_description_stored.get_value();
+                                            view! {
+                                                <div class="lesson-answer">
+                                                    <WordTranslations
+                                                        translations=Signal::derive(move || trans.clone())
+                                                        description=Signal::derive(move || desc.clone())
+                                                    />
+                                                </div>
+                                            }
+                                        }}
                                     </Show>
                                 </div>
                             }

--- a/origa_ui/src/pages/lesson/quiz_card.rs
+++ b/origa_ui/src/pages/lesson/quiz_card.rs
@@ -1,11 +1,13 @@
 use crate::i18n::*;
 use crate::ui_components::{
     Card, DisplayText, FuriganaTextWithHover, Heading, HeadingLevel, KanjiViewMode,
-    KanjiWritingSection, Text, TextSize, TypographyVariant, is_speech_supported, speak_word,
-    stop_current_audio,
+    KanjiWritingSection, MarkdownText, MarkdownVariant, Text, TextSize, TypographyVariant,
+    WordTranslations, is_speech_supported, speak_word, stop_current_audio,
 };
 use leptos::prelude::*;
-use origa::domain::{Card as DomainCard, MultiQuizResult, NativeLanguage, QuizCard, QuizMode};
+use origa::domain::{
+    Card as DomainCard, CardAnswer, MultiQuizResult, NativeLanguage, QuizCard, QuizMode,
+};
 use std::collections::HashSet;
 use tracing::warn;
 
@@ -73,6 +75,27 @@ pub fn QuizCardView(
     let options: StoredValue<Vec<origa::domain::QuizOption>> =
         StoredValue::new(quiz_card.options().to_vec());
     let multi_result_stored = StoredValue::new(multi_result);
+
+    let (answer_vocab_translations, answer_vocab_description, answer_text_display) =
+        match card.answer(&native_language) {
+            Ok(CardAnswer::Vocabulary {
+                translations,
+                description,
+            }) => (Some(translations), description, String::new()),
+            Ok(CardAnswer::Text(s)) => (None, None, s),
+            Err(e) => {
+                warn!(
+                    card_type = ?card_type,
+                    content_key = %card.content_key(),
+                    error = %e,
+                    "Failed to get answer for result display"
+                );
+                (None, None, String::new())
+            },
+        };
+    let answer_vocab_translations_stored = StoredValue::new(answer_vocab_translations);
+    let answer_vocab_description_stored = StoredValue::new(answer_vocab_description);
+    let answer_text_display_stored = StoredValue::new(answer_text_display);
 
     let quiz_result = move || {
         if dont_know_selected && show_result {
@@ -228,6 +251,40 @@ pub fn QuizCardView(
                     <Show when=move || show_result && quiz_result() != QuizResult::DontKnow>
                         <QuizResultDisplay quiz_result=quiz_result() />
                     </Show>
+                </Show>
+
+                <Show when=move || show_result>
+                    <div class="mt-4 text-center">
+                        <Show
+                            when=move || answer_vocab_translations_stored.get_value().is_some()
+                            fallback=move || {
+                                view! {
+                                    <Show when=move || !answer_text_display_stored.get_value().is_empty()>
+                                        <div class="lesson-answer text-left">
+                                            <MarkdownText
+                                                content=Signal::derive(move || answer_text_display_stored.get_value())
+                                                variant=Signal::derive(|| MarkdownVariant::Default)
+                                                known_kanji=known_kanji.get()
+                                            />
+                                        </div>
+                                    </Show>
+                                }
+                            }
+                        >
+                            {move || {
+                                let trans = answer_vocab_translations_stored.get_value().unwrap_or_default();
+                                let desc = answer_vocab_description_stored.get_value();
+                                view! {
+                                    <div class="lesson-answer text-left">
+                                        <WordTranslations
+                                            translations=Signal::derive(move || trans.clone())
+                                            description=Signal::derive(move || desc.clone())
+                                        />
+                                    </div>
+                                }
+                            }}
+                        </Show>
+                    </div>
                 </Show>
             </div>
         </Card>

--- a/origa_ui/src/pages/lesson/yesno_card_view.rs
+++ b/origa_ui/src/pages/lesson/yesno_card_view.rs
@@ -1,10 +1,10 @@
 use crate::i18n::*;
 use crate::ui_components::{
     Button, ButtonVariant, Card, DisplayText, MarkdownText, MarkdownVariant, Text, TextSize,
-    TypographyVariant, is_speech_supported, speak_word, stop_current_audio,
+    TypographyVariant, WordTranslations, is_speech_supported, speak_word, stop_current_audio,
 };
 use leptos::prelude::*;
-use origa::domain::{Card as DomainCard, NativeLanguage, YesNoCard};
+use origa::domain::{Card as DomainCard, CardAnswer, NativeLanguage, YesNoCard};
 use std::collections::HashSet;
 use tracing::warn;
 
@@ -96,6 +96,27 @@ pub fn YesNoCardView(
         },
         _ => None,
     });
+
+    let (answer_vocab_translations, answer_vocab_description, answer_text_display) =
+        match card.answer(&native_language) {
+            Ok(CardAnswer::Vocabulary {
+                translations,
+                description,
+            }) => (Some(translations), description, String::new()),
+            Ok(CardAnswer::Text(s)) => (None, None, s),
+            Err(e) => {
+                warn!(
+                    card_type = ?card_type,
+                    content_key = %card.content_key(),
+                    error = %e,
+                    "Failed to get answer for result display"
+                );
+                (None, None, String::new())
+            },
+        };
+    let answer_vocab_translations_stored = StoredValue::new(answer_vocab_translations);
+    let answer_vocab_description_stored = StoredValue::new(answer_vocab_description);
+    let answer_text_display_stored = StoredValue::new(answer_text_display);
 
     let lesson_ctx = use_context::<super::lesson_state::LessonContext>();
     Effect::new(move |_| {
@@ -282,6 +303,40 @@ pub fn YesNoCardView(
                             </Text>
                         </div>
                     </Show>
+                </Show>
+
+                <Show when=move || show_result>
+                    <div class="mt-4 text-center">
+                        <Show
+                            when=move || answer_vocab_translations_stored.get_value().is_some()
+                            fallback=move || {
+                                view! {
+                                    <Show when=move || !answer_text_display_stored.get_value().is_empty()>
+                                        <div class="lesson-answer text-left">
+                                            <MarkdownText
+                                                content=Signal::derive(move || answer_text_display_stored.get_value())
+                                                variant=Signal::derive(|| MarkdownVariant::Default)
+                                                known_kanji=known_kanji.get()
+                                            />
+                                        </div>
+                                    </Show>
+                                }
+                            }
+                        >
+                            {move || {
+                                let trans = answer_vocab_translations_stored.get_value().unwrap_or_default();
+                                let desc = answer_vocab_description_stored.get_value();
+                                view! {
+                                    <div class="lesson-answer text-left">
+                                        <WordTranslations
+                                            translations=Signal::derive(move || trans.clone())
+                                            description=Signal::derive(move || desc.clone())
+                                        />
+                                    </div>
+                                }
+                            }}
+                        </Show>
+                    </div>
                 </Show>
             </div>
         </Card>

--- a/origa_ui/src/ui_components/furigana_hover.rs
+++ b/origa_ui/src/ui_components/furigana_hover.rs
@@ -43,16 +43,18 @@ pub fn FuriganaTextWithHover(
             data-testid=test_id_val
         >
             <For
-                each=segments
-                key=|seg: &FuriganaSegment| {
-                    (seg.text().to_string(), seg.reading().map(|r| r.to_string()))
+                each=move || {
+                    segments().into_iter().enumerate().collect::<Vec<_>>()
                 }
-                let:segment
+                key=|(idx, seg): &(usize, FuriganaSegment)| {
+                    (*idx, seg.text().to_string(), seg.reading().map(|r| r.to_string()))
+                }
+                let:tuple
             >
                 {move || {
-                    let text = segment.text().to_string();
-                    let reading = segment.reading().map(|r| r.to_string());
-                    let is_known = segment.is_known();
+                    let text = tuple.1.text().to_string();
+                    let reading = tuple.1.reading().map(|r| r.to_string());
+                    let is_known = tuple.1.is_known();
                     let has_kanji = text.chars().any(|c| c.is_kanji());
                     render_segment_with_hover(
                         text,
@@ -61,6 +63,7 @@ pub fn FuriganaTextWithHover(
                         has_kanji,
                         hovered,
                         native_language,
+                        tuple.0,
                     )
                 }}
             </For>
@@ -75,6 +78,7 @@ fn render_segment_with_hover(
     has_kanji: bool,
     hovered: RwSignal<Option<usize>>,
     native_language: Option<NativeLanguage>,
+    segment_id: usize,
 ) -> impl IntoView {
     if !has_kanji || native_language.is_none() {
         return render_segment(text, reading, is_known).into_any();
@@ -86,8 +90,6 @@ fn render_segment_with_hover(
     let Some((kanji_char, description)) = kanji_info else {
         return render_segment(text, reading, is_known).into_any();
     };
-
-    let segment_id = kanji_char as usize;
 
     let kanji_display = kanji_char.to_string();
     let desc_display = description;


### PR DESCRIPTION
## Changes

Fixes 5 UI bugs in card answer display:

1. **Excessive spacing between translation lines** — replaced MarkdownText with WordTranslations + .lesson-answer CSS (line-height: 1.3)
2. **Insufficient spacing before description** — margin-top: 8px with border-left separator
3. **Description not visually highlighted** — added border-left: 3px olive + background
4. **Formatting only in normal card answers** — applied to reversed cards, Quiz results, YesNo results
5. **Kanji popup not working** — fixed For-key and segment_id collisions via enumerate

## Files changed
- `origa_ui/src/pages/lesson/lesson_card.rs` — extract raw translations/description
- `origa_ui/src/pages/lesson/lesson_card_answer.rs` — WordTranslations for answer display
- `origa_ui/src/pages/lesson/quiz_card.rs` — answer display in quiz results
- `origa_ui/src/pages/lesson/yesno_card_view.rs` — answer display in yesno results
- `origa_ui/src/ui_components/furigana_hover.rs` — fix segment_id collisions
- `origa_ui/input.css` — .lesson-answer CSS overrides

## Verification
- 1406 tests pass
- clippy 0 warnings
- cargo fmt clean