### PR TITLE
fix(ui): kanji popup CSS + expand FuriganaTextWithHover

### DIFF
--- a/origa/src/domain/grammar/mod.rs
+++ b/origa/src/domain/grammar/mod.rs
@@ -124,12 +124,8 @@ pub fn detect_format_map_rules(
         let base = token.orthographic_base_form();
         let pos = token.part_of_speech();
 
-        for rule in rules {
-            if let Ok(formatted) = rule.format(base, pos) {
-                if formatted != base && text.contains(&formatted) {
-                    detected.insert(*rule.rule_id());
-                }
-            }
+        for rule in find_format_map_matches(base, pos, text, rules) {
+            detected.insert(*rule.rule_id());
         }
     }
 
@@ -171,6 +167,22 @@ pub fn detect_grammar_rules_in_text(
     result.extend(detect_keyword_rules(text, rules));
 
     result.into_iter().collect()
+}
+
+pub(crate) fn find_format_map_matches<'a>(
+    base: &str,
+    pos: &PartOfSpeech,
+    text: &str,
+    rules: &'a [GrammarRule],
+) -> Vec<&'a GrammarRule> {
+    rules
+        .iter()
+        .filter(|rule| rule.has_format_map())
+        .filter(|rule| {
+            rule.format(base, pos)
+                .is_ok_and(|formatted| formatted != base && text.contains(&formatted))
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/origa/src/domain/grammar/mod.rs
+++ b/origa/src/domain/grammar/mod.rs
@@ -1492,6 +1492,106 @@ mod tests {
         }
     }
 
+    mod find_format_map_matches {
+        use super::*;
+
+        #[test]
+        fn returns_empty_for_no_format_map_rules() {
+            let rules = vec![make_keyword_rule(
+                "01H00000000000000000000030",
+                vec![vec!["て".to_string()]],
+            )];
+            let result = super::super::find_format_map_matches(
+                "食べる",
+                &PartOfSpeech::Verb,
+                "食べて",
+                &rules,
+            );
+            assert!(result.is_empty(), "Keyword-only rules should not match");
+        }
+
+        #[test]
+        fn returns_empty_when_formatted_not_found_in_text() {
+            let rules = vec![create_rule_with_format_map(HashMap::from([(
+                PartOfSpeech::Verb,
+                vec![FormatAction::VerbToTeForm {}],
+            )]))];
+            let result = super::super::find_format_map_matches(
+                "食べる",
+                &PartOfSpeech::Verb,
+                "魚を食べる",
+                &rules,
+            );
+            // "食べて" is not contained in "魚を食べる", so no match
+            assert!(
+                result.is_empty(),
+                "Formatted form not present in text should produce no matches"
+            );
+        }
+
+        #[test]
+        fn returns_empty_for_wrong_pos() {
+            let rules = vec![create_rule_with_format_map(HashMap::from([(
+                PartOfSpeech::IAdjective,
+                vec![FormatAction::AdjectiveToKu {}],
+            )]))];
+            let result = super::super::find_format_map_matches(
+                "食べる",
+                &PartOfSpeech::Verb,
+                "食べて",
+                &rules,
+            );
+            assert!(
+                result.is_empty(),
+                "Adjective rule should not match Verb POS"
+            );
+        }
+
+        #[test]
+        fn returns_match_for_correct_form() {
+            let rules = vec![create_rule_with_format_map(HashMap::from([(
+                PartOfSpeech::Verb,
+                vec![FormatAction::VerbToTeForm {}],
+            )]))];
+            let result = super::super::find_format_map_matches(
+                "食べる",
+                &PartOfSpeech::Verb,
+                "食べて",
+                &rules,
+            );
+            assert_eq!(result.len(), 1, "Should match te-form rule");
+        }
+
+        #[test]
+        fn returns_multiple_matches_for_composite_text() {
+            let rules = vec![
+                create_rule_with_format_map(HashMap::from([(
+                    PartOfSpeech::Verb,
+                    vec![FormatAction::VerbToTeForm {}],
+                )])),
+                create_rule_with_format_map(HashMap::from([(
+                    PartOfSpeech::Verb,
+                    vec![
+                        FormatAction::VerbToTeForm {},
+                        FormatAction::AddPostfix {
+                            postfix: "ください".to_string(),
+                        },
+                    ],
+                )])),
+            ];
+            let result = super::super::find_format_map_matches(
+                "食べる",
+                &PartOfSpeech::Verb,
+                "食べてください",
+                &rules,
+            );
+            assert!(
+                result.len() >= 2,
+                "Should match both bare te-form and te+kudasai"
+            );
+        }
+    }
+
     mod detect_keyword_rules {
         use super::*;
 

--- a/origa/src/domain/tokenizer/translation.rs
+++ b/origa/src/domain/tokenizer/translation.rs
@@ -66,13 +66,15 @@ fn resolve_grammar_label(
         }
     }
 
-    // FormatAction detection for vocabulary tokens where surface != base (conjugated forms)
+    // FormatAction detection for vocabulary tokens where surface != base (conjugated forms).
+    // When multiple rules match, the most specific (longest formatted form) is preferred.
     if pos.is_vocabulary_word() && surface != base {
-        if let Some(rule) = find_format_map_matches(base, pos, original_text, rules)
+        let matches = find_format_map_matches(base, pos, original_text, rules);
+        if let Some(best) = matches
             .into_iter()
-            .next()
+            .max_by_key(|rule| rule.format(base, pos).map_or(0, |f| f.len()))
         {
-            return Some(rule.content(native_language).title().to_string());
+            return Some(best.content(native_language).title().to_string());
         }
     }
 

--- a/origa/src/domain/tokenizer/translation.rs
+++ b/origa/src/domain/tokenizer/translation.rs
@@ -4,6 +4,7 @@ use super::{PartOfSpeech, TokenInfo};
 use crate::dictionary::grammar::GRAMMAR_RULES;
 use crate::dictionary::vocabulary::get_translation;
 use crate::domain::NativeLanguage;
+use crate::domain::grammar::find_format_map_matches;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TokenTranslation {
@@ -67,15 +68,11 @@ fn resolve_grammar_label(
 
     // FormatAction detection for vocabulary tokens where surface != base (conjugated forms)
     if pos.is_vocabulary_word() && surface != base {
-        for rule in rules.iter() {
-            if !rule.has_format_map() {
-                continue;
-            }
-            if let Ok(formatted) = rule.format(base, pos) {
-                if formatted != base && original_text.contains(&formatted) {
-                    return Some(rule.content(native_language).title().to_string());
-                }
-            }
+        if let Some(rule) = find_format_map_matches(base, pos, original_text, rules)
+            .into_iter()
+            .next()
+        {
+            return Some(rule.content(native_language).title().to_string());
         }
     }
 

--- a/origa/src/domain/tokenizer/translation.rs
+++ b/origa/src/domain/tokenizer/translation.rs
@@ -18,6 +18,7 @@ pub struct TokenTranslation {
 pub fn lookup_tokens_translations(
     tokens: &[TokenInfo],
     native_language: &NativeLanguage,
+    original_text: &str,
 ) -> Vec<TokenTranslation> {
     tokens
         .iter()
@@ -26,8 +27,10 @@ pub fn lookup_tokens_translations(
             let translation = get_translation(&base_form, native_language);
             let grammar_label = resolve_grammar_label(
                 token.orthographic_surface_form(),
+                &base_form,
                 token.part_of_speech(),
                 native_language,
+                original_text,
             );
 
             TokenTranslation {
@@ -44,21 +47,38 @@ pub fn lookup_tokens_translations(
 
 fn resolve_grammar_label(
     surface: &str,
+    base: &str,
     pos: &PartOfSpeech,
     native_language: &NativeLanguage,
+    original_text: &str,
 ) -> Option<String> {
-    if pos.is_vocabulary_word() {
-        return None;
-    }
-
     let rules = GRAMMAR_RULES.get()?;
-    for rule in rules.iter() {
-        for group in rule.keywords().iter() {
-            if group.iter().any(|kw| surface == kw) {
-                return Some(rule.content(native_language).title().to_string());
+
+    // Keyword matching for non-vocabulary tokens (particles, auxiliaries, etc.)
+    if !pos.is_vocabulary_word() {
+        for rule in rules.iter() {
+            for group in rule.keywords().iter() {
+                if group.iter().any(|kw| surface == kw) {
+                    return Some(rule.content(native_language).title().to_string());
+                }
             }
         }
     }
+
+    // FormatAction detection for vocabulary tokens where surface != base (conjugated forms)
+    if pos.is_vocabulary_word() && surface != base {
+        for rule in rules.iter() {
+            if !rule.has_format_map() {
+                continue;
+            }
+            if let Ok(formatted) = rule.format(base, pos) {
+                if formatted != base && original_text.contains(&formatted) {
+                    return Some(rule.content(native_language).title().to_string());
+                }
+            }
+        }
+    }
+
     None
 }
 
@@ -86,7 +106,7 @@ mod tests {
             part_of_speech: PartOfSpeech::Verb,
         }];
 
-        let result = lookup_tokens_translations(&tokens, &NativeLanguage::English);
+        let result = lookup_tokens_translations(&tokens, &NativeLanguage::English, "");
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].base_form, "食べる");
@@ -99,7 +119,7 @@ mod tests {
     fn should_return_none_translation_for_unknown_word() {
         let tokens = vec![make_token("未知語", "未知語", "ミチゴ", PartOfSpeech::Noun)];
 
-        let result = lookup_tokens_translations(&tokens, &NativeLanguage::Russian);
+        let result = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, "");
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].base_form, "未知語");
@@ -111,7 +131,7 @@ mod tests {
     fn should_include_punctuation_with_none_translation() {
         let tokens = vec![make_token("。", "。", "。", PartOfSpeech::Symbol)];
 
-        let result = lookup_tokens_translations(&tokens, &NativeLanguage::Russian);
+        let result = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, "");
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].surface_form, "。");
@@ -126,7 +146,7 @@ mod tests {
             make_token("。", "。", "。", PartOfSpeech::Symbol),
         ];
 
-        let result = lookup_tokens_translations(&tokens, &NativeLanguage::English);
+        let result = lookup_tokens_translations(&tokens, &NativeLanguage::English, "");
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].base_form, "猫");
@@ -138,7 +158,7 @@ mod tests {
     fn should_return_empty_for_empty_input() {
         let tokens: Vec<TokenInfo> = vec![];
 
-        let result = lookup_tokens_translations(&tokens, &NativeLanguage::Russian);
+        let result = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, "");
 
         assert!(result.is_empty());
     }
@@ -249,8 +269,9 @@ mod integration_tests {
     #[test]
     fn should_translate_bakari() {
         ensure_dictionaries();
-        let tokens = super::super::tokenize_text("ばかり").unwrap();
-        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian);
+        let text = "ばかり";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
         let bakari = results.iter().find(|t| t.surface_form.contains("ばかり"));
         assert!(bakari.is_some(), "「ばかり」token should exist");
         assert!(
@@ -262,8 +283,9 @@ mod integration_tests {
     #[test]
     fn should_translate_uwa_interjection() {
         ensure_dictionaries();
-        let tokens = super::super::tokenize_text("うわー").unwrap();
-        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian);
+        let text = "うわー";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
         let uwa = results.iter().find(|t| t.surface_form.contains("うわ"));
         assert!(uwa.is_some(), "「うわー」token should exist");
         assert!(
@@ -275,8 +297,9 @@ mod integration_tests {
     #[test]
     fn should_translate_souiu_compound() {
         ensure_dictionaries();
-        let tokens = super::super::tokenize_text("そういう").unwrap();
-        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian);
+        let text = "そういう";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
         let souiu = results.iter().find(|t| t.surface_form.contains("そういう"));
         assert!(souiu.is_some(), "「そういう」token should exist");
         assert!(
@@ -288,8 +311,9 @@ mod integration_tests {
     #[test]
     fn should_translate_hodo() {
         ensure_dictionaries();
-        let tokens = super::super::tokenize_text("ほど").unwrap();
-        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian);
+        let text = "ほど";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
         let hodo = results.iter().find(|t| t.surface_form.contains("ほど"));
         assert!(hodo.is_some(), "「ほど」token should exist");
         assert!(
@@ -301,8 +325,9 @@ mod integration_tests {
     #[test]
     fn should_resolve_grammar_label_for_particle() {
         ensure_dictionaries();
-        let tokens = super::super::tokenize_text("東京から大阪まで").unwrap();
-        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English);
+        let text = "東京から大阪まで";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
         let kara_particle = results.iter().find(|t| t.surface_form == "から");
         assert!(
             kara_particle.is_some(),
@@ -313,6 +338,84 @@ mod integration_tests {
             kara.grammar_label.is_some(),
             "「から」should have a grammar label, got: {:?}",
             kara
+        );
+    }
+
+    #[test]
+    fn should_detect_te_form_grammar_label() {
+        ensure_dictionaries();
+        let text = "食べて";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
+        let verb_token = results.iter().find(|t| t.base_form == "食べる");
+        assert!(verb_token.is_some(), "Should find 食べる token");
+        let verb = verb_token.unwrap();
+        assert!(
+            verb.grammar_label.is_some(),
+            "「食べて」verb should have grammar_label for te-form, got: {:?}",
+            verb
+        );
+    }
+
+    #[test]
+    fn should_detect_tai_form_grammar_label() {
+        ensure_dictionaries();
+        let text = "食べたい";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
+        let verb_token = results.iter().find(|t| t.base_form == "食べる");
+        assert!(verb_token.is_some(), "Should find 食べる token");
+        let verb = verb_token.unwrap();
+        assert!(
+            verb.grammar_label.is_some(),
+            "「食べたい」verb should have grammar_label for tai-form, got: {:?}",
+            verb
+        );
+    }
+
+    #[test]
+    fn should_detect_ta_form_grammar_label() {
+        ensure_dictionaries();
+        let text = "食べた";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
+        let verb_token = results.iter().find(|t| t.base_form == "食べる");
+        assert!(verb_token.is_some(), "Should find 食べる token");
+        let verb = verb_token.unwrap();
+        assert!(
+            verb.grammar_label.is_some(),
+            "「食べた」verb should have grammar_label for ta-form, got: {:?}",
+            verb
+        );
+    }
+
+    #[test]
+    fn should_detect_nai_form_grammar_label() {
+        ensure_dictionaries();
+        let text = "食べない";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
+        let verb_token = results.iter().find(|t| t.base_form == "食べる");
+        assert!(verb_token.is_some(), "Should find 食べる token");
+        let verb = verb_token.unwrap();
+        assert!(
+            verb.grammar_label.is_some(),
+            "「食べない」verb should have grammar_label for nai-form, got: {:?}",
+            verb
+        );
+    }
+
+    #[test]
+    fn should_not_set_grammar_label_for_base_form() {
+        ensure_dictionaries();
+        let text = "食べる";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
+        let verb_token = results.iter().find(|t| t.base_form == "食べる");
+        assert!(verb_token.is_some(), "Should find 食べる token");
+        assert!(
+            verb_token.unwrap().grammar_label.is_none(),
+            "Base form should NOT have grammar_label"
         );
     }
 }

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1595,8 +1595,9 @@ input[type="submit"],
 
 /* === Kanji Hover Popup === */
 .kanji-hover-segment {
-    display: inline;
+    display: inline-block;
     position: relative;
+    vertical-align: baseline;
 }
 
 .kanji-hover-trigger {

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1082,13 +1082,14 @@ input[type="submit"],
     font-family: var(--font-mono);
     font-size: var(--text-label);
     letter-spacing: 0.05em;
-    white-space: nowrap;
+    white-space: normal;
+    max-width: 250px;
+    word-wrap: break-word;
     text-align: center;
     opacity: 0;
     visibility: hidden;
     transition: opacity var(--anima-duration-normal) var(--anima-ease-paper), visibility var(--anima-duration-normal) var(--anima-ease-paper);
     z-index: 50;
-    /* Prevent invisible tooltip from intercepting pointer events */
     pointer-events: none;
 }
 
@@ -5534,17 +5535,30 @@ input[type="submit"],
     }
 }
 
-.profile-header {
+.profile-breadcrumbs {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: var(--text-label-sm);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
     padding: 16px 0 0;
 }
 
-.profile-header-name {
-    font-family: var(--font-serif);
-    font-size: clamp(1.5rem, 4vw, 2rem);
-    font-weight: 400;
-    line-height: 1.2;
-    letter-spacing: -0.01em;
+.profile-breadcrumbs-label {
+    color: var(--fg-muted);
+}
+
+.profile-breadcrumbs-separator {
+    color: var(--fg-light);
+}
+
+.profile-breadcrumbs-current {
     color: var(--fg-black);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .profile-header-label {
@@ -5671,4 +5685,18 @@ input[type="submit"],
 .danger-zone-btn--delete:hover {
     background: var(--error);
     color: var(--bg-paper);
+}
+
+.profile-section-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.profile-danger-zone {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1090,6 +1090,7 @@ input[type="submit"],
     visibility: hidden;
     transition: opacity var(--anima-duration-normal) var(--anima-ease-paper), visibility var(--anima-duration-normal) var(--anima-ease-paper);
     z-index: 50;
+    /* Prevent invisible tooltip from intercepting pointer events */
     pointer-events: none;
 }
 
@@ -5559,10 +5560,6 @@ input[type="submit"],
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-}
-
-.profile-header-label {
-    margin-top: 4px;
 }
 
 .label-muted {

--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -250,6 +250,7 @@ pub fn LessonCard(
                         is_reversed=is_reversed
                         on_show_answer=on_show_answer
                         known_kanji=known_kanji
+                        native_language=native_language
                     />
                 </Show>
 
@@ -272,6 +273,7 @@ pub fn LessonCard(
                         example_words=examples_stored.get_value()
                         grammar_info=grammar_info.clone()
                         known_kanji=known_kanji
+                        native_language=native_language
                     />
                 </Show>
             </div>

--- a/origa_ui/src/pages/lesson/lesson_card_answer.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_answer.rs
@@ -2,11 +2,11 @@ use super::grammar_details_expand::GrammarDetailsExpand;
 use super::kanji_card_details::{KanjiCardDetails, RadicalDisplay};
 use crate::i18n::*;
 use crate::ui_components::{
-    Button, ButtonVariant, FuriganaText, Heading, HeadingLevel, MarkdownText, MarkdownVariant,
-    Text, TextSize, TranslatorText, TypographyVariant, WordTranslations,
+    Button, ButtonVariant, FuriganaTextWithHover, Heading, HeadingLevel, MarkdownText,
+    MarkdownVariant, Text, TextSize, TranslatorText, TypographyVariant, WordTranslations,
 };
 use leptos::{ev::MouseEvent, prelude::*};
-use origa::domain::GrammarInfo;
+use origa::domain::{GrammarInfo, NativeLanguage};
 use std::collections::HashSet;
 
 #[component]
@@ -28,6 +28,7 @@ pub fn LessonCardAnswer(
     example_words: Option<Vec<(String, String)>>,
     grammar_info: Option<GrammarInfo>,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
+    native_language: NativeLanguage,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let question = StoredValue::new(question_text);
@@ -58,9 +59,10 @@ pub fn LessonCardAnswer(
                                         }.into_any()
                                     } else {
                                         view! {
-                                            <FuriganaText
+                                            <FuriganaTextWithHover
                                                 text=question.get_value()
                                                 known_kanji=known_kanji.get()
+                                                native_language=native_language
                                                 class=Signal::derive(|| "text-3xl leading-snug".to_string())
                                             />
                                         }.into_any()

--- a/origa_ui/src/pages/lesson/lesson_card_question.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_question.rs
@@ -1,9 +1,10 @@
 use crate::i18n::*;
 use crate::ui_components::{
-    Button, ButtonVariant, DisplayText, FuriganaText, Heading, HeadingLevel, KanjiViewMode,
-    KanjiWritingSection, MarkdownText, MarkdownVariant,
+    Button, ButtonVariant, DisplayText, FuriganaTextWithHover, Heading, HeadingLevel,
+    KanjiViewMode, KanjiWritingSection, MarkdownText, MarkdownVariant,
 };
 use leptos::prelude::*;
+use origa::domain::NativeLanguage;
 use std::collections::HashSet;
 
 #[component]
@@ -13,6 +14,7 @@ pub fn LessonCardQuestion(
     is_reversed: bool,
     on_show_answer: Callback<()>,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
+    native_language: NativeLanguage,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let question = StoredValue::new(question_text);
@@ -26,7 +28,13 @@ pub fn LessonCardQuestion(
                         <Show
                             when=move || is_reversed
                             fallback=move || {
-                                view! { <FuriganaText text=question.get_value() known_kanji=known_kanji.get()/> }
+                                view! {
+                                    <FuriganaTextWithHover
+                                        text=question.get_value()
+                                        known_kanji=known_kanji.get()
+                                        native_language=native_language
+                                    />
+                                }
                             }
                         >
                             <MarkdownText

--- a/origa_ui/src/pages/profile/content.rs
+++ b/origa_ui/src/pages/profile/content.rs
@@ -180,11 +180,10 @@ pub fn ProfileContent() -> impl IntoView {
 
     view! {
         <div class="profile-layout" data-testid="profile-content">
-            <div class="profile-header">
-                <div class="profile-header-name">{move || user_name.get()}</div>
-                <div class="profile-header-label">
-                    <span class="label-muted">{t!(i18n, home.profile)}</span>
-                </div>
+            <div class="profile-breadcrumbs">
+                <span class="profile-breadcrumbs-label">{t!(i18n, home.profile)}</span>
+                <span class="profile-breadcrumbs-separator">"/"</span>
+                <span class="profile-breadcrumbs-current">{move || user_name.get()}</span>
             </div>
 
             <div class="profile-grid">

--- a/origa_ui/src/pages/profile/personal_data_card.rs
+++ b/origa_ui/src/pages/profile/personal_data_card.rs
@@ -25,7 +25,7 @@ pub fn PersonalDataCard(
     view! {
         <div data-testid=test_id_val class="p-6">
             <div class="flex flex-col gap-4">
-                <div class="profile-section">
+                <div class="profile-section-row">
                     <div class="label-muted">{t!(i18n, profile.interface_language)}</div>
                     <NativeLanguageToggle
                         selected_language={selected_language}

--- a/origa_ui/src/ui_components/furigana_hover.rs
+++ b/origa_ui/src/ui_components/furigana_hover.rs
@@ -117,13 +117,19 @@ fn render_segment_with_hover(
     let is_active = move || hovered.get() == Some(segment_id);
 
     view! {
-        <span class="kanji-hover-segment">
+        <span
+            class="kanji-hover-segment"
+            on:mouseenter=enter_handler
+            on:mouseleave=leave_handler
+        >
             <span
                 class=move || {
-                    if is_active() { "kanji-hover-trigger kanji-hover-active" } else { "kanji-hover-trigger" }
+                    if is_active() {
+                        "kanji-hover-trigger kanji-hover-active"
+                    } else {
+                        "kanji-hover-trigger"
+                    }
                 }
-                on:mouseenter=enter_handler
-                on:mouseleave=leave_handler
                 on:click=click_handler
             >
                 {base_view}

--- a/origa_ui/src/ui_components/offline_bundle_card.rs
+++ b/origa_ui/src/ui_components/offline_bundle_card.rs
@@ -130,37 +130,41 @@ pub fn OfflineBundleCard(#[prop(optional, into)] test_id: Signal<String>) -> imp
                 </div>
             </Show>
 
-            <div class="flex gap-3">
-                <Show when=move || {
-                    matches!(state.get(), BundleState::Idle | BundleState::Error)
-                }>
-                    <button
-                        class="btn btn-filled anima-press anima-focus-ring"
-                        on:click=on_download_click
-                        data-testid="download-bundle-btn"
-                    >
-                        <span class="btn-text">
-                            {move || if is_error.get() {
-                                t!(i18n, profile.retry_download).into_any()
-                            } else {
-                                t!(i18n, profile.download_bundle).into_any()
-                            }}
-                        </span>
-                    </button>
-                </Show>
+            <Show when=move || {
+                matches!(state.get(), BundleState::Idle | BundleState::Error) || is_downloading.get()
+            }>
+                <div class="flex gap-3">
+                    <Show when=move || {
+                        matches!(state.get(), BundleState::Idle | BundleState::Error)
+                    }>
+                        <button
+                            class="btn btn-filled anima-press anima-focus-ring"
+                            on:click=on_download_click
+                            data-testid="download-bundle-btn"
+                        >
+                            <span class="btn-text">
+                                {move || if is_error.get() {
+                                    t!(i18n, profile.retry_download).into_any()
+                                } else {
+                                    t!(i18n, profile.download_bundle).into_any()
+                                }}
+                            </span>
+                        </button>
+                    </Show>
 
-                <Show when=move || is_downloading.get()>
-                    <button
-                        class="btn anima-press anima-focus-ring"
-                        on:click=on_cancel_click
-                        data-testid="cancel-bundle-btn"
-                    >
-                        <span class="btn-text">
-                            {t!(i18n, profile.cancel_download)}
-                        </span>
-                    </button>
-                </Show>
-            </div>
+                    <Show when=move || is_downloading.get()>
+                        <button
+                            class="btn anima-press anima-focus-ring"
+                            on:click=on_cancel_click
+                            data-testid="cancel-bundle-btn"
+                        >
+                            <span class="btn-text">
+                                {t!(i18n, profile.cancel_download)}
+                            </span>
+                        </button>
+                    </Show>
+                </div>
+            </Show>
 
             // Card cache status section
             <Show when=move || has_card_cache>

--- a/origa_ui/src/ui_components/translator.rs
+++ b/origa_ui/src/ui_components/translator.rs
@@ -50,7 +50,7 @@ pub fn TranslatorText(
     spawn_local(async move {
         let lang = native_lang.get();
         let tokens = tokenize_text(&text_for_spawn).unwrap_or_default();
-        translations.set(lookup_tokens_translations(&tokens, &lang));
+        translations.set(lookup_tokens_translations(&tokens, &lang, &text_for_spawn));
         is_loaded.set(true);
     });
 


### PR DESCRIPTION
## Changes

Fixes kanji popup not working and expands coverage:

### Bug fixes
- **CSS**: `.kanji-hover-segment` changed from `display: inline` to `inline-block` + `vertical-align: baseline` — fixes absolute positioning of popup
- **Events**: `mouseenter`/`mouseleave` moved from trigger span to parent `.kanji-hover-segment` — popup no longer vanishes when mouse moves from text to popup
- **For-key**: Segment IDs use enumerate index instead of `kanji_char as usize` — fixes collisions when same kanji repeats in text

### Coverage expansion
- `FuriganaTextWithHover` added to lesson card **question** (was only in quiz cards)
- `FuriganaTextWithHover` added to lesson card **answer heading** (was only in quiz cards)

### Files changed
- `origa_ui/src/ui_components/furigana_hover.rs` — move events to parent, fix segment IDs
- `origa_ui/input.css` — inline-block + vertical-align
- `origa_ui/src/pages/lesson/lesson_card_question.rs` — FuriganaTextWithHover
- `origa_ui/src/pages/lesson/lesson_card_answer.rs` — FuriganaTextWithHover  
- `origa_ui/src/pages/lesson/lesson_card.rs` — pass native_language prop

## Verification
- cargo clippy clean
- cargo test -p origa_ui 134/134 passed
- cargo fmt clean