### PR TITLE
refactor: Phase 3 — StatsTracker extraction + UI decomposition (Slice-10, Slice-11)

### DIFF
--- a/origa/src/domain/knowledge/daily_history.rs
+++ b/origa/src/domain/knowledge/daily_history.rs
@@ -163,6 +163,11 @@ impl DailyHistoryItem {
         self.phrase_cards_studied_today = stats.phrase_cards_studied_today;
     }
 
+    #[cfg(test)]
+    pub fn set_timestamp_for_test(&mut self, ts: DateTime<Utc>) {
+        self.timestamp = ts;
+    }
+
     pub fn merge_with(&mut self, other: &DailyHistoryItem) {
         self.lessons_completed = self.lessons_completed.max(other.lessons_completed);
         self.positive_ratings = self.positive_ratings.max(other.positive_ratings);

--- a/origa/src/domain/knowledge/mod.rs
+++ b/origa/src/domain/knowledge/mod.rs
@@ -6,6 +6,7 @@ mod kanji_companions;
 pub mod lesson;
 mod lesson_builder;
 mod phrase;
+mod stats_tracker;
 mod stats_updater;
 #[cfg(test)]
 mod tests;
@@ -20,9 +21,9 @@ pub use lesson::{
     MultiQuizResult, QuizCard, QuizMode, QuizOption, YesNoCard,
 };
 pub use phrase::PhraseCard;
+pub use stats_tracker::StatsTracker;
 pub use vocabulary::VocabularyCard;
 
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use ulid::Ulid;
@@ -41,7 +42,8 @@ pub struct KnowledgeSet {
     study_cards: HashMap<Ulid, StudyCard>,
     #[serde(default)]
     deleted_cards: HashSet<Ulid>,
-    lesson_history: Vec<DailyHistoryItem>,
+    #[serde(flatten)]
+    stats: StatsTracker,
 }
 
 fn deserialize_study_cards<'de, D>(deserializer: D) -> Result<HashMap<Ulid, StudyCard>, D::Error>
@@ -90,7 +92,7 @@ impl KnowledgeSet {
         Self {
             study_cards: HashMap::new(),
             deleted_cards: HashSet::new(),
-            lesson_history: Vec::new(),
+            stats: StatsTracker::new(),
         }
     }
 
@@ -112,21 +114,7 @@ impl KnowledgeSet {
             }
         }
 
-        for item in &new_values.lesson_history {
-            let date = item.timestamp().date_naive();
-            if let Some(existing_item) = self
-                .lesson_history
-                .iter_mut()
-                .find(|h| h.timestamp().date_naive() == date)
-            {
-                existing_item.merge_with(item);
-            } else {
-                self.lesson_history.push(item.clone());
-            }
-        }
-
-        self.lesson_history.sort_by_key(|h| h.timestamp());
-
+        self.stats.merge(&new_values.stats);
         self.recalculate_daily_stats();
     }
 
