### PR TITLE
feat(translator): grammar popup + lesson card DRY refactoring

### DIFF
--- a/origa/src/domain/tokenizer/translation.rs
+++ b/origa/src/domain/tokenizer/translation.rs
@@ -147,6 +147,7 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
+    use crate::dictionary::grammar::{GrammarData, init_grammar, is_grammar_loaded};
     use crate::dictionary::vocabulary::{
         VocabularyChunkData, init_vocabulary, is_vocabulary_loaded,
     };
@@ -155,6 +156,7 @@ mod integration_tests {
     fn ensure_dictionaries() {
         ensure_tokenizer_dictionary();
         ensure_vocabulary_dictionary();
+        ensure_grammar_dictionary();
     }
 
     fn ensure_tokenizer_dictionary() {
@@ -227,6 +229,23 @@ mod integration_tests {
         init_vocabulary(vocab_data).unwrap();
     }
 
+    fn ensure_grammar_dictionary() {
+        if is_grammar_loaded() {
+            return;
+        }
+
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let grammar_path = std::path::PathBuf::from(manifest_dir)
+            .parent()
+            .unwrap()
+            .join("cdn")
+            .join("grammar")
+            .join("grammar.json");
+
+        let grammar_json = std::fs::read_to_string(grammar_path).unwrap();
+        init_grammar(GrammarData { grammar_json }).unwrap();
+    }
+
     #[test]
     fn should_translate_bakari() {
         ensure_dictionaries();
@@ -276,6 +295,24 @@ mod integration_tests {
         assert!(
             hodo.unwrap().translation.is_some(),
             "「ほど」should have a translation"
+        );
+    }
+
+    #[test]
+    fn should_resolve_grammar_label_for_particle() {
+        ensure_dictionaries();
+        let tokens = super::super::tokenize_text("東京から大阪まで").unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English);
+        let kara_particle = results.iter().find(|t| t.surface_form == "から");
+        assert!(
+            kara_particle.is_some(),
+            "「から」particle should exist in tokens"
+        );
+        let kara = kara_particle.unwrap();
+        assert!(
+            kara.grammar_label.is_some(),
+            "「から」should have a grammar label, got: {:?}",
+            kara
         );
     }
 }

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1728,6 +1728,13 @@ input[type="submit"],
     color: var(--fg-muted);
 }
 
+.token-popup-grammar {
+    font-family: var(--font-mono);
+    font-size: var(--text-label-sm);
+    color: var(--accent-olive);
+    margin-top: var(--space-xs);
+}
+
 .kanji-animation-container {
     display: flex;
     flex-direction: column;

--- a/origa_ui/src/pages/lesson/answer_display.rs
+++ b/origa_ui/src/pages/lesson/answer_display.rs
@@ -1,0 +1,91 @@
+use std::collections::HashSet;
+
+use crate::ui_components::{MarkdownText, MarkdownVariant, WordTranslations};
+use leptos::prelude::*;
+use origa::domain::{Card, CardAnswer, NativeLanguage};
+use tracing::warn;
+
+use super::card_type::CardType;
+
+pub struct CardAnswerData {
+    pub translations: Option<Vec<String>>,
+    pub description: Option<String>,
+    pub text: String,
+}
+
+pub fn extract_card_answer(
+    card: &Card,
+    native_language: &NativeLanguage,
+    card_type: &CardType,
+) -> CardAnswerData {
+    match card.answer(native_language) {
+        Ok(CardAnswer::Vocabulary {
+            translations,
+            description,
+        }) => CardAnswerData {
+            translations: Some(translations),
+            description,
+            text: String::new(),
+        },
+        Ok(CardAnswer::Text(s)) => CardAnswerData {
+            translations: None,
+            description: None,
+            text: s,
+        },
+        Err(e) => {
+            warn!(
+                card_type = ?card_type,
+                content_key = %card.content_key(),
+                error = %e,
+                "Failed to get card answer"
+            );
+            CardAnswerData {
+                translations: None,
+                description: None,
+                text: String::new(),
+            }
+        },
+    }
+}
+
+#[component]
+pub fn CardAnswerDisplay(
+    #[prop(into)] translations: Signal<Option<Vec<String>>>,
+    #[prop(into)] description: Signal<Option<String>>,
+    #[prop(into)] text: Signal<String>,
+    #[prop(into)] known_kanji: Signal<HashSet<char>>,
+) -> impl IntoView {
+    view! {
+        <div class="mt-4 text-center">
+            <Show
+                when=move || translations.get().is_some()
+                fallback=move || {
+                    view! {
+                        <Show when=move || !text.get().is_empty()>
+                            <div class="lesson-answer text-left">
+                                <MarkdownText
+                                    content=text
+                                    variant=Signal::derive(|| MarkdownVariant::Default)
+                                    known_kanji=known_kanji.get()
+                                />
+                            </div>
+                        </Show>
+                    }
+                }
+            >
+                {move || {
+                    let trans = translations.get().unwrap_or_default();
+                    let desc = description.get();
+                    view! {
+                        <div class="lesson-answer text-left">
+                            <WordTranslations
+                                translations=Signal::derive(move || trans.clone())
+                                description=Signal::derive(move || desc.clone())
+                            />
+                        </div>
+                    }
+                }}
+            </Show>
+        </div>
+    }
+}

--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -6,10 +6,11 @@ use leptos::prelude::*;
 
 use leptos::wasm_bindgen::JsCast;
 use leptos::wasm_bindgen::closure::Closure;
-use origa::domain::{Card as DomainCard, CardAnswer, GrammarInfo, NativeLanguage};
+use origa::domain::{Card as DomainCard, GrammarInfo, NativeLanguage};
 use std::collections::HashSet;
 use tracing;
 
+use super::answer_display::extract_card_answer;
 use super::card_type::CardType;
 use super::kanji_card_details::RadicalDisplay;
 use super::lesson_card_answer::LessonCardAnswer;
@@ -53,28 +54,15 @@ pub fn LessonCard(
         question_text.clone()
     });
 
