### PR TITLE
refactor: landing DRY + Russian comments cleanup (Slice-12)

### DIFF
--- a/origa/src/use_cases/create_cards_from_analysis.rs
+++ b/origa/src/use_cases/create_cards_from_analysis.rs
@@ -22,10 +22,10 @@ impl<'a, R: UserRepository> CreateCardsFromAnalysisUseCase<'a, R> {
         Self { repository }
     }
 
-    /// Создаёт карточки из списка слов с опциональной пометкой наборов как импортированных.
+    /// Creates cards from a list of words with optional set import marking.
     ///
-    /// - `words` — список слов для создания карточек
-    /// - `set_ids` — ID наборов для пометки как импортированные (None = без пометки)
+    /// - `words` — list of words to create cards from
+    /// - `set_ids` — IDs of sets to mark as imported (None = no marking)
     pub async fn execute(
         &self,
         words: Vec<WordToCreate>,

--- a/origa_landing/src/components/cta.rs
+++ b/origa_landing/src/components/cta.rs
@@ -1,0 +1,20 @@
+use leptos::prelude::*;
+use leptos_router::components::A;
+
+#[component]
+pub(crate) fn CtaSection(
+    title: &'static str,
+    button_text: &'static str,
+    download_href: String,
+) -> impl IntoView {
+    view! {
+        <section class="home-cta">
+            <hr class="home-cta__rule" />
+            <h2 class="home-cta__title">{title}</h2>
+            <A href=download_href attr:class="btn btn-filled">{button_text}</A>
+            <p class="home-cta__platforms">
+                "Windows · Linux · macOS · Android · iOS · Web"
+            </p>
+        </section>
+    }
+}

--- a/origa_landing/src/components/mod.rs
+++ b/origa_landing/src/components/mod.rs
@@ -2,6 +2,8 @@ mod layout;
 mod not_found;
 pub mod seo;
 
+pub(crate) mod cta;
+
 pub use layout::Layout;
 pub use not_found::NotFound;
 pub use seo::{PageMeta, SchemaOrg};

--- a/origa_landing/src/pages/compare.rs
+++ b/origa_landing/src/pages/compare.rs
@@ -1,6 +1,6 @@
 use leptos::prelude::*;
-use leptos_router::components::A;
 
+use crate::components::cta::CtaSection;
 use crate::components::seo::PageMeta;
 use crate::content::Locale;
 
@@ -200,14 +200,7 @@ pub fn ComparePage() -> impl IntoView {
         />
 
         // Section 8: CTA (reuses home-cta dark olive)
-        <section class="home-cta">
-            <hr class="home-cta__rule" />
-            <h2 class="home-cta__title">{c.home_cta_title}</h2>
-            <A href=download_href attr:class="btn btn-filled">{c.home_cta_primary}</A>
-            <p class="home-cta__platforms">
-                "Windows · Linux · macOS · Android · iOS · Web"
-            </p>
-        </section>
+        <CtaSection title=c.home_cta_title button_text=c.home_cta_primary download_href=download_href />
     }
 }
 
@@ -244,12 +237,6 @@ fn ScoreboardCell(
         "partial" => view! {
             <div class="cmp-grid__cell cmp-grid__cell--default">
                 <CompareMarker kind="partial"/>
-                {label}
-            </div>
-        },
-        "no" => view! {
-            <div class="cmp-grid__cell cmp-grid__cell--default">
-                <CompareMarker kind="no"/>
                 {label}
             </div>
         },
@@ -290,12 +277,8 @@ fn CompareMarker(kind: &'static str) -> AnyView {
             <div class="compare-marker compare-marker--partial" aria-label="Partial"></div>
         }
         .into_any(),
-        "no" => view! {
-            <div class="compare-marker compare-marker--no" aria-label="No">"—"</div>
-        }
-        .into_any(),
         _ => view! {
-            <div class="compare-marker compare-marker--no">"—"</div>
+            <div class="compare-marker compare-marker--no" aria-label="No">"—"</div>
         }
         .into_any(),
     }