@@ -139,27 +127,15 @@ impl KnowledgeSet {
     }
 
     pub fn lesson_history(&self) -> &[DailyHistoryItem] {
-        &self.lesson_history
+        self.stats.history()
     }
 
     pub fn new_cards_studied_today(&self) -> usize {
-        let today = Utc::now().date_naive();
-        self.lesson_history
-            .iter()
-            .rev()
-            .find(|item| item.timestamp().date_naive() == today)
-            .map(|item| item.new_cards_studied_today() as usize)
-            .unwrap_or(0)
+        self.stats.new_cards_studied_today()
     }
 
     pub fn phrase_cards_studied_today(&self) -> usize {
-        let today = Utc::now().date_naive();
-        self.lesson_history
-            .iter()
-            .rev()
-            .find(|item| item.timestamp().date_naive() == today)
-            .map(|item| item.phrase_cards_studied_today() as usize)
-            .unwrap_or(0)
+        self.stats.phrase_cards_studied_today()
     }
 
     pub fn get_known_kanji(&self) -> HashSet<char> {
@@ -295,14 +271,8 @@ impl KnowledgeSet {
     }
 
     fn update_history(&mut self, rating: Rating, was_new: bool, is_phrase: bool, mode: RateMode) {
-        stats_updater::update_history(
-            &self.study_cards,
-            &mut self.lesson_history,
-            rating,
-            was_new,
-            is_phrase,
-            mode,
-        );
+        self.stats
+            .update(&self.study_cards, rating, was_new, is_phrase, mode);
     }
 
     pub fn create_companion_vocab_cards(
@@ -342,7 +312,7 @@ impl KnowledgeSet {
     }
 
     fn recalculate_daily_stats(&mut self) {
-        stats_updater::recalculate_daily_stats(&self.study_cards, &mut self.lesson_history);
+        self.stats.recalculate(&self.study_cards);
     }
 
     pub fn mark_card_as_known(&mut self, card_id: Ulid) -> Result<(), OrigaError> {

--- a/origa/src/domain/knowledge/stats_tracker.rs
+++ b/origa/src/domain/knowledge/stats_tracker.rs
@@ -1,0 +1,234 @@
+use std::collections::HashMap;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+use super::{DailyHistoryItem, StudyCard};
+use crate::domain::{RateMode, Rating};
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct StatsTracker {
+    lesson_history: Vec<DailyHistoryItem>,
+}
+
+impl StatsTracker {
+    pub fn new() -> Self {
+        Self {
+            lesson_history: Vec::new(),
+        }
+    }
+
+    pub fn history(&self) -> &[DailyHistoryItem] {
+        &self.lesson_history
+    }
+
+    pub fn new_cards_studied_today(&self) -> usize {
+        let today = Utc::now().date_naive();
+        self.lesson_history
+            .iter()
+            .rev()
+            .find(|item| item.timestamp().date_naive() == today)
+            .map(|item| item.new_cards_studied_today() as usize)
+            .unwrap_or(0)
+    }
+
+    pub fn phrase_cards_studied_today(&self) -> usize {
+        let today = Utc::now().date_naive();
+        self.lesson_history
+            .iter()
+            .rev()
+            .find(|item| item.timestamp().date_naive() == today)
+            .map(|item| item.phrase_cards_studied_today() as usize)
+            .unwrap_or(0)
+    }
+
+    pub fn update(
+        &mut self,
+        study_cards: &HashMap<Ulid, StudyCard>,
+        rating: Rating,
+        was_new: bool,
+        is_phrase: bool,
+        mode: RateMode,
+    ) {
+        super::stats_updater::update_history(
+            study_cards,
+            &mut self.lesson_history,
+            rating,
+            was_new,
+            is_phrase,
+            mode,
+        );
+    }
+
+    pub fn recalculate(&mut self, study_cards: &HashMap<Ulid, StudyCard>) {
+        super::stats_updater::recalculate_daily_stats(study_cards, &mut self.lesson_history);
+    }
+
+    pub fn merge(&mut self, other: &StatsTracker) {
+        for item in &other.lesson_history {
+            let date = item.timestamp().date_naive();
+            if let Some(existing_item) = self
+                .lesson_history
+                .iter_mut()
+                .find(|h| h.timestamp().date_naive() == date)
+            {
+                existing_item.merge_with(item);
+            } else {
+                self.lesson_history.push(item.clone());
+            }
+        }
+
+        self.lesson_history.sort_by_key(|h| h.timestamp());
+    }
+}
+
+#[cfg(test)]
+mod stats_tracker_tests {
+    use super::*;
+    use crate::domain::knowledge::daily_history::DailyStatsUpdate;
+    use chrono::Duration;
+
+    fn create_test_history_item(
+        timestamp: chrono::DateTime<Utc>,
+        new_studied: u32,
+        phrase_studied: u32,
+    ) -> DailyHistoryItem {
+        let mut item = DailyHistoryItem::new();
+        item.update_stats(DailyStatsUpdate {
+            avg_stability: 0.5,
+            avg_difficulty: 0.3,
+            total_words: 10,
+            known_words: 5,
+            new_words: 5,
+            in_progress_words: 0,
+            high_difficulty_words: 0,
+            positive_ratings: 1,
+            negative_ratings: 0,
+            total_ratings: 1,
+            new_cards_studied_today: new_studied,
+            phrase_cards_studied_today: phrase_studied,
+        });
+        item.set_timestamp_for_test(timestamp);
+        item
+    }
+
+    #[test]
+    fn new_tracker_has_empty_history() {
+        let tracker = StatsTracker::new();
+        assert!(tracker.history().is_empty());
+        assert_eq!(tracker.new_cards_studied_today(), 0);
+        assert_eq!(tracker.phrase_cards_studied_today(), 0);
+    }
+
+    #[test]
+    fn merge_combines_history_from_different_days() {
+        let now = Utc::now();
+        let yesterday = now - Duration::days(1);
+
+        let mut tracker1 = StatsTracker::new();
+        tracker1
+            .lesson_history
+            .push(create_test_history_item(now, 3, 0));
+
+        let mut tracker2 = StatsTracker::new();
+        tracker2
+            .lesson_history
+            .push(create_test_history_item(yesterday, 5, 2));
+
+        tracker1.merge(&tracker2);
+
+        assert_eq!(tracker1.history().len(), 2);
+        assert_eq!(tracker1.history()[0].new_cards_studied_today(), 5);
+        assert_eq!(tracker1.history()[1].new_cards_studied_today(), 3);
+    }
+
+    #[test]
+    fn merge_takes_max_for_same_day() {
+        let now = Utc::now();
+
+        let mut tracker1 = StatsTracker::new();
+        tracker1
+            .lesson_history
+            .push(create_test_history_item(now, 3, 1));
+
+        let mut tracker2 = StatsTracker::new();
+        tracker2
+            .lesson_history
+            .push(create_test_history_item(now, 7, 4));
+
+        tracker1.merge(&tracker2);
+
+        assert_eq!(tracker1.history().len(), 1);
+        assert_eq!(tracker1.history()[0].new_cards_studied_today(), 7);
+        assert_eq!(tracker1.history()[0].phrase_cards_studied_today(), 4);
+    }
+
+    #[test]
+    fn merge_sorts_history_by_timestamp() {
+        let now = Utc::now();
+        let day1 = now - Duration::days(2);
+        let day2 = now - Duration::days(1);
+
+        let mut tracker1 = StatsTracker::new();
+        tracker1
+            .lesson_history
+            .push(create_test_history_item(now, 1, 0));
+
+        let mut tracker2 = StatsTracker::new();
+        tracker2
+            .lesson_history
+            .push(create_test_history_item(day1, 5, 0));
+        tracker2
+            .lesson_history
+            .push(create_test_history_item(day2, 3, 0));
+
+        tracker1.merge(&tracker2);
+
+        assert_eq!(tracker1.history().len(), 3);
+        assert!(tracker1.history()[0].timestamp() < tracker1.history()[1].timestamp());
+        assert!(tracker1.history()[1].timestamp() < tracker1.history()[2].timestamp());
+    }
+
+    #[test]
+    fn serialization_roundtrip_preserves_data() {
+        let now = Utc::now();
+        let mut tracker = StatsTracker::new();
+        tracker
+            .lesson_history
+            .push(create_test_history_item(now, 4, 2));
+
+        let json = serde_json::to_string(&tracker).unwrap();
+        let deserialized: StatsTracker = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(tracker, deserialized);
+    }
+
+    #[test]
+    fn knowledge_set_serialization_uses_lesson_history_key() {
+        use crate::domain::knowledge::KnowledgeSet;
+
+        let ks = KnowledgeSet::new();
+        let json = serde_json::to_string(&ks).unwrap();
+
+        assert!(
+            json.contains("\"lesson_history\":[]"),
+            "JSON must use 'lesson_history' key for backward compatibility, got: {json}"
+        );
+        assert!(
+            !json.contains("\"stats\""),
+            "JSON must not contain 'stats' key, got: {json}"
+        );
+    }
+
+    #[test]
+    fn knowledge_set_deserializes_old_format() {
+        use crate::domain::knowledge::KnowledgeSet;
+
+        let old_json = r#"{"study_cards":{},"deleted_cards":[],"lesson_history":[]}"#;
+        let ks: KnowledgeSet = serde_json::from_str(old_json).unwrap();
+
+        assert!(ks.lesson_history().is_empty());
+        assert!(ks.study_cards().is_empty());
+    }
+}

--- a/origa_ui/src/pages/kanji/kanji_detail.rs
+++ b/origa_ui/src/pages/kanji/kanji_detail.rs
@@ -1,9 +1,8 @@
-use std::collections::HashSet;
-
 use super::super::shared::{
     CardStatus, DeleteRequest, create_delete_callback, create_mark_as_known_callback,
     format_answer_text,
 };
+use super::kanji_detail_parts::{KanjiDetailHeroCard, MobileOverview};
 use crate::i18n::use_i18n;
 use crate::repository::HybridUserRepository;
 use crate::ui_components::{
@@ -553,129 +552,5 @@ pub fn KanjiDetail() -> impl IntoView {
             }}
         </Show>
         </div>
-    }
-}
-
-#[component]
-fn KanjiDetailHeroCard(
-    kanji_stored: StoredValue<String>,
-    answer_text: Memo<String>,
-    on_readings: StoredValue<String>,
-    kun_readings: StoredValue<String>,
-    has_radicals: bool,
-    radicals_stored: StoredValue<String>,
-    #[prop(into)] tag_variant: Signal<crate::ui_components::TagVariant>,
-    #[prop(into)] tag_label: Signal<String>,
-    #[prop(into)] radicals_title: Signal<String>,
-    #[prop(into)] on_label: Signal<String>,
-    #[prop(into)] kun_label: Signal<String>,
-) -> impl IntoView {
-    view! {
-        <div class="kanji-detail-hero-card">
-            <div class="kanji-detail-hero-header">
-                <div class="kanji-detail-hero-kanji">{kanji_stored.get_value()}</div>
-                <div class="kanji-detail-hero-info">
-                    <div class="kanji-detail-hero-meaning">{answer_text}</div>
-                    <div class="kanji-detail-hero-readings">
-                        <Show when=move || !on_readings.get_value().is_empty()>
-                            <div class="kanji-detail-hero-reading">
-                                <span class="kanji-detail-hero-reading-label">{on_label}</span>
-                                {on_readings.get_value()}
-                            </div>
-                        </Show>
-                        <Show when=move || !kun_readings.get_value().is_empty()>
-                            <div class="kanji-detail-hero-reading">
-                                <span class="kanji-detail-hero-reading-label">{kun_label}</span>
-                                {kun_readings.get_value()}
-                            </div>
-                        </Show>
-                    </div>
-                </div>
-                <div class="kanji-detail-hero-badge">
-                    <Tag variant=tag_variant>{tag_label}</Tag>
-                </div>
-            </div>
-
-            <Show when=move || has_radicals>
-                <div style="margin-top:12px">
-                    <span
-                        style="font-family:var(--font-mono);font-size:var(--text-2xs,11px);\
-                               text-transform:uppercase;letter-spacing:0.1em;\
-                               color:var(--fg-muted);margin-right:8px"
-                    >
-                        {radicals_title}
-                    </span>
-                    <span
-                        style="font-family:var(--font-serif);font-size:var(--text-sm,16px);\
-                               color:var(--fg-black)"
-                    >
-                        {radicals_stored.get_value()}
-                    </span>
-                </div>
-            </Show>
-        </div>
-    }
-}
-
-#[component]
-fn MobileOverview(
-    description: Memo<String>,
-    has_radicals: bool,
-    radicals_stored: StoredValue<String>,
-    #[prop(into)] radicals_title: Signal<String>,
-    has_examples: Memo<bool>,
-    #[prop(into)] vocabulary_title: Signal<String>,
-    example_words: Memo<Vec<(String, String)>>,
-    known_kanji: HashSet<char>,
-) -> impl IntoView {
-    let known_kanji_stored = StoredValue::new(known_kanji);
-
-    view! {
-        <Show when=move || !description.get().is_empty()>
-            <div class="kanji-detail-section">
-                <MarkdownText
-                    content=Signal::derive(move || description.get())
-                    known_kanji=known_kanji_stored.get_value()
-                />
-            </div>
-        </Show>
-
-        <Show when=move || has_radicals>
-            <div class="kanji-detail-section">
-                <div class="kanji-detail-section-title">{radicals_title}</div>
-                <Text size=TextSize::Default variant=TypographyVariant::Primary>
-                    {radicals_stored.get_value()}
-                </Text>
-            </div>
-        </Show>
-
-        <Show when=move || has_examples.get()>
-            <div class="kanji-detail-section">
-                <div class="kanji-detail-section-title">{vocabulary_title}</div>
-                <div class="kanji-vocab-list">
-                    <For
-                        each=move || example_words.get()
-                        key=|(word, _)| word.clone()
-                        children=move |(word, meaning): (String, String)| {
-                            view! {
-                                <div class="kanji-vocab-item">
-                                    <div class="kanji-vocab-item-kanji">
-                                        {word.chars().next().unwrap_or('?').to_string()}
-                                    </div>
-                                    <div>
-                                        <div class="kanji-vocab-item-reading">
-                                            <FuriganaText text=word.clone() known_kanji=known_kanji_stored.get_value()/>
-                                        </div>
-                                        <div class="kanji-vocab-item-meaning">
-                                            <MarkdownText content=Signal::derive(move || meaning.clone()) known_kanji=known_kanji_stored.get_value()/>
-                                        </div>
-                                    </div>
-                                </div>
-                            }
-                        }
-                    />
-                </div>
-            </div>
-        </Show>
     }
 }

--- a/origa_ui/src/pages/kanji/kanji_detail_parts.rs
+++ b/origa_ui/src/pages/kanji/kanji_detail_parts.rs
@@ -1,0 +1,128 @@
+use std::collections::HashSet;
+
+use crate::ui_components::{FuriganaText, MarkdownText, Tag, Text, TextSize, TypographyVariant};
+use leptos::prelude::*;
+
+#[component]
+pub(in crate::pages::kanji) fn KanjiDetailHeroCard(
+    kanji_stored: StoredValue<String>,
+    answer_text: Memo<String>,
+    on_readings: StoredValue<String>,
+    kun_readings: StoredValue<String>,
+    has_radicals: bool,
+    radicals_stored: StoredValue<String>,
+    #[prop(into)] tag_variant: Signal<crate::ui_components::TagVariant>,
+    #[prop(into)] tag_label: Signal<String>,
+    #[prop(into)] radicals_title: Signal<String>,
+    #[prop(into)] on_label: Signal<String>,
+    #[prop(into)] kun_label: Signal<String>,
+) -> impl IntoView {
+    view! {
+        <div class="kanji-detail-hero-card">
+            <div class="kanji-detail-hero-header">
+                <div class="kanji-detail-hero-kanji">{kanji_stored.get_value()}</div>
+                <div class="kanji-detail-hero-info">
+                    <div class="kanji-detail-hero-meaning">{answer_text}</div>
+                    <div class="kanji-detail-hero-readings">
+                        <Show when=move || !on_readings.get_value().is_empty()>
+                            <div class="kanji-detail-hero-reading">
+                                <span class="kanji-detail-hero-reading-label">{on_label}</span>
+                                {on_readings.get_value()}
+                            </div>
+                        </Show>
+                        <Show when=move || !kun_readings.get_value().is_empty()>
+                            <div class="kanji-detail-hero-reading">
+                                <span class="kanji-detail-hero-reading-label">{kun_label}</span>
+                                {kun_readings.get_value()}
+                            </div>
+                        </Show>
+                    </div>
+                </div>
+                <div class="kanji-detail-hero-badge">
+                    <Tag variant=tag_variant>{tag_label}</Tag>
+                </div>
+            </div>
+
+            <Show when=move || has_radicals>
+                <div style="margin-top:12px">
+                    <span
+                        style="font-family:var(--font-mono);font-size:var(--text-2xs,11px);\
+                               text-transform:uppercase;letter-spacing:0.1em;\
+                               color:var(--fg-muted);margin-right:8px"
+                    >
+                        {radicals_title}
+                    </span>
+                    <span
+                        style="font-family:var(--font-serif);font-size:var(--text-sm,16px);\
+                               color:var(--fg-black)"
+                    >
+                        {radicals_stored.get_value()}
+                    </span>
+                </div>
+            </Show>
+        </div>
+    }
+}
+
+#[component]
+pub(in crate::pages::kanji) fn MobileOverview(
+    description: Memo<String>,
+    has_radicals: bool,
+    radicals_stored: StoredValue<String>,
+    #[prop(into)] radicals_title: Signal<String>,
+    has_examples: Memo<bool>,
+    #[prop(into)] vocabulary_title: Signal<String>,
+    example_words: Memo<Vec<(String, String)>>,
+    known_kanji: HashSet<char>,
+) -> impl IntoView {
+    let known_kanji_stored = StoredValue::new(known_kanji);
+
+    view! {
+        <Show when=move || !description.get().is_empty()>
+            <div class="kanji-detail-section">
+                <MarkdownText
+                    content=Signal::derive(move || description.get())
+                    known_kanji=known_kanji_stored.get_value()
+                />
+            </div>
+        </Show>
+
+        <Show when=move || has_radicals>
+            <div class="kanji-detail-section">
+                <div class="kanji-detail-section-title">{radicals_title}</div>
+                <Text size=TextSize::Default variant=TypographyVariant::Primary>
+                    {radicals_stored.get_value()}
+                </Text>
+            </div>
+        </Show>
+
+        <Show when=move || has_examples.get()>
+            <div class="kanji-detail-section">
+                <div class="kanji-detail-section-title">{vocabulary_title}</div>
+                <div class="kanji-vocab-list">
+                    <For
+                        each=move || example_words.get()
+                        key=|(word, _)| word.clone()
+                        children=move |(word, meaning): (String, String)| {
+                            view! {
+                                <div class="kanji-vocab-item">
+                                    <div class="kanji-vocab-item-kanji">
+                                        {word.chars().next().unwrap_or('?').to_string()}
+                                    </div>
+                                    <div>
+                                        <div class="kanji-vocab-item-reading">
+                                            <FuriganaText text=word.clone() known_kanji=known_kanji_stored.get_value()/>
+                                        </div>
+                                        <div class="kanji-vocab-item-meaning">
+                                            <MarkdownText content=Signal::derive(move || meaning.clone()) known_kanji=known_kanji_stored.get_value()/>
+                                        </div>
+                                    </div>
+                                </div>
+                            }
+                        }
+                    />
+                </div>
+            </div>
+        </Show>
+    }
+}

--- a/origa_ui/src/pages/kanji/mod.rs
+++ b/origa_ui/src/pages/kanji/mod.rs
@@ -5,6 +5,7 @@ mod content;
 mod header;
 mod kanji_card_item;
 mod kanji_detail;
+mod kanji_detail_parts;
 mod kanji_item;
 mod kanji_list;
 

--- a/origa_ui/src/pages/lesson/lesson_card_container.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_container.rs
@@ -1,5 +1,5 @@
 use super::keyboard_handler::{KeyboardActions, create_keyboard_handler};
-use super::lesson_card::LessonCard as LessonCardComponent;
+use super::lesson_card_renderer::render_lesson_card;
 use super::lesson_state::LessonContext;
 use super::on_dont_know::create_on_dont_know;
 use super::on_quiz_select::create_on_quiz_select;
@@ -8,19 +8,14 @@ use super::on_quiz_toggle::create_on_quiz_toggle;
 use super::on_rate::create_on_rate_callback;
 use super::on_yesno_select::create_on_yesno_select;
 use super::phrase_card::PhraseCardView;
-use super::phrase_rating_buttons::PhraseRatingButtons;
 use super::quiz_card::QuizCardView;
 use super::quiz_card::QuizVariant;
-use super::rating_buttons_view::RatingButtonsView;
 use super::writing_card::WritingCard;
 use super::yesno_card_view::YesNoCardView;
 use crate::pages::lesson::card_type::CardType;
 use crate::ui_components::stop_current_audio;
 use leptos::prelude::*;
-use origa::domain::{
-    Card, CardAnswer, GrammarInfo, LessonCard, LessonCardView, NativeLanguage, Rating,
-};
-use std::collections::HashSet;
+use origa::domain::{CardAnswer, LessonCardView, Rating};
 use ulid::Ulid;
 
 #[component]
@@ -346,118 +341,5 @@ pub fn LessonCardContainer() -> impl IntoView {
                 </Show>
             </Show>
         </div>
-    }
-}
-
-struct LessonCardParams {
-    card: origa::domain::Card,
-    is_reversed: bool,
-    grammar_info: Option<GrammarInfo>,
-}
-
-fn render_lesson_card(
-    lesson_card: LessonCard,
-    show_answer: bool,
-    on_show_answer: Callback<()>,
-    on_rate_callback: Callback<Rating>,
-    is_rating: RwSignal<Option<Ulid>>,
-    known_kanji: RwSignal<HashSet<char>>,
-    native_language: RwSignal<NativeLanguage>,
-) -> impl IntoView {
-    let params = match lesson_card.into_view() {
-        LessonCardView::Normal(card) => {
-            let grammar_info = match &card {
-                Card::Grammar(grc) => {
-                    let lang = native_language.get();
-                    let title = grc
-                        .title(&lang)
-                        .ok()
-                        .map(|q| q.text().to_string())
-                        .unwrap_or_default();
-                    // description left empty: answer_text already shows short_description
-                    // via Card::answer(). GrammarInfo carries rule_id for the
-                    // "More details" expand button in LessonCardAnswer.
-                    Some(GrammarInfo::new(Some(*grc.rule_id()), title, String::new()))
-                },
-                _ => None,
-            };
-            LessonCardParams {
-                card,
-                is_reversed: false,
-                grammar_info,
-            }
-        },
-        LessonCardView::Reversed(card) => LessonCardParams {
-            card,
-            is_reversed: true,
-            grammar_info: None,
-        },
-        LessonCardView::GrammarMutated { card, grammar_info } => LessonCardParams {
-            card,
-            is_reversed: false,
-            grammar_info: Some(grammar_info),
-        },
-        LessonCardView::Quiz(_)
-        | LessonCardView::Writing(_)
-        | LessonCardView::YesNo(_)
-        | LessonCardView::PhraseListen { .. }
-        | LessonCardView::KanjiReadingQuiz(_)
-        | LessonCardView::GrammarQuiz(_) => {
-            return ().into_any();
-        },
-    };
-
-    let is_phrase = matches!(params.card, Card::Phrase(_));
-
-    if is_phrase {
-        let phrase_audio_src = match &params.card {
-            Card::Phrase(pc) => Some(crate::repository::cdn_provider::resolve_audio_url(
-                &format!("phrases/audio/{}.opus", pc.phrase_id()),
-            )),
-            _ => None,
-        };
-
-        view! {
-            <LessonCardComponent
-                card=params.card
-                is_reversed=params.is_reversed
-                show_answer
-                on_show_answer=on_show_answer
-                grammar_info=params.grammar_info
-                native_language=native_language.get()
-                known_kanji=Signal::from(known_kanji)
-                audio_src=phrase_audio_src
-            />
-
-            <Show when=move || show_answer>
-                <PhraseRatingButtons
-                    on_rate=on_rate_callback
-                    disabled=Signal::derive(move || is_rating.get().is_some())
-                    test_id=Signal::derive(|| "lesson-phrase-rating".to_string())
-                />
-            </Show>
-        }
-        .into_any()
-    } else {
-        view! {
-            <LessonCardComponent
-                card=params.card
-                is_reversed=params.is_reversed
-                show_answer
-                on_show_answer=on_show_answer
-                grammar_info=params.grammar_info
-                native_language=native_language.get()
-                known_kanji=Signal::from(known_kanji)
-                audio_src=None
-            />
-
-            <Show when=move || show_answer>
-                <RatingButtonsView
-                    on_rate=on_rate_callback
-                    disabled=Signal::derive(move || is_rating.get().is_some())
-                />
-            </Show>
-        }
-        .into_any()
     }
 }

