### PR TITLE
refactor: Phase 2 — extract business logic from UI into domain/use_cases

### DIFF
--- a/origa/src/domain/mod.rs
+++ b/origa/src/domain/mod.rs
@@ -10,6 +10,7 @@ mod memory;
 mod score_content;
 mod serde_utils;
 mod srs;
+mod stats;
 mod tokenizer;
 mod user;
 pub(crate) mod value_objects;
@@ -36,6 +37,7 @@ pub use knowledge::{
 pub use memory::{CardState, Difficulty, MemoryHistory, MemoryState, Rating, ReviewLog, Stability};
 pub use score_content::ScoreContentResult;
 pub use srs::RateMode;
+pub use stats::{RatingRatio, TodayOverview, compute_rating_ratio, compute_today_overview};
 pub use tokenizer::{
     DictionaryData, PartOfSpeech, TokenInfo, TokenTranslation, init_dictionary,
     init_dictionary_from_rkyv, is_dictionary_loaded, lookup_tokens_translations,

--- a/origa/src/domain/stats.rs
+++ b/origa/src/domain/stats.rs
@@ -1,0 +1,175 @@
+use super::{CardType, DailyHistoryItem, KnowledgeSet};
+
+#[derive(Clone, Default)]
+pub struct TodayOverview {
+    pub new_count: usize,
+    pub learned_count: usize,
+    pub in_progress_count: usize,
+    pub difficult_count: usize,
+    pub new_delta: Option<i32>,
+    pub learned_delta: Option<i32>,
+    pub in_progress_delta: Option<i32>,
+    pub difficult_delta: Option<i32>,
+}
+
+impl TodayOverview {
+    pub fn total(&self) -> usize {
+        self.new_count + self.learned_count + self.in_progress_count + self.difficult_count
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct RatingRatio {
+    pub percentage: u8,
+    pub positive_count: usize,
+    pub negative_count: usize,
+}
+
+pub fn compute_today_overview(
+    knowledge_set: &KnowledgeSet,
+    history: &[DailyHistoryItem],
+) -> TodayOverview {
+    let mut overview = TodayOverview::default();
+
+    for study_card in knowledge_set.study_cards().values() {
+        let card = study_card.card();
+        if matches!(CardType::from(card), CardType::Phrase) {
+            continue;
+        }
+        let memory = study_card.memory();
+        if memory.is_new() {
+            overview.new_count += 1;
+        } else if memory.is_high_difficulty() {
+            overview.difficult_count += 1;
+        } else if memory.is_known_card() {
+            overview.learned_count += 1;
+        } else {
+            overview.in_progress_count += 1;
+        }
+    }
+
+    if history.len() >= 2 {
+        let mut sorted: Vec<_> = history.to_vec();
+        sorted.sort_by_key(|a| a.timestamp());
+        let today = sorted.last().expect("last item exists");
+        let yesterday = sorted
+            .iter()
+            .rev()
+            .nth(1)
+            .expect("second-to-last item exists");
+
+        overview.new_delta = Some((today.new_words() as i64 - yesterday.new_words() as i64) as i32);
+        overview.learned_delta =
+            Some((today.known_words() as i64 - yesterday.known_words() as i64) as i32);
+        overview.in_progress_delta =
+            Some((today.in_progress_words() as i64 - yesterday.in_progress_words() as i64) as i32);
+        overview.difficult_delta = Some(
+            (today.high_difficulty_words() as i64 - yesterday.high_difficulty_words() as i64)
+                as i32,
+        );
+    }
+
+    overview
+}
+
+pub fn compute_rating_ratio(history: &[DailyHistoryItem]) -> Option<RatingRatio> {
+    let mut positive = 0usize;
+    let mut negative = 0usize;
+
+    for item in history {
+        positive += item.positive_ratings();
+        negative += item.negative_ratings();
+    }
+
+    let total = positive + negative;
+    if total == 0 {
+        return None;
+    }
+
+    let percentage = (positive as f64 / total as f64 * 100.0).round() as u8;
+
+    Some(RatingRatio {
+        percentage,
+        positive_count: positive,
+        negative_count: negative,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        Card, KnowledgeSet, RateMode, Rating, VocabularyCard, value_objects::Question,
+    };
+
+    fn create_vocab_card(word: &str) -> Card {
+        Card::Vocabulary(VocabularyCard::new(
+            Question::new(word.to_string()).unwrap(),
+        ))
+    }
+
+    #[test]
+    fn compute_today_overview_empty_data() {
+        let ks = KnowledgeSet::new();
+        let history: Vec<DailyHistoryItem> = vec![];
+
+        let overview = compute_today_overview(&ks, &history);
+
+        assert_eq!(overview.new_count, 0);
+        assert_eq!(overview.learned_count, 0);
+        assert_eq!(overview.in_progress_count, 0);
+        assert_eq!(overview.difficult_count, 0);
+        assert_eq!(overview.total(), 0);
+        assert!(overview.new_delta.is_none());
+        assert!(overview.learned_delta.is_none());
+        assert!(overview.in_progress_delta.is_none());
+        assert!(overview.difficult_delta.is_none());
+    }
+
+    #[test]
+    fn compute_today_overview_with_cards_of_different_statuses() {
+        let mut ks = KnowledgeSet::new();
+
+        let _card1 = ks.create_card(create_vocab_card("猫")).unwrap();
+        let _card2 = ks.create_card(create_vocab_card("犬")).unwrap();
+        let card3 = ks.create_card(create_vocab_card("鳥")).unwrap();
+
+        ks.mark_card_as_known(*card3.card_id()).unwrap();
+
+        let overview = compute_today_overview(&ks, ks.lesson_history());
+
+        assert_eq!(overview.new_count, 2);
+        assert_eq!(overview.learned_count, 1);
+        assert_eq!(overview.in_progress_count, 0);
+        assert_eq!(overview.difficult_count, 0);
+        assert_eq!(overview.total(), 3);
+    }
+
+    #[test]
+    fn compute_rating_ratio_with_history() {
+        let mut ks = KnowledgeSet::new();
+
+        let card1 = ks.create_card(create_vocab_card("猫")).unwrap();
+        let card2 = ks.create_card(create_vocab_card("犬")).unwrap();
+
+        ks.rate_card(*card1.card_id(), Rating::Good, RateMode::ShortTerm)
+            .unwrap();
+        ks.rate_card(*card2.card_id(), Rating::Again, RateMode::ShortTerm)
+            .unwrap();
+
+        let result = compute_rating_ratio(ks.lesson_history());
+
+        assert!(result.is_some());
+        let ratio = result.unwrap();
+        assert_eq!(ratio.positive_count, 1);
+        assert_eq!(ratio.negative_count, 1);
+        assert_eq!(ratio.percentage, 50);
+    }
+
+    #[test]
+    fn compute_rating_ratio_empty_history() {
+        let result = compute_rating_ratio(&[]);
+
+        assert!(result.is_none());
+    }
+}

--- a/origa/src/use_cases/mod.rs
+++ b/origa/src/use_cases/mod.rs
@@ -11,6 +11,7 @@ mod import_onboarding_sets;
 mod mark_card_as_known;
 mod migrate_kanji_companions;
 mod rate_card;
+mod rate_card_with_side_effects;
 mod seed_ready_phrases;
 mod select_cards_to_lesson;
 mod toggle_favorite;
@@ -40,6 +41,7 @@ pub use import_onboarding_sets::{ImportOnboardingResult, ImportOnboardingSetsUse
 pub use mark_card_as_known::MarkCardAsKnownUseCase;
 pub use migrate_kanji_companions::{MigrateKanjiCompanionsUseCase, MigrationResult};
 pub use rate_card::RateCardUseCase;
+pub use rate_card_with_side_effects::RateCardWithSideEffectsUseCase;
 pub use seed_ready_phrases::SeedReadyPhrasesUseCase;
 pub use seed_ready_phrases::collect_known_grammar_rules;
 pub use seed_ready_phrases::{classify_orphaned_phrases, delete_phrase_cards_by_phrase_ids};

--- a/origa/src/use_cases/rate_card_with_side_effects.rs
+++ b/origa/src/use_cases/rate_card_with_side_effects.rs
@@ -1,0 +1,195 @@
+use crate::domain::{Card, OrigaError, RateMode, Rating};
+use crate::traits::UserRepository;
+use crate::use_cases::{CreateGrammarCardUseCase, RateCardUseCase};
+use tracing::warn;
+use ulid::Ulid;
+
+pub struct RateCardWithSideEffectsUseCase<'a, R: UserRepository> {
+    repository: &'a R,
+}
+
+impl<'a, R: UserRepository> RateCardWithSideEffectsUseCase<'a, R> {
+    pub fn new(repository: &'a R) -> Self {
+        Self { repository }
+    }
+
+    pub async fn execute(
+        &self,
+        card_id: Ulid,
+        rate_mode: RateMode,
+        rating: Rating,
+        grammar_rule_id: Option<Ulid>,
+    ) -> Result<(), OrigaError> {
+        RateCardUseCase::new(self.repository)
+            .execute(card_id, rate_mode, rating)
+            .await?;
+
+        if let Some(grammar_rule_id) = grammar_rule_id {
+            self.handle_grammar_dual_rating(grammar_rule_id, rating)
+                .await;
+        }
+
+        Ok(())
+    }
+
+    async fn handle_grammar_dual_rating(&self, grammar_rule_id: Ulid, rating: Rating) {
+        let Some(user) = self.repository.get_current_user().await.ok().flatten() else {
+            return;
+        };
+
+        let existing_card_id = user
+            .knowledge_set()
+            .study_cards()
+            .iter()
+            .find(|(_, study_card)| {
+                let Card::Grammar(grammar_card) = study_card.card() else {
+                    return false;
+                };
+                grammar_card.rule_id() == &grammar_rule_id
+            })
+            .map(|(id, _)| *id);
+
+        if let Some(card_id) = existing_card_id {
+            if let Err(e) = RateCardUseCase::new(self.repository)
+                .execute(card_id, RateMode::GrammarReview, rating)
+                .await
+            {
+                warn!(error = ?e, "Failed to rate grammar card during dual rating");
+            }
+            return;
+        }
+
+        let Ok(new_cards) = CreateGrammarCardUseCase::new(self.repository)
+            .execute(vec![grammar_rule_id])
+            .await
+        else {
+            return;
+        };
+
+        let Some(first_card) = new_cards.first() else {
+            return;
+        };
+
+        if let Err(e) = RateCardUseCase::new(self.repository)
+            .execute(*first_card.card_id(), RateMode::GrammarReview, rating)
+            .await
+        {
+            warn!(error = ?e, "Failed to rate newly created grammar card during dual rating");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{Card, GrammarRuleCard, NativeLanguage, Question, User, VocabularyCard};
+    use crate::use_cases::tests::fixtures::InMemoryUserRepository;
+
+    fn create_test_user_with_vocab() -> User {
+        User::new(
+            "test@example.com".to_string(),
+            NativeLanguage::Russian,
+            None,
+        )
+    }
+
+    fn create_vocab_card(word: &str) -> Card {
+        Card::Vocabulary(VocabularyCard::new(
+            Question::new(word.to_string()).unwrap(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn rates_card_without_grammar_dual_rating() {
+        let mut user = create_test_user_with_vocab();
+        let study_card = user.create_card(create_vocab_card("猫")).unwrap();
+        let card_id = *study_card.card_id();
+        let repo = InMemoryUserRepository::with_user(user);
+
+        let use_case = RateCardWithSideEffectsUseCase::new(&repo);
+
+        let result = use_case
+            .execute(card_id, RateMode::StandardLesson, Rating::Good, None)
+            .await;
+
+        assert!(result.is_ok());
+
+        let updated_user = repo.get_current_user().await.unwrap().unwrap();
+        let rated_card = updated_user
+            .knowledge_set()
+            .study_cards()
+            .get(&card_id)
+            .unwrap();
+        assert!(!rated_card.is_new());
+    }
+
+    #[tokio::test]
+    async fn rates_card_with_grammar_dual_rating_creates_new_grammar_card() {
+        let mut user = create_test_user_with_vocab();
+        let study_card = user.create_card(create_vocab_card("猫")).unwrap();
+        let card_id = *study_card.card_id();
+        let repo = InMemoryUserRepository::with_user(user.clone());
+
+        let grammar_rule_id = Ulid::new();
+        let use_case = RateCardWithSideEffectsUseCase::new(&repo);
+
+        let result = use_case
+            .execute(
+                card_id,
+                RateMode::StandardLesson,
+                Rating::Good,
+                Some(grammar_rule_id),
+            )
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rates_card_with_existing_grammar_card() {
+        let mut user = create_test_user_with_vocab();
+        let study_card = user.create_card(create_vocab_card("猫")).unwrap();
+        let card_id = *study_card.card_id();
+
+        let grammar_rule_id = Ulid::new();
+        let grammar_card = GrammarRuleCard::new_test_with_id(grammar_rule_id);
+        let grammar_study = user.create_card(Card::Grammar(grammar_card)).unwrap();
+        let grammar_card_id = *grammar_study.card_id();
+
+        let repo = InMemoryUserRepository::with_user(user);
+        let use_case = RateCardWithSideEffectsUseCase::new(&repo);
+
+        let result = use_case
+            .execute(
+                card_id,
+                RateMode::StandardLesson,
+                Rating::Good,
+                Some(grammar_rule_id),
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        let updated_user = repo.get_current_user().await.unwrap().unwrap();
+        let rated_grammar = updated_user
+            .knowledge_set()
+            .study_cards()
+            .get(&grammar_card_id)
+            .unwrap();
+        assert!(!rated_grammar.is_new());
+    }
+
+    #[tokio::test]
+    async fn returns_error_for_nonexistent_card() {
+        let user = create_test_user_with_vocab();
+        let repo = InMemoryUserRepository::with_user(user);
+
+        let use_case = RateCardWithSideEffectsUseCase::new(&repo);
+
+        let result = use_case
+            .execute(Ulid::new(), RateMode::StandardLesson, Rating::Good, None)
+            .await;
+
+        assert!(result.is_err());
+    }
+}

--- a/origa_ui/src/pages/home/activity_chart.rs
+++ b/origa_ui/src/pages/home/activity_chart.rs
@@ -1,7 +1,8 @@
-use super::dashboard_stats::{ActivityDataPoint, RatingRatio};
+use super::dashboard_stats::ActivityDataPoint;
 use crate::i18n::{t, td_string, use_i18n};
 use crate::ui_components::{Card, ChartLine, MultiLineChart, Text, TextSize, TypographyVariant};
 use leptos::prelude::*;
+use origa::domain::RatingRatio;
 
 #[component]
 pub fn ActivityChart(

--- a/origa_ui/src/pages/home/dashboard_stats.rs
+++ b/origa_ui/src/pages/home/dashboard_stats.rs
@@ -10,24 +10,6 @@ const EN_MONTHS_SHORT: [&str; 12] = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
 
-#[derive(Clone, Default)]
-pub struct TodayOverview {
-    pub new_count: usize,
-    pub learned_count: usize,
-    pub in_progress_count: usize,
-    pub difficult_count: usize,
-    pub new_delta: Option<i32>,
-    pub learned_delta: Option<i32>,
-    pub in_progress_delta: Option<i32>,
-    pub difficult_delta: Option<i32>,
-}
-
-impl TodayOverview {
-    pub fn total(&self) -> usize {
-        self.new_count + self.learned_count + self.in_progress_count + self.difficult_count
-    }
-}
-
 #[derive(Clone)]
 pub struct RecentlyStudiedItem {
     pub card_id: String,
@@ -45,53 +27,6 @@ pub struct ActivityDataPoint {
     pub in_progress: f64,
     pub new_count: f64,
     pub difficult: f64,
-}
-
-pub fn compute_today_overview(
-    knowledge_set: &KnowledgeSet,
-    history: &[DailyHistoryItem],
-) -> TodayOverview {
-    let mut overview = TodayOverview::default();
-
-    for study_card in knowledge_set.study_cards().values() {
-        let card = study_card.card();
-        if matches!(CardType::from(card), CardType::Phrase) {
-            continue;
-        }
-        let memory = study_card.memory();
-        if memory.is_new() {
-            overview.new_count += 1;
-        } else if memory.is_high_difficulty() {
-            overview.difficult_count += 1;
-        } else if memory.is_known_card() {
-            overview.learned_count += 1;
-        } else {
-            overview.in_progress_count += 1;
-        }
-    }
-
-    if history.len() >= 2 {
-        let mut sorted: Vec<_> = history.to_vec();
-        sorted.sort_by_key(|a| a.timestamp());
-        let today = sorted.last().expect("last item exists");
-        let yesterday = sorted
-            .iter()
-            .rev()
-            .nth(1)
-            .expect("second-to-last item exists");
-
-        overview.new_delta = Some((today.new_words() as i64 - yesterday.new_words() as i64) as i32);
-        overview.learned_delta =
-            Some((today.known_words() as i64 - yesterday.known_words() as i64) as i32);
-        overview.in_progress_delta =
-            Some((today.in_progress_words() as i64 - yesterday.in_progress_words() as i64) as i32);
-        overview.difficult_delta = Some(
-            (today.high_difficulty_words() as i64 - yesterday.high_difficulty_words() as i64)
-                as i32,
-        );
-    }
-
-    overview
 }
 
 pub fn compute_studied_today(
@@ -209,36 +144,6 @@ pub fn compute_30day_chart_data(
             }
         })
         .collect()
-}
-
-#[derive(Clone, Default)]
-pub struct RatingRatio {
-    pub percentage: u8,
-    pub positive_count: usize,
-    pub negative_count: usize,
-}
-
-pub fn compute_rating_ratio(history: &[DailyHistoryItem]) -> Option<RatingRatio> {
-    let mut positive = 0usize;
-    let mut negative = 0usize;
-
-    for item in history {
-        positive += item.positive_ratings();
-        negative += item.negative_ratings();
-    }
-
-    let total = positive + negative;
-    if total == 0 {
-        return None;
-    }
-
-    let percentage = (positive as f64 / total as f64 * 100.0).round() as u8;
-
-    Some(RatingRatio {
-        percentage,
-        positive_count: positive,
-        negative_count: negative,
-    })
 }
 
 #[derive(Clone, Default)]

--- a/origa_ui/src/pages/home/mod.rs
+++ b/origa_ui/src/pages/home/mod.rs
@@ -12,12 +12,12 @@ pub mod welcome_card;
 pub use activity_chart::ActivityChart;
 pub use content::HomeContent;
 pub use dashboard_stats::{
-    ActivityDataPoint, CompletionForecast, RatingRatio, RecentlyStudiedItem, TodayOverview,
-    compute_30day_chart_data, compute_completion_forecast, compute_rating_ratio,
-    compute_studied_today, compute_today_overview,
+    ActivityDataPoint, CompletionForecast, RecentlyStudiedItem, compute_30day_chart_data,
+    compute_completion_forecast, compute_studied_today,
 };
 pub use home_skeleton::JlptSkeleton;
 pub use jlpt_progress_card::JlptProgressCard;
+pub use origa::domain::{RatingRatio, TodayOverview, compute_rating_ratio, compute_today_overview};
 pub use recent_study::StudiedTodayList;
 pub use today_overview::TodayOverviewCard;
 pub use welcome_card::WelcomeCard;

--- a/origa_ui/src/pages/home/today_overview.rs
+++ b/origa_ui/src/pages/home/today_overview.rs
@@ -1,7 +1,8 @@
-use super::dashboard_stats::{CompletionForecast, TodayOverview};
+use super::dashboard_stats::CompletionForecast;
 use crate::i18n::{t, td_string, use_i18n};
 use crate::ui_components::{Card, Text, TextSize, TypographyVariant};
 use leptos::prelude::*;
+use origa::domain::TodayOverview;
 
 fn delta_color(delta: i32, is_positive_good: bool) -> &'static str {
     if delta == 0 {

--- a/origa_ui/src/pages/lesson/on_rate.rs
+++ b/origa_ui/src/pages/lesson/on_rate.rs
@@ -4,7 +4,7 @@ use leptos::prelude::*;
 use leptos::task::spawn_local;
 use origa::domain::{Card, CardType, LessonCard, RateMode, Rating};
 use origa::traits::UserRepository;
-use origa::use_cases::{CreateGrammarCardUseCase, CreatePhraseCardUseCase, RateCardUseCase};
+use origa::use_cases::{CreatePhraseCardUseCase, RateCardWithSideEffectsUseCase};
 use tracing::warn;
 use ulid::Ulid;
 
@@ -30,52 +30,6 @@ fn extract_grammar_rule_id(card: &LessonCard) -> Option<Ulid> {
         },
         origa::domain::LessonCardView::GrammarQuiz(gq) => gq.grammar_info().rule_id(),
         _ => None,
-    }
-}
-
-async fn handle_grammar_dual_rating<R: UserRepository>(
-    grammar_rule_id: Ulid,
-    repo: &R,
-    rating: Rating,
-) {
-    let rate_use_case = RateCardUseCase::new(repo);
-    let Some(user) = repo.get_current_user().await.ok().flatten() else {
-        return;
-    };
-
-    let grammar_card_id = user
-        .knowledge_set()
-        .study_cards()
-        .iter()
-        .find(|(_, study_card)| {
-            if let Card::Grammar(grammar_card) = study_card.card() {
-                grammar_card.rule_id() == &grammar_rule_id
-            } else {
-                false
-            }
-        })
-        .map(|(id, _)| *id);
-
-    if let Some(grammar_card_id) = grammar_card_id {
-        if let Err(e) = rate_use_case
-            .execute(grammar_card_id, RateMode::GrammarReview, rating)
-            .await
-        {
-            warn!(error = ?e, "Failed to rate grammar card during dual rating");
-        }
-        return;
-    }
-
-    let create_use_case = CreateGrammarCardUseCase::new(repo);
-    let cards = create_use_case.execute(vec![grammar_rule_id]).await;
-
-    if let Ok(grammar_cards) = cards
-        && let Some(grammar_card) = grammar_cards.first()
-        && let Err(e) = rate_use_case
-            .execute(*grammar_card.card_id(), RateMode::GrammarReview, rating)
-            .await
-    {
-        warn!(error = ?e, "Failed to rate newly created grammar card during dual rating");
     }
 }
 
@@ -172,14 +126,13 @@ pub fn create_on_rate_callback(
         let grammar_rule_id = state.cards.get(&card_id).and_then(extract_grammar_rule_id);
 
         spawn_local(async move {
-            let use_case = RateCardUseCase::new(&repo);
+            let use_case = RateCardWithSideEffectsUseCase::new(&repo);
 
-            if let Err(e) = use_case.execute(card_id, rate_mode, rating).await {
+            if let Err(e) = use_case
+                .execute(card_id, rate_mode, rating, grammar_rule_id)
+                .await
+            {
                 warn!(error = ?e, "Failed to rate card");
-            }
-
-            if let Some(grammar_rule_id) = grammar_rule_id {
-                handle_grammar_dual_rating(grammar_rule_id, &repo, rating).await;
             }
 
             check_and_create_ready_phrases(card_id, &repo, rating).await;


### PR DESCRIPTION
## Phase 2: Business Logic Extraction

### Slices:
1. **domain/stats.rs** — extracted compute_today_overview + compute_rating_ratio from UI dashboard_stats into domain. UI formatting stays in UI. (+4 tests)
2. **RateCardWithSideEffectsUseCase** — extracted grammar dual rating from on_rate.rs UI into use case. on_rate.rs: 195→148 lines. (+4 tests)

### Verification:
- [x] 1417+ tests pass (origa + origa_ui)
- [x] 0 clippy warnings
- [x] cargo fmt clean

### Note:
Slice-8 (utils dedup) will be a separate PR — independent crate.