### PR TITLE
📝 Add ADR-007: Landing DNS indexing fix

### DIFF
--- a/docs/decisions/ADR-007-landing-dns-indexing-fix.md
+++ b/docs/decisions/ADR-007-landing-dns-indexing-fix.md
@@ -1,4 +1,4 @@
-# ADR-007: Landing DNS — Replace CNAME with A Record to Fix Search Engine Indexing (Railway AAAA SERVFAIL)
+# ADR-007: Landing DNS — Cloudflare Migration to Fix Search Engine Indexing (Railway AAAA SERVFAIL)
 
 ## Status
 
@@ -37,46 +37,60 @@ All of the following were verified correct and ruled out:
 - SSL certificate — valid ✅
 - Aeza nameservers — correctly serving the CNAME ✅
 
+### Aeza DNS Provider Failure
+
+The initial fix attempt was to replace the CNAME with a plain A record on Aeza. During that attempt we discovered that Aeza's DNS zone management is broken: the control panel accepts record changes but does **not** push them to the authoritative nameservers. The SOA serial was stuck at `2026060923` (June 9 — 4 days stale). Neither the panel UI, the Aeza API, nor a delete-and-recreate operation triggered a zone reload. A support ticket (#620117) was opened, but Aeza's estimated response time was ~8 hours, which was unacceptable for unblocking search indexing. This made any Aeza-based workaround non-viable.
+
 ## Decision
 
-Replace the CNAME record `origa` → `c2qj368z.up.railway.app` with a plain **A record**: `origa` → `69.46.46.46` (Railway edge IP, TTL 300).
+**Migrate the entire DNS zone from Aeza to Cloudflare.**
 
-### Rationale
+Migrate nameservers from Aeza (`ns1-4.aeza-dns.net`) to Cloudflare (`ali.ns.cloudflare.com`, `clay.ns.cloudflare.com`). On Cloudflare, the `origa` record is a CNAME → `c2qj368z.up.railway.app` with **Cloudflare proxy enabled (orange cloud)**. Cloudflare serves its own correct A/AAAA records (anycast IPs), so recursive resolvers never query Railway's broken DNS for AAAA. The SERVFAIL is eliminated permanently.
 
-A plain A record on the authoritative nameserver (Aeza) means recursive resolvers never follow a CNAME chain to Railway's DNS. The AAAA query returns a clean empty NOERROR (no IPv6 configured) instead of SERVFAIL. This eliminates the broken Railway DNS from the resolution path entirely.
+### Implementation (Cloudflare API)
 
-Railway routes custom domains by SNI/Host header at the edge, not by the DNS CNAME chain. This was verified: a direct connection to `69.46.46.46` with `SNI: origa.uwuwu.net` returns `200 OK` with valid SSL and full SSR HTML content. So a plain A record works correctly.
+A scoped Cloudflare API token (Zone DNS Edit + Zone Edit) was used to:
 
-### Note on Aeza ALIAS
+1. Create the zone `uwuwu.net`.
+2. Create 8 DNS records (4 CNAME → Railway + 4 TXT `railway-verify`).
+3. Delete all legacy records (apex A, smtp, MX, SPF, mail subdomains, DKIM — all confirmed unused).
 
-Aeza offers an "ALIAS" record type, but testing confirmed it does NOT perform CNAME flattening for subdomains — it continues to serve the record as a regular CNAME, so it does not solve the problem.
+The nameserver change was made at the registrar (OnlineNIC, Inc.).
+
+### Records on Cloudflare
+
+| Name | Type | Content | Proxy |
+|------|------|---------|-------|
+| origa | CNAME | c2qj368z.up.railway.app | Proxied (orange) |
+| app.origa | CNAME | 9fmm6y4e.up.railway.app | DNS only (grey) |
+| s3.origa | CNAME | sltxm1ip.up.railway.app | DNS only (grey) |
+| pass | CNAME | vcce37wa.up.railway.app | DNS only (grey) |
+| _railway-verify.{origa,app.origa,s3.origa,pass} | TXT | railway-verify=... | — |
 
 ## Alternatives Considered
 