--- a/origa_landing/src/pages/download.rs
+++ b/origa_landing/src/pages/download.rs
@@ -81,7 +81,7 @@ pub fn DownloadPage() -> impl IntoView {
                     button_text=c.download_button
                 />
                 // iOS — coming soon (no download button)
-                <DownloadCardComingSoon
+                <DownloadCard
                     icon=view! { <IconApple /> }.into_any()
                     name=c.download_ios
                     formats=c.download_ios_formats
@@ -97,34 +97,17 @@ fn DownloadCard(
     #[prop(into)] icon: AnyView,
     name: &'static str,
     formats: &'static str,
-    href: &'static str,
-    button_text: &'static str,
+    #[prop(optional)] href: Option<&'static str>,
+    #[prop(optional)] button_text: Option<&'static str>,
+    #[prop(optional)] badge: Option<&'static str>,
 ) -> impl IntoView {
-    view! {
-        <div class="download-secondary__card">
-            <div class="download-secondary__card-header">
-                <div class="download-icon download-icon--secondary" aria-hidden="true">
-                    {icon}
-                </div>
-                <div>
-                    <p class="download-platform__name">{name}</p>
-                    <p class="download-platform__formats">{formats}</p>
-                </div>
-            </div>
-            <a href=href class="btn">{button_text}" →"</a>
-        </div>
-    }
-}
+    let card_class = match badge {
+        Some(_) => "download-secondary__card download-secondary__card--soon",
+        None => "download-secondary__card",
+    };
 
-#[component]
-fn DownloadCardComingSoon(
-    #[prop(into)] icon: AnyView,
-    name: &'static str,
-    formats: &'static str,
-    badge: &'static str,
-) -> impl IntoView {
     view! {
-        <div class="download-secondary__card download-secondary__card--soon">
+        <div class=card_class>
             <div class="download-secondary__card-header">
                 <div class="download-icon download-icon--secondary" aria-hidden="true">
                     {icon}
@@ -134,7 +117,15 @@ fn DownloadCardComingSoon(
                     <p class="download-platform__formats">{formats}</p>
                 </div>
             </div>
-            <p class="download-coming-soon-badge">{badge}</p>
+            {match (badge, href, button_text) {
+                (Some(badge_text), _, _) => view! {
+                    <p class="download-coming-soon-badge">{badge_text}</p>
+                }.into_any(),
+                (None, Some(href), Some(btn)) => view! {
+                    <a href=href class="btn">{btn}" →"</a>
+                }.into_any(),
+                _ => ().into_any(),
+            }}
         </div>
     }
 }

--- a/origa_landing/src/pages/features.rs
+++ b/origa_landing/src/pages/features.rs
@@ -1,6 +1,6 @@
 use leptos::prelude::*;
-use leptos_router::components::A;
 
+use crate::components::cta::CtaSection;
 use crate::components::seo::{PageMeta, SchemaOrg, how_to_schema};
 use crate::content::Locale;
 
@@ -135,14 +135,7 @@ pub fn FeaturesPage() -> impl IntoView {
         </section>
 
         // Section 5: CTA (reuses home-cta dark olive)
-        <section class="home-cta">
-            <hr class="home-cta__rule" />
-            <h2 class="home-cta__title">{c.home_cta_title}</h2>
-            <A href=download_href attr:class="btn btn-filled">{c.features_cta}</A>
-            <p class="home-cta__platforms">
-                "Windows · Linux · macOS · Android · iOS · Web"
-            </p>
-        </section>
+        <CtaSection title=c.home_cta_title button_text=c.features_cta download_href=download_href />
     }
 }
 

--- a/origa_landing/src/pages/home.rs
+++ b/origa_landing/src/pages/home.rs
@@ -1,6 +1,7 @@
 use leptos::prelude::*;
 use leptos_router::components::A;
 
+use crate::components::cta::CtaSection;
 use crate::components::seo::{
     PageMeta, SchemaOrg, organization_schema, software_application_schema,
 };
@@ -123,14 +124,7 @@ pub fn HomePage() -> impl IntoView {
         <hr class="divider-full" />
 
         // Section 4: Final CTA (dark olive) with platforms
-        <section class="home-cta">
-            <hr class="home-cta__rule" />
-            <h2 class="home-cta__title">{c.home_cta_title}</h2>
-            <A href=download_href attr:class="btn btn-filled">{c.home_cta_primary}</A>
-            <p class="home-cta__platforms">
-                "Windows · Linux · macOS · Android · iOS · Web"
-            </p>
-        </section>
+        <CtaSection title=c.home_cta_title button_text=c.home_cta_primary download_href=download_href />
     }
 }
 

