### PR TITLE
fix: add visible backgrounds to danger zone buttons

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -5652,3 +5652,22 @@ input[type="submit"],
     color: var(--error);
     margin-bottom: 16px;
 }
+
+.danger-zone-btn {
+    background: var(--bg-warm);
+}
+
+.danger-zone-btn:hover {
+    background: var(--fg-black);
+    color: var(--bg-paper);
+}
+
+.danger-zone-btn--delete {
+    background: var(--bg-warm);
+    color: var(--error);
+}
+
+.danger-zone-btn--delete:hover {
+    background: var(--error);
+    color: var(--bg-paper);
+}

--- a/origa_ui/src/pages/profile/danger_zone_card.rs
+++ b/origa_ui/src/pages/profile/danger_zone_card.rs
@@ -24,9 +24,10 @@ pub fn DangerZoneCard(
 
             <div class="flex flex-col gap-3">
                 <Button
-                    variant={Signal::derive(|| ButtonVariant::Ghost)}
+                    variant={Signal::derive(|| ButtonVariant::Default)}
                     on_click={on_logout}
                     disabled=is_logging_out
+                    class=Signal::derive(|| "danger-zone-btn".to_string())
                     test_id="profile-logout-btn"
                 >
                     {move || if is_logging_out.get() {
@@ -57,7 +58,7 @@ pub fn DangerZoneCard(
                                     }}
                                 </Button>
                                 <Button
-                                    variant={Signal::derive(|| ButtonVariant::Ghost)}
+                                    variant={Signal::derive(|| ButtonVariant::Default)}
                                     on_click={Callback::new(move |_| show_delete_confirm.set(false))}
                                     test_id="profile-cancel-delete-btn"
                                 >
@@ -69,9 +70,9 @@ pub fn DangerZoneCard(
                 } else {
                     view! {
                         <Button
-                            variant={Signal::derive(|| ButtonVariant::Ghost)}
+                            variant={Signal::derive(|| ButtonVariant::Default)}
                             on_click={Callback::new(move |_| show_delete_confirm.set(true))}
-                            class=Signal::derive(|| "text-[var(--fg-muted)] hover:text-[var(--error)]".to_string())
+                            class=Signal::derive(|| "danger-zone-btn danger-zone-btn--delete".to_string())
                             test_id="profile-delete-btn"
                         >
                             {t!(i18n, profile.delete_account)}


### PR DESCRIPTION
Ghost buttons in DangerZoneCard were invisible on bg-paper background. Changed to Default variant with bg-warm tinting for visual clarity.