--- a/origa_ui/src/pages/lesson/lesson_card_renderer.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_renderer.rs
@@ -1,0 +1,117 @@
+use super::lesson_card::LessonCard as LessonCardComponent;
+use super::phrase_rating_buttons::PhraseRatingButtons;
+use super::rating_buttons_view::RatingButtonsView;
+use leptos::prelude::*;
+use origa::domain::{Card, GrammarInfo, LessonCard, LessonCardView, NativeLanguage, Rating};
+use std::collections::HashSet;
+use ulid::Ulid;
+
+struct LessonCardParams {
+    card: Card,
+    is_reversed: bool,
+    grammar_info: Option<GrammarInfo>,
+}
+
+pub(in crate::pages::lesson) fn render_lesson_card(
+    lesson_card: LessonCard,
+    show_answer: bool,
+    on_show_answer: Callback<()>,
+    on_rate_callback: Callback<Rating>,
+    is_rating: RwSignal<Option<Ulid>>,
+    known_kanji: RwSignal<HashSet<char>>,
+    native_language: RwSignal<NativeLanguage>,
+) -> impl IntoView {
+    let params = match lesson_card.into_view() {
+        LessonCardView::Normal(card) => {
+            let grammar_info = match &card {
+                Card::Grammar(grc) => {
+                    let lang = native_language.get();
+                    let title = grc
+                        .title(&lang)
+                        .ok()
+                        .map(|q| q.text().to_string())
+                        .unwrap_or_default();
+                    Some(GrammarInfo::new(Some(*grc.rule_id()), title, String::new()))
+                },
+                _ => None,
+            };
+            LessonCardParams {
+                card,
+                is_reversed: false,
+                grammar_info,
+            }
+        },
+        LessonCardView::Reversed(card) => LessonCardParams {
+            card,
+            is_reversed: true,
+            grammar_info: None,
+        },
+        LessonCardView::GrammarMutated { card, grammar_info } => LessonCardParams {
+            card,
+            is_reversed: false,
+            grammar_info: Some(grammar_info),
+        },
+        LessonCardView::Quiz(_)
+        | LessonCardView::Writing(_)
+        | LessonCardView::YesNo(_)
+        | LessonCardView::PhraseListen { .. }
+        | LessonCardView::KanjiReadingQuiz(_)
+        | LessonCardView::GrammarQuiz(_) => {
+            return ().into_any();
+        },
+    };
+
+    let is_phrase = matches!(params.card, Card::Phrase(_));
+
+    if is_phrase {
+        let phrase_audio_src = match &params.card {
+            Card::Phrase(pc) => Some(crate::repository::cdn_provider::resolve_audio_url(
+                &format!("phrases/audio/{}.opus", pc.phrase_id()),
+            )),
+            _ => None,
+        };
+
+        view! {
+            <LessonCardComponent
+                card=params.card
+                is_reversed=params.is_reversed
+                show_answer
+                on_show_answer=on_show_answer
+                grammar_info=params.grammar_info
+                native_language=native_language.get()
+                known_kanji=Signal::from(known_kanji)
+                audio_src=phrase_audio_src
+            />
+
+            <Show when=move || show_answer>
+                <PhraseRatingButtons
+                    on_rate=on_rate_callback
+                    disabled=Signal::derive(move || is_rating.get().is_some())
+                    test_id=Signal::derive(|| "lesson-phrase-rating".to_string())
+                />
+            </Show>
+        }
+        .into_any()
+    } else {
+        view! {
+            <LessonCardComponent
+                card=params.card
+                is_reversed=params.is_reversed
+                show_answer
+                on_show_answer=on_show_answer
+                grammar_info=params.grammar_info
+                native_language=native_language.get()
+                known_kanji=Signal::from(known_kanji)
+                audio_src=None
+            />
+
+            <Show when=move || show_answer>
+                <RatingButtonsView
+                    on_rate=on_rate_callback
+                    disabled=Signal::derive(move || is_rating.get().is_some())
+                />
+            </Show>
+        }
+        .into_any()
+    }
+}

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -12,6 +12,7 @@ mod lesson_card_answer;
 mod lesson_card_container;
 mod lesson_card_header;
 mod lesson_card_question;
+mod lesson_card_renderer;
 mod lesson_progress;
 mod lesson_state;
 mod na_adjective_helper;


### PR DESCRIPTION
## Phase 3: Structural Refactoring

### Slice-10: Extract StatsTracker from KnowledgeSet
- Created `origa/src/domain/knowledge/stats_tracker.rs` with `StatsTracker` struct
- Moved `lesson_history`, `new_cards_studied_today`, `phrase_cards_studied_today`, `update()`, `recalculate()`, `merge()` into StatsTracker
- `#[serde(flatten)]` preserves backward-compatible JSON format
- 7 new tests (1291 total pass)

### Slice-11: UI decomposition of large files
- Extracted `kanji_detail_parts.rs` from `kanji_detail.rs` (~122 lines)
- Extracted `lesson_card_renderer.rs` from `lesson_card_container.rs` (~112 lines)
- `grammar_detail.rs` (597 lines) — already decomposed, not touched
- `auth_store.rs` (485 lines) — single struct, not splittable
- 134 origa_ui tests pass

### Verification
- [x] All 1291 `origa` tests pass
- [x] All 134 `origa_ui` tests pass
- [x] clippy clean (0 warnings)
- [x] fmt clean