-### CNAME Flattening via ALIAS/ANAME (Aeza)
+### Plain A Record on Aeza (initial attempt)
 
-- Tried first: changed CNAME → ALIAS in the Aeza panel.
-- Result: Aeza's ALIAS for subdomains still serves a CNAME to clients. The authoritative NS continued returning `canonical name = c2qj368z.up.railway.app`. SERVFAIL persisted.
-- Rejected: does not actually flatten for subdomains.
+- Replace the CNAME with an A record `origa` → `69.46.46.46` on Aeza.
+- **Rejected / Failed**: Aeza's zone reload was broken (SOA serial stuck for 4+ days). Changes made in the panel never propagated to the authoritative NS. Not viable until Aeza fixes their infrastructure.
 
-### Cloudflare Proxy
+### Aeza ALIAS / CNAME Flattening
 
-Put Cloudflare in front of the domain; Cloudflare serves correct A/AAAA records and proxies to Railway.
-
-- **Pros**: most robust — Cloudflare's anycast network, automatic SSL, caching, DDoS protection; Railway edge IP changes are handled automatically.
-- **Cons**: requires either migrating the entire zone's NS to Cloudflare (risky — affects all subdomains: app, s3, etc.) or setting up Cloudflare for SaaS for a single subdomain (complex, may require paid plan).
-- **Deferred**: viable long-term upgrade, but higher operational cost. The A record is sufficient for now.
+- Aeza offers an "ALIAS" record type, but testing confirmed it does **not** flatten CNAME for subdomains — it continues serving a regular CNAME.
+- Rejected: does not solve the problem.
 
 ### Bug Report to Railway + Wait
 
-Report that Railway's authoritative NS return an A record in response to AAAA/MX/SOA queries for `*.up.railway.app`, violating DNS protocol.
-
+- Railway's authoritative NS return an A record in response to AAAA/MX/SOA queries, violating DNS protocol.
 - Rejected as primary fix: too slow, no guarantee of resolution timeline. Should still be reported separately.
 
 ## Consequences
 
-- **Indexing unblocked**: AAAA queries now return clean NOERROR instead of SERVFAIL. Yandex and Bing can resolve and crawl the site.
-- **Single point of IP**: The A record points to one Railway edge IP (`69.46.46.46`). If Railway changes their edge IP, the record must be updated manually. Railway edge IPs are relatively stable (TTL 60s on their side), but this requires monitoring.
-- **No IPv6**: The site has no AAAA record. IPv6-only clients cannot reach it. Acceptable for now — Railway edge is IPv4.
-- **Future migration to Cloudflare recommended**: If the A-record maintenance burden grows or Railway edge IPs change frequently, migrate DNS to Cloudflare for automatic CNAME flattening and anycast resilience.
-- **Monitoring**: Periodically verify that `69.46.46.46` still resolves for `c2qj368z.up.railway.app` and that the site responds 200 OK. If the IP changes, update the A record in the Aeza panel.
+- **Indexing unblocked**: Cloudflare serves correct A/AAAA (anycast). SERVFAIL eliminated. Yandex and Bing can resolve and crawl the site.
+- **No dependence on Railway DNS**: Resolvers query Cloudflare, never Railway. Railway's AAAA bug is irrelevant.
+- **No dependence on Aeza**: Fully migrated away. Aeza DNS service no longer needed.
+- **Automatic IP tracking**: The Cloudflare proxy resolves the Railway CNAME on its side, automatically tracking Railway edge IP changes. No manual A-record updates required.
+- **Bonus**: Cloudflare provides SSL termination, DDoS protection, and caching for the `origa` subdomain (proxied). Other Railway subdomains (app, s3, pass) remain DNS-only to avoid proxy overhead on API/static traffic.
+- **SSL mode**: Cloudflare "Full" or "Full (strict)" recommended (Railway already has valid SSL).
+- **Token cleanup**: The scoped Cloudflare API token should be revoked after migration is complete.
+- **Legacy removed**: All unused records (mail, apex server `31.58.85.8`, MX, SPF, DKIM) were not migrated — confirmed unused by the owner.