--- a/origa_landing/src/pages/integrations.rs
+++ b/origa_landing/src/pages/integrations.rs
@@ -1,6 +1,6 @@
 use leptos::prelude::*;
-use leptos_router::components::A;
 
+use crate::components::cta::CtaSection;
 use crate::components::seo::PageMeta;
 use crate::content::Locale;
 
@@ -69,11 +69,12 @@ pub fn IntegrationsPage() -> impl IntoView {
                 <IntgSectionHeader number="03" title=c.integrations_section_apps/>
                 <div class="intg-grid-stagger">
                     <div class="intg-grid-stagger__row intg-grid-stagger__row--3-2">
-                        <IntgDuolingoCard
+                        <IntgCard
                             tag=c.integrations_tag_app
                             name=c.integrations_duolingo_name
                             desc=c.integrations_duolingo_desc
                             detail=c.integrations_duolingo_detail
+                            badges=("EN", "RU")
                         />
                         <IntgCard
                             tag=c.integrations_tag_app
@@ -89,7 +90,7 @@ pub fn IntegrationsPage() -> impl IntoView {
                             desc=c.integrations_spy_desc
                             detail=c.integrations_spy_detail
                         />
-                        <IntgAnkiCard
+                        <IntgCard
                             tag=c.integrations_tag_import
                             name=c.integrations_anki_name
                             desc=c.integrations_anki_desc
@@ -101,14 +102,7 @@ pub fn IntegrationsPage() -> impl IntoView {
         </section>
 
         // ── Section 4: CTA ──
-        <section class="home-cta">
-            <hr class="home-cta__rule"/>
-            <h2 class="home-cta__title">{c.home_cta_title}</h2>
-            <A href=download_href attr:class="btn btn-filled">{c.home_cta_primary}</A>
-            <p class="home-cta__platforms">
-                "Windows · Linux · macOS · Android · iOS · Web"
-            </p>
-        </section>
+        <CtaSection title=c.home_cta_title button_text=c.home_cta_primary download_href=download_href />
     }
 }
 
@@ -167,6 +161,7 @@ fn IntgCard(
     name: &'static str,
     desc: &'static str,
     detail: &'static str,
+    #[prop(optional)] badges: Option<(&'static str, &'static str)>,
 ) -> impl IntoView {
     view! {
         <div class="intg-card">
@@ -174,44 +169,12 @@ fn IntgCard(
             <h3 class="intg-card__name">{name}</h3>
             <p class="intg-card__desc">{desc}</p>
             <p class="intg-card__detail">{detail}</p>
-        </div>
-    }
-}
-
-#[component]
-fn IntgDuolingoCard(
-    tag: &'static str,
-    name: &'static str,
-    desc: &'static str,
-    detail: &'static str,
-) -> impl IntoView {
-    view! {
-        <div class="intg-card">
-            <p class="intg-card__tag">{tag}</p>
-            <h3 class="intg-card__name">{name}</h3>
-            <p class="intg-card__desc">{desc}</p>
-            <p class="intg-card__detail">{detail}</p>
-            <div class="intg-card__badges">
-                <span class="intg-card__badge">"EN"</span>
-                <span class="intg-card__badge">"RU"</span>
-            </div>
-        </div>
-    }
-}
-
-#[component]
-fn IntgAnkiCard(
-    tag: &'static str,
-    name: &'static str,
-    desc: &'static str,
-    detail: &'static str,
-) -> impl IntoView {
-    view! {
-        <div class="intg-card">
-            <p class="intg-card__tag">{tag}</p>
-            <h3 class="intg-card__name">{name}</h3>
-            <p class="intg-card__desc">{desc}</p>
-            <p class="intg-card__detail">{detail}</p>
+            {badges.map(|(b1, b2)| view! {
+                <div class="intg-card__badges">
+                    <span class="intg-card__badge">{b1}</span>
+                    <span class="intg-card__badge">{b2}</span>
+                </div>
+            })}
         </div>
     }
 }

--- a/origa_ui/src/loaders/phrase_data_loader.rs
+++ b/origa_ui/src/loaders/phrase_data_loader.rs
@@ -10,7 +10,7 @@ use ulid::Ulid;
 
 use crate::repository::cdn_provider;
 
-#[expect(dead_code, reason = "lazy-load для будущих задач")]
+#[expect(dead_code, reason = "lazy-load for future tasks")]
 pub async fn load_phrase_detail(phrase_id: Ulid) -> Result<PhraseDetail, OrigaError> {
     if let Some(detail) = get_cached_phrase_detail(&phrase_id) {
         return Ok(detail);

--- a/origa_ui/src/repository/trailbase_auth.rs
+++ b/origa_ui/src/repository/trailbase_auth.rs
@@ -56,9 +56,9 @@ pub fn decode_jwt_claims(token: &str) -> Result<JwtClaims, String> {
         }
     }
 
-    // Валидация issuer опциональна: TrailBase может не включать iss в JWT
-    // для некоторых auth flow (OIDC). Когда iss присутствует и не из доверенных
-    // — логируем warning, но не блокируем, т.к. все запросы идут к известному серверу.
+    // Issuer validation is optional: TrailBase may not include iss in JWT
+    // for some auth flows (OIDC). When iss is present and not from trusted
+    // sources — log warning, but don't block, since all requests go to a known server.
     if let Some(ref iss) = claims.iss {
         let is_trusted = iss == "trailbase" || iss == env!("TRAILBASE_URL");
         if !is_trusted {

--- a/origa_ui/src/ui_components/drawer.rs
+++ b/origa_ui/src/ui_components/drawer.rs
@@ -56,7 +56,7 @@ pub fn Drawer(
     view! {
         <Show when=move || is_open.get()>
             <>
-                {/* Используем тот же бэкдроп, что и в модалке, для консистентности */}
+                {/* Use the same backdrop as the modal for consistency */}
                 <div
                     class="modal-backdrop anima-backdrop-enter"
                     on:click=close_drawer
@@ -64,7 +64,7 @@ pub fn Drawer(
                 ></div>
 
                 <div class="drawer-content" data-testid=test_id_val>
-                    {/* Header: фиксированный */}
+                    {/* Header: fixed */}
                     <div class="modal-header">
                         <div>
                             <h3 class="drawer-header">{move || title.get()}</h3>
@@ -83,7 +83,7 @@ pub fn Drawer(
                         </div>
                     </div>
 
-                    {/* Body: скроллируемый контент */}
+                    {/* Body: scrollable content */}
                     <div class="drawer-body">
                         {move || children.with_value(|c| c())}
                     </div>


### PR DESCRIPTION
## Slice-12: Landing DRY + Russian comments

### Landing DRY
- Extracted `CtaSection` component (was copy-pasted ×4 in home, compare, features, integrations)
- Deleted `IntgAnkiCard` — byte-for-byte copy of `IntgCard`
- Merged `IntgDuolingoCard` → `IntgCard` (optional `badges` prop)
- Merged `DownloadCardComingSoon` → `DownloadCard` (optional `badge` prop)
- Simplified `ScoreboardCell`/`CompareMarker` match arms (merged identical branches)

### Russian comments → English (9 total)
- `create_cards_from_analysis.rs`: 1 doc comment block
- `trailbase_auth.rs`: 3 line comments
- `drawer.rs`: 3 JSX comments

### Production string → English
- `phrase_data_loader.rs`: `#[expect]` reason string

### Not changed (by design)
- `kanji.rs` `"Перевод не найден"` — correct fallback for Russian locale
- OCR native/WASM — shared.rs already contains all deduplicatable code

### Verification
- [x] `cargo clippy -D warnings` clean
- [x] `cargo test -p origa` — 1298 passed
- [x] `cargo check -p origa_landing` — SSR builds
- [x] No behavioral changes