-    let (answer_translations, answer_description, answer_text) = match card.answer(&lang) {
-        Ok(CardAnswer::Vocabulary {
-            translations,
-            description,
-        }) => {
-            let tts_text = translations.join(", ");
-            (Some(translations), description, tts_text)
-        },
-        Ok(CardAnswer::Text(s)) => (None, None, s),
-        Err(e) => {
-            tracing::warn!(
-                card_type = ?card_type,
-                content_key = %card.content_key(),
-                error = %e,
-                "Failed to get card answer"
-            );
-            (None, None, String::new())
-        },
-    };
-    let answer = StoredValue::new(answer_text);
-    let answer_translations_stored = StoredValue::new(answer_translations);
-    let answer_description_stored = StoredValue::new(answer_description);
+    let answer_data = extract_card_answer(&card, &lang, &card_type);
+    let tts_text = answer_data
+        .translations
+        .as_ref()
+        .map(|t| t.join(", "))
+        .unwrap_or_else(|| answer_data.text.clone());
+    let answer = StoredValue::new(tts_text);
+    let answer_translations_stored = StoredValue::new(answer_data.translations);
+    let answer_description_stored = StoredValue::new(answer_data.description);
 
     let radicals: Option<Vec<RadicalDisplay>> = match &card {
         DomainCard::Kanji(kanji) => match kanji.radicals_info() {

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -1,3 +1,4 @@
+mod answer_display;
 pub mod card_type;
 mod complete_screen;
 mod content;

--- a/origa_ui/src/pages/lesson/quiz_card.rs
+++ b/origa_ui/src/pages/lesson/quiz_card.rs
@@ -1,16 +1,15 @@
 use crate::i18n::*;
 use crate::ui_components::{
     Card, DisplayText, FuriganaTextWithHover, Heading, HeadingLevel, KanjiViewMode,
-    KanjiWritingSection, MarkdownText, MarkdownVariant, Text, TextSize, TypographyVariant,
-    WordTranslations, is_speech_supported, speak_word, stop_current_audio,
+    KanjiWritingSection, Text, TextSize, TypographyVariant, is_speech_supported, speak_word,
+    stop_current_audio,
 };
 use leptos::prelude::*;
-use origa::domain::{
-    Card as DomainCard, CardAnswer, MultiQuizResult, NativeLanguage, QuizCard, QuizMode,
-};
+use origa::domain::{Card as DomainCard, MultiQuizResult, NativeLanguage, QuizCard, QuizMode};
 use std::collections::HashSet;
 use tracing::warn;
 
+use super::answer_display::{CardAnswerDisplay, extract_card_answer};
 use super::card_type::CardType;
 use super::quiz_card_header::QuizCardHeader;
 use super::quiz_options::QuizOptions;
@@ -76,26 +75,10 @@ pub fn QuizCardView(
         StoredValue::new(quiz_card.options().to_vec());
     let multi_result_stored = StoredValue::new(multi_result);
 
-    let (answer_vocab_translations, answer_vocab_description, answer_text_display) =
-        match card.answer(&native_language) {
-            Ok(CardAnswer::Vocabulary {
-                translations,
-                description,
-            }) => (Some(translations), description, String::new()),
-            Ok(CardAnswer::Text(s)) => (None, None, s),
-            Err(e) => {
-                warn!(
-                    card_type = ?card_type,
-                    content_key = %card.content_key(),
-                    error = %e,
-                    "Failed to get answer for result display"
-                );
-                (None, None, String::new())
-            },
-        };
-    let answer_vocab_translations_stored = StoredValue::new(answer_vocab_translations);
-    let answer_vocab_description_stored = StoredValue::new(answer_vocab_description);
-    let answer_text_display_stored = StoredValue::new(answer_text_display);
+    let answer_data = extract_card_answer(&card, &native_language, &card_type);
+    let answer_vocab_translations_stored = StoredValue::new(answer_data.translations);
+    let answer_vocab_description_stored = StoredValue::new(answer_data.description);
+    let answer_text_display_stored = StoredValue::new(answer_data.text);
 
     let quiz_result = move || {
         if dont_know_selected && show_result {
@@ -254,37 +237,12 @@ pub fn QuizCardView(
                 </Show>
 
                 <Show when=move || show_result>
-                    <div class="mt-4 text-center">
-                        <Show
-                            when=move || answer_vocab_translations_stored.get_value().is_some()
-                            fallback=move || {
-                                view! {
-                                    <Show when=move || !answer_text_display_stored.get_value().is_empty()>
-                                        <div class="lesson-answer text-left">
-                                            <MarkdownText
-                                                content=Signal::derive(move || answer_text_display_stored.get_value())
-                                                variant=Signal::derive(|| MarkdownVariant::Default)
-                                                known_kanji=known_kanji.get()
-                                            />
-                                        </div>
-                                    </Show>
-                                }
-                            }
-                        >
-                            {move || {
-                                let trans = answer_vocab_translations_stored.get_value().unwrap_or_default();
-                                let desc = answer_vocab_description_stored.get_value();
-                                view! {
-                                    <div class="lesson-answer text-left">
-                                        <WordTranslations
-                                            translations=Signal::derive(move || trans.clone())
-                                            description=Signal::derive(move || desc.clone())
-                                        />
-                                    </div>
-                                }
-                            }}
-                        </Show>
-                    </div>
+                    <CardAnswerDisplay
+                        translations=Signal::derive(move || answer_vocab_translations_stored.get_value())
+                        description=Signal::derive(move || answer_vocab_description_stored.get_value())
+                        text=Signal::derive(move || answer_text_display_stored.get_value())
+                        known_kanji=known_kanji
+                    />
                 </Show>
             </div>
         </Card>

--- a/origa_ui/src/pages/lesson/yesno_card_view.rs
+++ b/origa_ui/src/pages/lesson/yesno_card_view.rs
@@ -1,13 +1,14 @@
 use crate::i18n::*;
 use crate::ui_components::{
     Button, ButtonVariant, Card, DisplayText, MarkdownText, MarkdownVariant, Text, TextSize,
-    TypographyVariant, WordTranslations, is_speech_supported, speak_word, stop_current_audio,
+    TypographyVariant, is_speech_supported, speak_word, stop_current_audio,
 };
 use leptos::prelude::*;
-use origa::domain::{Card as DomainCard, CardAnswer, NativeLanguage, YesNoCard};
+use origa::domain::{Card as DomainCard, NativeLanguage, YesNoCard};
 use std::collections::HashSet;
 use tracing::warn;
 
+use super::answer_display::{CardAnswerDisplay, extract_card_answer};
 use super::card_type::CardType;
 use super::quiz_card_header::QuizCardHeader;
 
@@ -97,26 +98,10 @@ pub fn YesNoCardView(
         _ => None,
     });
 
-    let (answer_vocab_translations, answer_vocab_description, answer_text_display) =
-        match card.answer(&native_language) {
-            Ok(CardAnswer::Vocabulary {
-                translations,
-                description,
-            }) => (Some(translations), description, String::new()),
-            Ok(CardAnswer::Text(s)) => (None, None, s),
-            Err(e) => {
-                warn!(
-                    card_type = ?card_type,
-                    content_key = %card.content_key(),
-                    error = %e,
-                    "Failed to get answer for result display"
-                );
-                (None, None, String::new())
-            },
-        };
-    let answer_vocab_translations_stored = StoredValue::new(answer_vocab_translations);
-    let answer_vocab_description_stored = StoredValue::new(answer_vocab_description);
-    let answer_text_display_stored = StoredValue::new(answer_text_display);
+    let answer_data = extract_card_answer(&card, &native_language, &card_type);
+    let answer_vocab_translations_stored = StoredValue::new(answer_data.translations);
+    let answer_vocab_description_stored = StoredValue::new(answer_data.description);
+    let answer_text_display_stored = StoredValue::new(answer_data.text);
 
     let lesson_ctx = use_context::<super::lesson_state::LessonContext>();
     Effect::new(move |_| {
@@ -306,37 +291,12 @@ pub fn YesNoCardView(
                 </Show>
 
                 <Show when=move || show_result>
-                    <div class="mt-4 text-center">
-                        <Show
-                            when=move || answer_vocab_translations_stored.get_value().is_some()
-                            fallback=move || {
-                                view! {
-                                    <Show when=move || !answer_text_display_stored.get_value().is_empty()>
-                                        <div class="lesson-answer text-left">
-                                            <MarkdownText
-                                                content=Signal::derive(move || answer_text_display_stored.get_value())
-                                                variant=Signal::derive(|| MarkdownVariant::Default)
-                                                known_kanji=known_kanji.get()
-                                            />
-                                        </div>
-                                    </Show>
-                                }
-                            }
-                        >
-                            {move || {
-                                let trans = answer_vocab_translations_stored.get_value().unwrap_or_default();
-                                let desc = answer_vocab_description_stored.get_value();
-                                view! {
-                                    <div class="lesson-answer text-left">
-                                        <WordTranslations
-                                            translations=Signal::derive(move || trans.clone())
-                                            description=Signal::derive(move || desc.clone())
-                                        />
-                                    </div>
-                                }
-                            }}
-                        </Show>
-                    </div>
+                    <CardAnswerDisplay
+                        translations=Signal::derive(move || answer_vocab_translations_stored.get_value())
+                        description=Signal::derive(move || answer_vocab_description_stored.get_value())
+                        text=Signal::derive(move || answer_text_display_stored.get_value())
+                        known_kanji=known_kanji
+                    />
                 </Show>
             </div>
         </Card>

--- a/origa_ui/src/ui_components/translator.rs
+++ b/origa_ui/src/ui_components/translator.rs
@@ -104,7 +104,8 @@ pub fn TranslatorText(
                         let reading = token.reading.clone();
                         let base_form = token.base_form.clone();
                         let translation_text = token.translation.clone();
-                        let clickable = token.pos.is_vocabulary_word();
+                        let grammar_label = token.grammar_label.clone();
+                        let clickable = token.pos.is_vocabulary_word() || grammar_label.is_some();
                         let has_kanji = has_kanji(&surface);
                         let show_base = base_form != surface;
 
@@ -163,15 +164,28 @@ pub fn TranslatorText(
                                                     } else {
                                                         ().into_any()
                                                     }}
-                                                    <MarkdownText
-                                                        content=Signal::derive({
-                                                            let text = translation_text.clone();
-                                                            move || text.clone().unwrap_or_default()
-                                                        })
-                                                        known_kanji=HashSet::new()
-                                                        variant=Signal::derive(|| MarkdownVariant::Compact)
-                                                        furigana=false
-                                                    />
+                                                    {if let Some(label) = &grammar_label {
+                                                        view! {
+                                                            <div class="token-popup-grammar">{label.clone()}</div>
+                                                        }.into_any()
+                                                    } else {
+                                                        ().into_any()
+                                                    }}
+                                                    {if let Some(text) = &translation_text {
+                                                        view! {
+                                                            <MarkdownText
+                                                                content=Signal::derive({
+                                                                    let text = text.clone();
+                                                                    move || text.clone()
+                                                                })
+                                                                known_kanji=HashSet::new()
+                                                                variant=Signal::derive(|| MarkdownVariant::Compact)
+                                                                furigana=false
+                                                            />
+                                                        }.into_any()
+                                                    } else {
+                                                        ().into_any()
+                                                    }}
                                                 </div>
                                             }.into_any()
                                         } else {


### PR DESCRIPTION
## Changes

### Grammar popup in TranslatorText
- Show translation popup for tokens with detected grammar patterns (particles, auxiliary verbs)
- Display grammar rule label (e.g. grammar rule title) in popup
- Conditional MarkdownText rendering (no empty space for grammar-only popups)
- Integration test with grammar dictionary loading

### DRY Refactoring: Lesson Card Answer Display
- Extract CardAnswerData struct + extract_card_answer() function
- Extract CardAnswerDisplay Leptos component
- Eliminate ~47 lines of duplicated code across quiz_card, yesno_card_view, lesson_card

## Files changed
- origa_ui/src/ui_components/translator.rs
- origa_ui/input.css
- origa/src/domain/tokenizer/translation.rs
- origa_ui/src/pages/lesson/answer_display.rs (new)
- origa_ui/src/pages/lesson/mod.rs
- origa_ui/src/pages/lesson/quiz_card.rs
- origa_ui/src/pages/lesson/yesno_card_view.rs
- origa_ui/src/pages/lesson/lesson_card.rs

## Verification
- cargo fmt: clean
- cargo clippy --workspace --all-targets -- -D warnings: 0 warnings
- cargo test --workspace: 1273 + 134 passed