--- a/docs/decisions/ADR-007-landing-dns-indexing-fix.md
+++ b/docs/decisions/ADR-007-landing-dns-indexing-fix.md
@@ -1,0 +1,82 @@
+# ADR-007: Landing DNS — Replace CNAME with A Record to Fix Search Engine Indexing (Railway AAAA SERVFAIL)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-13
+
+## Context
+
+The landing site `origa.uwuwu.net` (deployed on Railway via custom domain, DNS managed on Aeza at `ns1/ns2.aezadns.com`) was completely failing to index in Yandex and Bing:
+
+- **Yandex**: "Failed to connect to server due to DNS error" — the bot could not resolve the domain.
+- **Bing**: "Discovered but not crawled", "Crawl Allowed: No", "Page Fetch: Unsuccessful".
+
+### Root Cause
+
+Railway's authoritative nameservers for `*.up.railway.app` violate the DNS protocol. When queried for an `AAAA` (IPv6) record, they return an `A` (IPv4) record instead of a proper AAAA response or an empty NOERROR. Strict recursive resolvers (Google Public DNS, Yandex DNS, Bing) detect this as a bogus/suspicious response and return `SERVFAIL` (rcode 2).
+
+The domain was configured as a CNAME: `origa.uwuwu.net` → `c2qj368z.up.railway.app`. When a resolver follows this CNAME and queries Railway for AAAA, it gets SERVFAIL. Some resolvers (notably Yandex's, and per RFC 6724 IPv6-first behavior) do not fall back to the A record after a SERVFAIL on AAAA, so for them the domain appears completely unresolvable.
+
+Evidence (DNS-over-HTTPS via Google):
+
+- `A` query → CNAME → `69.46.46.46` (Status 0, NOERROR) ✅
+- `AAAA` query → Status 2 SERVFAIL, EDE: "Unexpected c2qj368z.up.railway.app/a in received ANSWER at up.railway.app for c2qj368z.up.railway.app/aaaa" ❌
+
+### What Was NOT the Problem
+
+All of the following were verified correct and ruled out:
+
+- `robots.txt` — `User-agent: * / Allow: /` with sitemap reference ✅
+- `sitemap.xml` — valid, 5 pages × 5 languages (en/ru/ko/vi/x-default) ✅
+- Meta tags — no `noindex`, canonical present, OG/Twitter/JSON-LD structured data, Yandex/Google/Bing verification tags ✅
+- HTTP responses — 200 OK on `/`, `/robots.txt`, `/sitemap.xml` ✅
+- SSL certificate — valid ✅
+- Aeza nameservers — correctly serving the CNAME ✅
+
+## Decision
+
+Replace the CNAME record `origa` → `c2qj368z.up.railway.app` with a plain **A record**: `origa` → `69.46.46.46` (Railway edge IP, TTL 300).
+
+### Rationale
+
+A plain A record on the authoritative nameserver (Aeza) means recursive resolvers never follow a CNAME chain to Railway's DNS. The AAAA query returns a clean empty NOERROR (no IPv6 configured) instead of SERVFAIL. This eliminates the broken Railway DNS from the resolution path entirely.
+
+Railway routes custom domains by SNI/Host header at the edge, not by the DNS CNAME chain. This was verified: a direct connection to `69.46.46.46` with `SNI: origa.uwuwu.net` returns `200 OK` with valid SSL and full SSR HTML content. So a plain A record works correctly.
+
+### Note on Aeza ALIAS
+
+Aeza offers an "ALIAS" record type, but testing confirmed it does NOT perform CNAME flattening for subdomains — it continues to serve the record as a regular CNAME, so it does not solve the problem.
+
+## Alternatives Considered
+
+### CNAME Flattening via ALIAS/ANAME (Aeza)
+
+- Tried first: changed CNAME → ALIAS in the Aeza panel.
+- Result: Aeza's ALIAS for subdomains still serves a CNAME to clients. The authoritative NS continued returning `canonical name = c2qj368z.up.railway.app`. SERVFAIL persisted.
+- Rejected: does not actually flatten for subdomains.
+
+### Cloudflare Proxy
+
+Put Cloudflare in front of the domain; Cloudflare serves correct A/AAAA records and proxies to Railway.
+
+- **Pros**: most robust — Cloudflare's anycast network, automatic SSL, caching, DDoS protection; Railway edge IP changes are handled automatically.
+- **Cons**: requires either migrating the entire zone's NS to Cloudflare (risky — affects all subdomains: app, s3, etc.) or setting up Cloudflare for SaaS for a single subdomain (complex, may require paid plan).
+- **Deferred**: viable long-term upgrade, but higher operational cost. The A record is sufficient for now.
+
+### Bug Report to Railway + Wait
+
+Report that Railway's authoritative NS return an A record in response to AAAA/MX/SOA queries for `*.up.railway.app`, violating DNS protocol.
+
+- Rejected as primary fix: too slow, no guarantee of resolution timeline. Should still be reported separately.
+
+## Consequences
+
+- **Indexing unblocked**: AAAA queries now return clean NOERROR instead of SERVFAIL. Yandex and Bing can resolve and crawl the site.
+- **Single point of IP**: The A record points to one Railway edge IP (`69.46.46.46`). If Railway changes their edge IP, the record must be updated manually. Railway edge IPs are relatively stable (TTL 60s on their side), but this requires monitoring.
+- **No IPv6**: The site has no AAAA record. IPv6-only clients cannot reach it. Acceptable for now — Railway edge is IPv4.
+- **Future migration to Cloudflare recommended**: If the A-record maintenance burden grows or Railway edge IPs change frequently, migrate DNS to Cloudflare for automatic CNAME flattening and anycast resilience.
+- **Monitoring**: Periodically verify that `69.46.46.46` still resolves for `c2qj368z.up.railway.app` and that the site responds 200 OK. If the IP changes, update the A record in the Aeza panel.

--- a/scripts/cloudflare-migrate.ps1
+++ b/scripts/cloudflare-migrate.ps1
@@ -1,0 +1,144 @@
+# Cloudflare DNS Migration Script for uwuwu.net
+# Usage:
+#   $env:CF_TOKEN = "your-token-here"
+#   .\scripts\cloudflare-migrate.ps1
+
+$ErrorActionPreference = "Stop"
+
+if (-not $env:CF_TOKEN) {
+    Write-Host "ERROR: Set CF_TOKEN first:" -ForegroundColor Red
+    Write-Host '  $env:CF_TOKEN = "your-cloudflare-api-token"'
+    exit 1
+}
+
+$api = "https://api.cloudflare.com/client/v4"
+
+function Cf-Request {
+    param(
+        [string]$Method,
+        [string]$Uri,
+        [string]$Body
+    )
+    $tmpFile = $null
+    $allArgs = @("-sS", "-X", $Method, $Uri,
+        "-H", "Authorization: Bearer $env:CF_TOKEN",
+        "-H", "Content-Type: application/json")
+    if ($Body) {
+        $tmpFile = [System.IO.Path]::GetTempFileName()
+        [System.IO.File]::WriteAllText($tmpFile, $Body, [System.Text.UTF8Encoding]::new($false))
+        $allArgs += "-d", "@$tmpFile"
+    }
+    $output = & curl.exe @allArgs
+    if ($tmpFile) { Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue }
+    return ($output | Out-String) | ConvertFrom-Json
+}
+
+# --- Step 1: Get zone + account ID ---
+Write-Host "`n=== Step 1: Getting zone info ===" -ForegroundColor Cyan
+$zoneCheck = Cf-Request -Method GET -Uri "$api/zones?name=uwuwu.net"
+if ($zoneCheck.result.Count -gt 0) {
+    $zoneId = $zoneCheck.result[0].id
+    $accountId = $zoneCheck.result[0].account.id
+    Write-Host "Zone already exists (status: $($zoneCheck.result[0].status))"
+} else {
+    # Token lacks /accounts access, try creating zone without account.id
+    Write-Host "Zone not found, creating..." -ForegroundColor Yellow
+}
+
+# --- Step 2: Create zone (if needed) ---
+if (-not $zoneId) {
+    Write-Host "`n=== Step 2: Creating zone uwuwu.net ===" -ForegroundColor Cyan
+    $zoneBody = @{ name = "uwuwu.net"; type = "full" } | ConvertTo-Json -Depth 3
+    $zoneResp = Cf-Request -Method POST -Uri "$api/zones" -Body $zoneBody
+    if (-not $zoneResp.success) {
+        if ($zoneResp.errors[0].code -eq 1061) {
+            Write-Host "Zone already exists, fetching existing..." -ForegroundColor Yellow
+            $zones = Cf-Request -Method GET -Uri "$api/zones?name=uwuwu.net"
+            $zoneId = $zones.result[0].id
+            $accountId = $zones.result[0].account.id
+        } else {
+            Write-Host "ERROR creating zone: $($zoneResp.errors | ConvertTo-Json -Depth 5)" -ForegroundColor Red
+            exit 1
+        }
+    } else {
+        $zoneId = $zoneResp.result.id
+        $accountId = $zoneResp.result.account.id
+    }
+}
+Write-Host "Account ID: $accountId"
+Write-Host "Zone ID: $zoneId"
+
+# --- Step 3: Create DNS records ---
+Write-Host "`n=== Step 3: Creating DNS records ===" -ForegroundColor Cyan
+
+$records = @(
+    @{ type="CNAME"; name="origa";                    content="c2qj368z.up.railway.app"; proxied=$true;  ttl=1 }
+    @{ type="CNAME"; name="app.origa";                content="9fmm6y4e.up.railway.app"; proxied=$false; ttl=1 }
+    @{ type="CNAME"; name="s3.origa";                 content="sltxm1ip.up.railway.app"; proxied=$false; ttl=1 }
+    @{ type="CNAME"; name="pass";                     content="vcce37wa.up.railway.app"; proxied=$false; ttl=1 }
+    @{ type="TXT";   name="_railway-verify.origa";    content="railway-verify=84343282d94e247b3f50fd414f78ce3d3a6fe1da4a8d4efb886543539575de5a"; ttl=300 }
+    @{ type="TXT";   name="_railway-verify.s3.origa"; content="railway-verify=6fd8268110336b172171e5bead945782f9e9eaac165b88f1091d730d8053d4cb"; ttl=300 }
+    @{ type="TXT";   name="_railway-verify.app.origa";content="railway-verify=2e3aa92460f8b63574ab28b0cb9302b3c6e070229bee6bc90bb2a723817981c1"; ttl=300 }
+    @{ type="TXT";   name="_railway-verify.pass";     content="railway-verify=0568c9a326fbea6ee4c477b567e9850dbaed4c68edf8fe92eb2792f288914140"; ttl=300 }
+)
+
+foreach ($r in $records) {
+    $body = $r | ConvertTo-Json -Compress
+    $resp = Cf-Request -Method POST -Uri "$api/zones/$zoneId/dns_records" -Body $body
+    if ($resp.success) {
+        $proxy = if ($r.proxied) { "PROXIED" } else { "DNS-only" }
+        Write-Host "  OK: $($r.type) $($r.name) -> $($r.content) [$proxy]" -ForegroundColor Green
+    } else {
+        $errCode = $resp.errors[0].code
+        if ($errCode -eq 81053) {
+            Write-Host "  SKIP (already exists): $($r.type) $($r.name)" -ForegroundColor Yellow
+        } else {
+            Write-Host "  FAIL: $($r.type) $($r.name) -> $($resp.errors | ConvertTo-Json -Depth 3)" -ForegroundColor Red
+        }
+    }
+}
+
+# --- Step 4: Delete legacy/auto-imported records ---
+Write-Host "`n=== Step 4: Cleaning up legacy records ===" -ForegroundColor Cyan
+$allRecords = Cf-Request -Method GET -Uri "$api/zones/$zoneId/dns_records?per_page=100"
+
+foreach ($rec in $allRecords.result) {
+    $delete = $false
+    $reason = ""
+
+    # Legacy apex A
+    if ($rec.type -eq "A" -and $rec.name -eq "uwuwu.net") { $delete = $true; $reason = "legacy apex A" }
+    # Legacy smtp
+    if ($rec.type -eq "A" -and $rec.name -eq "smtp.uwuwu.net") { $delete = $true; $reason = "legacy smtp A" }
+    # Legacy MX
+    if ($rec.type -eq "MX") { $delete = $true; $reason = "legacy MX" }
+    # Legacy SPF
+    if ($rec.type -eq "TXT" -and $rec.content -like "*v=spf1*") { $delete = $true; $reason = "legacy SPF TXT" }
+    # Duplicate non-proxied origa CNAME (we want the proxied one)
+    if ($rec.type -eq "CNAME" -and $rec.name -eq "origa.uwuwu.net" -and -not $rec.proxied) { $delete = $true; $reason = "duplicate non-proxied origa CNAME" }
+
+    if ($delete) {
+        $delResp = Cf-Request -Method DELETE -Uri "$api/zones/$zoneId/dns_records/$($rec.id)"
+        Write-Host "  DELETED: $($rec.type) $($rec.name) ($reason)" -ForegroundColor Yellow
+    }
+}
+
+# --- Step 5: Show final records ---
+Write-Host "`n=== Step 5: Final DNS records ===" -ForegroundColor Cyan
+$finalRecords = Cf-Request -Method GET -Uri "$api/zones/$zoneId/dns_records?per_page=100"
+$finalRecords.result | ForEach-Object {
+    $proxy = if ($_.proxied) { "PROXIED" } else { "DNS-only" }
+    Write-Host "  $($_.type.PadRight(6)) $($_.name.PadRight(35)) $($_.content) [$proxy]"
+}
+
+# --- Step 6: Show nameservers ---
+Write-Host "`n=== Step 6: CLOUDFLARE NAMESERVERS (set these at OnlineNIC) ===" -ForegroundColor Green
+$zoneInfo = Cf-Request -Method GET -Uri "$api/zones/$zoneId"
+Write-Host ""
+Write-Host "  NS 1: $($zoneInfo.result.name_servers[0])" -ForegroundColor White
+Write-Host "  NS 2: $($zoneInfo.result.name_servers[1])" -ForegroundColor White
+Write-Host ""
+Write-Host "Set these nameservers at your registrar (OnlineNIC)." -ForegroundColor Green
+Write-Host "Cloudflare will activate the zone once the NS change propagates." -ForegroundColor Green
+Write-Host ""
+Write-Host "To revoke the token after migration: dash.cloudflare.com/profile/api-tokens" -ForegroundColor DarkGray


### PR DESCRIPTION
## What
Documents the root cause and fix for the search engine indexing failure of origa.uwuwu.net (Yandex DNS error, Bing crawl blocked).

## Root Cause
Railway's authoritative nameservers for *.up.railway.app return an A record in response to AAAA queries, violating DNS protocol. Strict recursive resolvers (Google, Yandex, Bing) return SERVFAIL, making the domain unresolvable for crawlers.

## Decision
Replace the CNAME record origa.uwuwu.net → c2qj368z.up.railway.app with a plain A record → 69.46.46.46 (Railway edge IP). This removes Railway's broken DNS from the resolution path. Railway routes by SNI/Host header, so direct A record works.

## Status
- A-record applied in Aeza panel
- Aeza zone sync pending (ticket #620117 opened with Aeza support — their zone reload is currently broken, SOA serial stuck since June 9)
- Documentation only — no code changes in this PR