### PR TITLE
fix(sync): decode base64 JWT sub correctly to stop cross-device progress loss

### DIFF
--- a/end2end/tests/sync.spec.ts
+++ b/end2end/tests/sync.spec.ts
@@ -1,0 +1,174 @@
+import { testWithFreshUser } from "../fixtures";
+import { skipOnboarding } from "../helpers/navigation";
+import { setupTestUser, uiLogin } from "../helpers/auth";
+import { loginTestUser } from "../fixtures/admin";
+import { fetchWithTimeout } from "../helpers/http";
+import { getTrailBaseUrl } from "../config";
+import { expect, test, type Page } from "@playwright/test";
+
+const NIL_USER_ID = "0".repeat(26);
+
+/**
+ * Reads all IndexedDB keys from the "users" object store. Rejects on database
+ * errors so tests cannot pass for the wrong reason (e.g. empty result masking
+ * a real failure to open the store).
+ */
+async function readUserStoreKeys(page: Page): Promise<string[]> {
+  return await page.evaluate(async (): Promise<string[]> => {
+    return await new Promise<string[]>((resolve, reject) => {
+      const open = indexedDB.open("origa");
+      open.onerror = () => reject(new Error("indexedDB open failed"));
+      open.onupgradeneeded = () => resolve([]);
+      open.onsuccess = () => {
+        const db = open.result;
+        if (!db.objectStoreNames.contains("users")) {
+          resolve([]);
+          return;
+        }
+        const tx = db.transaction("users", "readonly");
+        const store = tx.objectStore("users");
+        const req = store.getAllKeys();
+        req.onsuccess = () => resolve(req.result.map((k) => String(k)));
+        req.onerror = () => reject(new Error("getAllKeys failed"));
+      };
+    });
+  });
+}
+
+/**
+ * Polls IndexedDB until a non-nil user key appears (the canonical record the
+ * app writes after a successful sync) or the timeout elapses. Replaces a fixed
+ * sleep with a deterministic readiness signal.
+ */
+async function waitForCanonicalUserKey(
+  page: Page,
+  timeoutMs = 10_000,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const keys = await readUserStoreKeys(page).catch(() => [] as string[]);
+    const canonical = keys.find((k) => !k.endsWith(`:${NIL_USER_ID}`));
+    if (canonical) return canonical;
+    await page.waitForTimeout(250);
+  }
+  return null;
+}
+
+/**
+ * Counts `user` records owned by the authenticated user whose email matches.
+ * The records API uses a filter expression; we query the canonical table that
+ * the app syncs to.
+ */
+async function countRemoteUserRecords(
+  token: string,
+  email: string,
+): Promise<number> {
+  const url = `${getTrailBaseUrl()}/api/records/v1/user?filter[email][$eq]=${encodeURIComponent(
+    email,
+  )}`;
+  const response = await fetchWithTimeout(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `records list failed: ${response.status} ${await response.text()}`,
+    );
+  }
+  const data = (await response.json()) as { records: unknown[] };
+  return data.records.length;
+}
+
+testWithFreshUser.describe("User Identity Sync", () => {
+  testWithFreshUser(
+    "user id is never nil after login @critical",
+    async ({ page }) => {
+      const nilLogHits: string[] = [];
+      page.on("console", (msg) => {
+        const text = msg.text();
+        if (text.includes(NIL_USER_ID)) {
+          nilLogHits.push(text);
+        }
+      });
+
+      await skipOnboarding(page);
+      await page.waitForURL(/\/home$/, { timeout: 15_000 });
+      await page
+        .getByTestId("home-page")
+        .waitFor({ state: "visible", timeout: 30_000 });
+
+      // Deterministic readiness signal: the canonical (non-nil) user key
+      // must appear in IndexedDB after the synced save flushes.
+      const canonicalKey = await waitForCanonicalUserKey(page);
+      expect(
+        canonicalKey,
+        "Expected a non-nil user key in IndexedDB after login",
+      ).not.toBeNull();
+
+      const keys = await readUserStoreKeys(page);
+      const nilKeys = keys.filter((k) => k.endsWith(`:${NIL_USER_ID}`));
+
+      expect(
+        nilKeys,
+        `IndexedDB must not hold a nil user key; found: ${nilKeys.join(", ")}`,
+      ).toHaveLength(0);
+      expect(
+        nilLogHits,
+        `save must not be attributed to the nil user id; saw: ${nilLogHits.join(" | ")}`,
+      ).toHaveLength(0);
+    },
+  );
+});
+
+test.describe("Multi-browser sync @critical", () => {
+  // NOTE: this test runs browsers A and B sequentially, so it catches the
+  // duplicate-creation regression where a single browser somehow writes two
+  // remote rows. It does NOT cover the harder concurrent-first-login race,
+  // where A and B both call `find_current → None` simultaneously and both
+  // `create` — that is a server-side read-modify-write race in the upsert
+  // path and is out of scope for this client-side fix.
+  test("two browsers on the same account share one remote user record", async ({
+    browser,
+  }) => {
+    const userCtx = await setupTestUser();
+    try {
+      const ctxA = await browser.newContext();
+      const pageA = await ctxA.newPage();
+      await pageA.setViewportSize({ width: 1280, height: 720 });
+      await uiLogin(pageA, userCtx.email, userCtx.password);
+      await skipOnboarding(pageA);
+      await pageA
+        .getByTestId("home-page")
+        .waitFor({ state: "visible", timeout: 30_000 });
+
+      // First browser has flushed a remote record through the synced
+      // save path; there must be exactly one for this email.
+      const { token } = await loginTestUser(userCtx.email, userCtx.password);
+      const countAfterA = await countRemoteUserRecords(token, userCtx.email);
+      // Strict equality: the first browser must produce exactly one
+      // remote record for this account. `toBeGreaterThanOrEqual(1)`
+      // would silently pass even if browser A created two rows (the
+      // duplicate-creation regression this test exists to catch).
+      expect(countAfterA).toBe(1);
+
+      const ctxB = await browser.newContext();
+      const pageB = await ctxB.newPage();
+      await pageB.setViewportSize({ width: 1280, height: 720 });
+      await uiLogin(pageB, userCtx.email, userCtx.password);
+      await skipOnboarding(pageB);
+      await pageB
+        .getByTestId("home-page")
+        .waitFor({ state: "visible", timeout: 30_000 });
+
+      // Second browser must reuse the existing remote record, not
+      // create a duplicate. A duplicate would split progress again.
+      const countAfterB = await countRemoteUserRecords(token, userCtx.email);
+      expect(countAfterB).toBe(countAfterA);
+
+      await ctxA.close();
+      await ctxB.close();
+    } finally {
+      await userCtx.cleanup();
+    }
+  });
+});

--- a/origa/src/domain/user.rs
+++ b/origa/src/domain/user.rs
@@ -95,6 +95,20 @@ impl User {
     }
 
     pub fn merge(&mut self, another_user: &User) {
+        // Remote is the source of truth for identity: a local record must not
+        // override the canonical user id, otherwise saves on the same browser
+        // get attributed to different ids and break cross-device sync.
+        //
+        // Defensive guard: a nil remote id means the remote trailbase_id failed
+        // to decode. Propagating nil here would re-introduce the bug this merge
+        // change is meant to prevent, so when the remote id is nil the local id
+        // is left untouched (non-identity fields are still merged). Callers that
+        // must never observe a nil remote should reject it upstream — see
+        // `TrailBaseUserRepository::find_current`, which returns an error before
+        // reaching merge when the decoded id is nil.
+        if another_user.id != Ulid::nil() {
+            self.id = another_user.id;
+        }
         self.email = another_user.email.clone();
         self.username = another_user.username.clone();
         self.native_language = another_user.native_language;
@@ -520,6 +534,80 @@ mod tests {
         assert!(user1.is_set_imported("set-2"));
         assert!(user1.is_set_imported("set-3"));
         assert_eq!(user1.imported_sets().len(), 3);
+    }
+
+    #[test]
+    fn user_merge_takes_identity_from_remote() {
+        // Remote is the source of truth for identity. A local user created with
+        // a random ULID must adopt the remote id on merge so that subsequent
+        // saves are attributed to the correct canonical user across devices.
+        let mut local = User::new(
+            "local@example.com".to_string(),
+            NativeLanguage::Russian,
+            None,
+        );
+        let local_random_id = local.id();
+        assert_ne!(local_random_id, Ulid::nil());
+
+        let remote_id = Ulid::from_bytes([
+            0x01, 0x67, 0x4f, 0x3a, 0x4e, 0x32, 0xdf, 0x41, 0x8c, 0x6b, 0x27, 0x4e, 0x73, 0x91,
+            0x5f, 0xce,
+        ]);
+        let remote = User::from_row(
+            remote_id,
+            "remote@example.com".to_string(),
+            "remote".to_string(),
+            JlptProgress::new(),
+            NativeLanguage::Russian,
+            None,
+            KnowledgeSet::new(),
+            Utc::now(),
+            HashSet::new(),
+            DailyLoad::default(),
+            0,
+        );
+
+        local.merge(&remote);
+
+        assert_eq!(local.id(), remote_id);
+        assert_ne!(local.id(), local_random_id);
+        assert_ne!(local.id(), Ulid::nil());
+    }
+
+    #[test]
+    fn user_merge_does_not_adopt_nil_remote_id() {
+        // Regression guard for the nil-identity bug: a remote row whose id
+        // failed to decode (nil) must not poison the local id. Otherwise the
+        // "remote is source of truth" rule would re-introduce the cross-device
+        // sync corruption that merge is meant to fix.
+        let mut local = User::new(
+            "local@example.com".to_string(),
+            NativeLanguage::Russian,
+            None,
+        );
+        let local_id_before = local.id();
+        assert_ne!(local_id_before, Ulid::nil());
+
+        let nil_remote = User::from_row(
+            Ulid::nil(),
+            "remote@example.com".to_string(),
+            "remote".to_string(),
+            JlptProgress::new(),
+            NativeLanguage::Russian,
+            None,
+            KnowledgeSet::new(),
+            Utc::now(),
+            HashSet::new(),
+            DailyLoad::default(),
+            0,
+        );
+
+        local.merge(&nil_remote);
+
+        assert_eq!(local.id(), local_id_before);
+        assert_ne!(local.id(), Ulid::nil());
+        // Non-identity fields are still merged.
+        assert_eq!(local.email(), "remote@example.com");
     }
 
     #[test]

--- a/origa_ui/src/pages/login/auth_handlers.rs
+++ b/origa_ui/src/pages/login/auth_handlers.rs
@@ -1,8 +1,12 @@
 use crate::i18n::{I18nContext, Locale};
-use crate::repository::{TrailBaseClient, set_session_async, take_pkce_verifier_async};
+use crate::repository::{
+    TrailBaseClient, get_session, set_session_async, take_pkce_verifier_async, uuid_to_ulid,
+};
 use crate::store::auth_store::AuthStore;
-use origa::domain::{NativeLanguage, User};
+use chrono::Utc;
+use origa::domain::{DailyLoad, JlptProgress, KnowledgeSet, NativeLanguage, User};
 use origa::traits::UserRepository;
+use std::collections::HashSet;
 
 pub async fn get_or_create_profile(
     auth_store: &AuthStore,
@@ -24,15 +28,22 @@ pub async fn get_or_create_profile(
     match auth_store.repository().get_current_user().await {
         Ok(Some(user)) => Ok(user),
         Ok(None) => {
-            let new_user = User::new(email.to_string(), NativeLanguage::Russian, None);
+            let new_user = create_new_user_from_session(email)?;
 
-            auth_store.repository().save(&new_user).await.map_err(|e| {
-                i18n.get_keys_untracked()
-                    .login()
-                    .create_profile_error()
-                    .inner()
-                    .replace("{}", &e.to_string())
-            })?;
+            // First-time profile creation is an explicit sync checkpoint: the
+            // canonical user must exist remotely before any other device can
+            // log in and merge against it.
+            auth_store
+                .repository()
+                .save_sync(&new_user)
+                .await
+                .map_err(|e| {
+                    i18n.get_keys_untracked()
+                        .login()
+                        .create_profile_error()
+                        .inner()
+                        .replace("{}", &e.to_string())
+                })?;
 
             auth_store
                 .repository()
@@ -60,6 +71,46 @@ pub async fn get_or_create_profile(
             .inner()
             .replace("{}", &e.to_string())),
     }
+}
+
+/// Build a brand-new local user whose identity is pinned to the TrailBase
+/// session id (decoded from the JWT `sub`).
+///
+/// `User::new` mints a random ULID, which would diverge from the server-assigned
+/// id and re-introduce the cross-device sync bug where every device ended up
+/// with its own key. We instead derive the id from `session.trailbase_id` so the
+/// first save is already attributed to the canonical user. Field defaults mirror
+/// `User::new`; they are duplicated here only because identity is restricted to
+/// the `merge` change in the domain layer.
+fn create_new_user_from_session(email: &str) -> Result<User, String> {
+    let session = get_session().ok_or_else(|| {
+        "No active session: cannot create user profile without a TrailBase id".to_string()
+    })?;
+
+    let user_id = uuid_to_ulid(&session.trailbase_id);
+    if user_id == ulid::Ulid::nil() {
+        tracing::error!(
+            "Session trailbase_id did not decode to a valid user id: {}",
+            crate::repository::redact_id(&session.trailbase_id)
+        );
+        return Err("Invalid TrailBase session id: please log in again".to_string());
+    }
+
+    let username = email.split('@').next().unwrap_or(email).to_string();
+
+    Ok(User::from_row(
+        user_id,
+        email.to_string(),
+        username,
+        JlptProgress::new(),
+        NativeLanguage::Russian,
+        None,
+        KnowledgeSet::new(),
+        Utc::now(),
+        HashSet::new(),
+        DailyLoad::default(),
+        0,
+    ))
 }
 
 pub async fn handle_oauth_callback(

--- a/origa_ui/src/pages/onboarding/onboarding_actions.rs
+++ b/origa_ui/src/pages/onboarding/onboarding_actions.rs
@@ -32,6 +32,11 @@ where
             user.mark_set_as_imported("__onboarding_skipped__".to_string());
             recalculate_user_jlpt_progress(&mut user);
 
+            // Hard block on remote failure: completing onboarding is a sync
+            // checkpoint, so the user must not proceed to /home without a
+            // canonical remote record. This differs from the import path
+            // below, which logs and continues because the import itself has
+            // already committed locally by the time this save runs.
             if let Err(e) = repo.save_sync(&user).await {
                 tracing::error!("Onboarding skip: save error: {:?}", e);
                 return;

--- a/origa_ui/src/repository/file_repository.rs
+++ b/origa_ui/src/repository/file_repository.rs
@@ -6,15 +6,15 @@ use origa::{
 use ulid::Ulid;
 use wasm_bindgen::JsValue;
 
-const DB_NAME: &str = "origa";
-const DB_VERSION: u32 = 1;
-const STORE_NAME: &str = "users";
+pub(crate) const DB_NAME: &str = "origa";
+pub(crate) const DB_VERSION: u32 = 1;
+pub(crate) const STORE_NAME: &str = "users";
 
-fn user_key(user_id: Ulid) -> String {
+pub(crate) fn user_key(user_id: Ulid) -> String {
     format!("user:{}", user_id)
 }
 
-async fn open_database() -> Result<Database, OrigaError> {
+pub(crate) async fn open_database() -> Result<Database, OrigaError> {
     let factory = Factory::new().map_err(|e| {
         let reason = format!("Failed to create IndexedDB factory: {:?}", e);
         tracing::error!("{}", reason);
@@ -108,6 +108,13 @@ impl FileSystemUserRepository {
 
 impl UserRepository for FileSystemUserRepository {
     async fn get_current_user(&self) -> Result<Option<User>, OrigaError> {
+        // Self-heal legacy nil-keyed rows before reading so that the first
+        // read after upgrade returns the canonical record. Migration errors are
+        // non-fatal: the read still proceeds against whatever rows exist.
+        if let Err(e) = super::legacy_migration::migrate_nil_users_to_session_id().await {
+            tracing::warn!("Legacy nil-user migration skipped: {:?}", e);
+        }
+
         let users = self.list_users().await?;
         Ok(users.first().cloned())
     }

--- a/origa_ui/src/repository/hybrid_repository.rs
+++ b/origa_ui/src/repository/hybrid_repository.rs
@@ -67,29 +67,46 @@ impl UserRepository for HybridUserRepository {
         self.local.get_current_user().await
     }
 
+    // Local-only write on the hot path. Rating a card, marking it known, or
+    // creating one are high-frequency actions; awaiting a remote round-trip
+    // here would block the core study loop (especially on mobile). The local
+    // write is authoritative for the device; cross-device propagation happens
+    // through `save_sync` at explicit checkpoints (onboarding, imports, auth)
+    // and through `merge_current_user` on login. The user id is already
+    // canonical thanks to the session-derived ULID, so a local-only save is
+    // correctly attributed to the right identity.
     async fn save(&self, user: &User) -> Result<(), OrigaError> {
-        tracing::info!("save: Starting save for user {}", user.id());
+        tracing::info!("save: Starting local save for user {}", user.id());
         self.local.save(user).await?;
-        tracing::info!("save: Local save completed");
+        tracing::info!("save: Local save completed for user {}", user.id());
         Ok(())
     }
 
+    // Explicit sync checkpoint: local + remote. Used by auth, onboarding, and
+    // imports where a network round-trip is acceptable and the data must reach
+    // the server before the user can switch devices.
+    //
+    // The local write runs first so the device stays usable offline even when
+    // the network is down. Remote failures are then surfaced as `Err` instead
+    // of being swallowed: a silent `Ok` here is what allowed the cross-device
+    // split-progress bug, because the initial profile create would log a remote
+    // error and return `Ok`, so the user moved on without a canonical remote
+    // record and the next device's login found nothing to merge against.
     async fn save_sync(&self, user: &User) -> Result<(), OrigaError> {
+        tracing::info!("save_sync: Starting save for user {}", user.id());
         self.local.save(user).await?;
-        tracing::info!("save_sync: Local save completed");
+        tracing::info!("save_sync: Local save completed for user {}", user.id());
 
-        match self.remote.save(user).await {
-            Ok(_) => {
-                tracing::info!("save_sync: Remote save completed");
-            },
-            Err(e) => {
-                tracing::error!(
-                    "save_sync: Remote save failed: {:?}. Local save is still valid.",
-                    e
-                );
-            },
+        if let Err(e) = self.remote.save(user).await {
+            tracing::error!(
+                "save_sync: Remote save failed for user {}: {:?}. Local save kept; surfacing error to caller.",
+                user.id(),
+                e
+            );
+            return Err(e);
         }
 
+        tracing::info!("save_sync: Remote save completed for user {}", user.id());
         Ok(())
     }
 

--- a/origa_ui/src/repository/legacy_migration.rs
+++ b/origa_ui/src/repository/legacy_migration.rs
@@ -1,0 +1,152 @@
+//! One-shot migration of pre-fix user records keyed under the nil ULID.
+//!
+//! Before the `uuid_to_ulid` fix, every local save was written to IndexedDB
+//! under `user:00000000000000000000000000` because the JWT `sub` was parsed as
+//! hex and collapsed to `Ulid::nil()`. After the fix the canonical id is
+//! derived from the session, so new saves land on `user:{correct_id}` — but the
+//! old nil-keyed record still holds the user's accumulated progress and would
+//! be returned nondeterministically by `get_current_user` (which takes the
+//! first row in the store).
+//!
+//! This module re-keys such legacy rows to the canonical id derived from the
+//! active session and deletes the stale nil row, preserving progress across
+//! the upgrade. The migration runs at most once per browser: a LocalStorage
+//! gate flag is set after the first attempt (success or no-op), and the whole
+//! re-key happens inside a single read-write transaction so concurrent reads
+//! never observe both keys at once.
+
+use chrono::Utc;
+use gloo_storage::{LocalStorage, Storage};
+use origa::domain::{OrigaError, User};
+use ulid::Ulid;
+
+use super::session::get_session;
+use super::uuid_to_ulid;
+
+#[path = "legacy_migration_idb.rs"]
+mod legacy_migration_idb;
+#[path = "legacy_migration_rekey.rs"]
+mod legacy_migration_rekey;
+use legacy_migration_rekey::rekey_nil_rows_in_single_transaction;
+
+const MIGRATION_GATE_KEY: &str = "origa_nil_migration_v1";
+
+pub(super) fn migration_err<E: std::fmt::Debug>(prefix: &str, e: E) -> OrigaError {
+    OrigaError::RepositoryError {
+        reason: format!("{prefix}: {e:?}"),
+    }
+}
+
+/// Re-keys any user rows stored under the nil ULID to the id encoded in the
+/// active session. Returns the number of rows migrated. Runs at most once per
+/// browser via a LocalStorage gate; subsequent calls are a cheap no-op.
+///
+/// The gate is only set once a session is available, so a user whose JWT has
+/// expired on first post-upgrade launch does not permanently strand a nil-keyed
+/// record: the next authenticated run retries.
+pub(crate) async fn migrate_nil_users_to_session_id() -> Result<usize, OrigaError> {
+    if migration_already_done() {
+        return Ok(0);
+    }
+
+    let correct_id = match resolve_canonical_id() {
+        Some(id) => id,
+        // No session yet: defer both the migration and the gate so the next
+        // authenticated launch can re-key the legacy record.
+        None => return Ok(0),
+    };
+
+    let migrated = rekey_nil_rows_in_single_transaction(correct_id).await?;
+
+    mark_migration_done();
+    if migrated > 0 {
+        tracing::info!(
+            "Migrated {} legacy user record(s) from nil key to {}",
+            migrated,
+            correct_id
+        );
+    }
+    Ok(migrated)
+}
+
+fn migration_already_done() -> bool {
+    LocalStorage::get::<bool>(MIGRATION_GATE_KEY).unwrap_or(false)
+}
+
+fn mark_migration_done() {
+    if let Err(e) = LocalStorage::set(MIGRATION_GATE_KEY, true) {
+        tracing::warn!("Failed to persist nil-user migration gate: {}", e);
+    }
+}
+
+fn resolve_canonical_id() -> Option<Ulid> {
+    let session = get_session()?;
+    canonical_id_from_trailbase_id(&session.trailbase_id)
+}
+
+/// Pure projection of a session's `trailbase_id` onto the canonical `Ulid`.
+/// Extracted from `resolve_canonical_id` so the encoding/empty/nil rules are
+/// unit-testable without a browser session: callers that already hold a
+/// session string can reuse this directly.
+fn canonical_id_from_trailbase_id(trailbase_id: &str) -> Option<Ulid> {
+    if trailbase_id.is_empty() {
+        return None;
+    }
+    let id = uuid_to_ulid(trailbase_id);
+    (id != Ulid::nil()).then_some(id)
+}
+
+/// Rebuild a legacy user row under the canonical id. The domain `User` has no
+/// id setter (identity is owned by the remote), so the row is rebuilt through
+/// `from_row` with the canonical id and every other field copied verbatim.
+pub(super) fn reseat_user_id(legacy: &User, new_id: Ulid) -> User {
+    User::from_row(
+        new_id,
+        legacy.email().to_string(),
+        legacy.username().to_string(),
+        legacy.jlpt_progress().clone(),
+        *legacy.native_language(),
+        legacy.telegram_user_id().copied(),
+        legacy.knowledge_set().clone(),
+        *legacy.updated_at(),
+        legacy.imported_sets().clone(),
+        *legacy.daily_load(),
+        legacy.known_vocab_hash(),
+    )
+}
+
+/// Merge progress accumulated under the legacy nil key into the canonical row.
+///
+/// Identity and profile fields (id, email, username, native_language,
+/// telegram_user_id, daily_load) stay canonical because the remote is the
+/// source of truth — `User::merge` is intentionally avoided here because it
+/// overwrites email/username, which would let a stale local copy clobber the
+/// canonical profile. Only the progress collections the user accumulated
+/// locally (knowledge_set, imported_sets) are unioned in so nothing is lost.
+pub(super) fn merge_legacy_progress_into_canonical(canonical: &User, legacy: &User) -> User {
+    let mut merged_knowledge = canonical.knowledge_set().clone();
+    merged_knowledge.merge(legacy.knowledge_set());
+
+    let mut merged_imported_sets = canonical.imported_sets().clone();
+    for set_id in legacy.imported_sets() {
+        merged_imported_sets.insert(set_id.clone());
+    }
+
+    User::from_row(
+        canonical.id(),
+        canonical.email().to_string(),
+        canonical.username().to_string(),
+        canonical.jlpt_progress().clone(),
+        *canonical.native_language(),
+        canonical.telegram_user_id().copied(),
+        merged_knowledge,
+        Utc::now(),
+        merged_imported_sets,
+        *canonical.daily_load(),
+        canonical.known_vocab_hash(),
+    )
+}
+
+#[cfg(test)]
+#[path = "legacy_migration_tests.rs"]
+mod tests;

--- a/origa_ui/src/repository/legacy_migration_idb.rs
+++ b/origa_ui/src/repository/legacy_migration_idb.rs
@@ -1,0 +1,80 @@
+//! Primitive IndexedDB operations used by the nil-user migration.
+//!
+//! Each helper wraps a single idb request and maps its error into
+//! `OrigaError::RepositoryError` with a stable prefix so failures are easy to
+//! attribute in logs. Callers are responsible for transaction lifecycle: every
+//! function here operates on a store obtained from an already-open transaction,
+//! so a sequence of reads/writes either commits together or not at all.
+
+use idb::ObjectStore;
+use origa::domain::{OrigaError, User};
+use ulid::Ulid;
+use wasm_bindgen::JsValue;
+
+use super::migration_err;
+use crate::repository::file_repository::user_key;
+
+/// Read the user stored under the given id, if any. Returns `None` when the
+/// key is absent or holds a null/undefined value. Corrupt rows are logged and
+/// treated as missing so a single bad entry cannot abort the whole migration.
+pub(super) async fn read_row(store: &ObjectStore, id: Ulid) -> Result<Option<User>, OrigaError> {
+    let key = JsValue::from_str(&user_key(id));
+    let value = store
+        .get(key)
+        .map_err(|e| migration_err("Migration row read failed", e))?
+        .await
+        .map_err(|e| migration_err("Migration row read await failed", e))?;
+
+    let Some(value) = value.filter(|v| !v.is_null() && !v.is_undefined()) else {
+        return Ok(None);
+    };
+
+    match serde_wasm_bindgen::from_value::<User>(value) {
+        Ok(user) => Ok(Some(user)),
+        Err(e) => {
+            tracing::warn!("Skipping corrupted user entry for {id}: {e:?}");
+            Ok(None)
+        },
+    }
+}
+
+/// Returns true when a row exists under the canonical id. Uses `count` rather
+/// than `get` so the store never materialises the value — existence is all the
+/// migration needs to decide between reseat and merge.
+pub(super) async fn row_exists(store: &ObjectStore, id: Ulid) -> Result<bool, OrigaError> {
+    let key = idb::Query::Key(JsValue::from_str(&user_key(id)));
+    let count = store
+        .count(Some(key))
+        .map_err(|e| migration_err("Migration row count failed", e))?
+        .await
+        .map_err(|e| migration_err("Migration row count await failed", e))?;
+    Ok(count > 0)
+}
+
+/// Write a user under the given id, overwriting any existing row.
+pub(super) async fn write_row(
+    store: &ObjectStore,
+    user: &User,
+    id: Ulid,
+) -> Result<(), OrigaError> {
+    let value = serde_wasm_bindgen::to_value(user)
+        .map_err(|e| migration_err("Migration serialize failed", e))?;
+    let key = JsValue::from_str(&user_key(id));
+    store
+        .put(&value, Some(&key))
+        .map_err(|e| migration_err("Migration put failed", e))?
+        .await
+        .map_err(|e| migration_err("Migration put await failed", e))?;
+    Ok(())
+}
+
+/// Delete the row stored under the given id, if any.
+pub(super) async fn delete_row(store: &ObjectStore, id: Ulid) -> Result<(), OrigaError> {
+    let key = JsValue::from_str(&user_key(id));
+    store
+        .delete(key)
+        .map_err(|e| migration_err("Migration delete failed", e))?
+        .await
+        .map_err(|e| migration_err("Migration delete await failed", e))?;
+    Ok(())
+}

--- a/origa_ui/src/repository/legacy_migration_rekey.rs
+++ b/origa_ui/src/repository/legacy_migration_rekey.rs
@@ -1,0 +1,108 @@
+//! IndexedDB orchestration for the nil-user re-key.
+//!
+//! Houses the single read-write transaction that atomically reseats a legacy
+//! nil-keyed user row under the canonical id (or merges it into an existing
+//! canonical row) and then deletes the stale nil row. Kept in its own module
+//! so the pure decision functions (`reseat_user_id`,
+//! `merge_legacy_progress_into_canonical`) in the parent module stay
+//! independently unit-testable without dragging in idb wiring.
+
+use idb::TransactionMode;
+use origa::domain::{OrigaError, User};
+use ulid::Ulid;
+
+use super::legacy_migration_idb::{delete_row, read_row, row_exists, write_row};
+use super::{merge_legacy_progress_into_canonical, migration_err, reseat_user_id};
+use crate::repository::file_repository::{STORE_NAME, open_database};
+
+/// Read-modify-write the nil-keyed row into the canonical id inside one
+/// transaction. Returns 1 when a legacy row was migrated, 0 when there was
+/// nothing to re-key. The transaction commits only after both the canonical
+/// write and the nil delete succeed, so concurrent readers never observe both
+/// keys at once.
+pub(super) async fn rekey_nil_rows_in_single_transaction(
+    correct_id: Ulid,
+) -> Result<usize, OrigaError> {
+    let db = open_database().await?;
+    let transaction = db
+        .transaction(&[STORE_NAME], TransactionMode::ReadWrite)
+        .map_err(|e| migration_err("Migration transaction failed", e))?;
+    let store = transaction
+        .object_store(STORE_NAME)
+        .map_err(|e| migration_err("Migration store failed", e))?;
+
+    let legacy = read_nil_row(&store).await?;
+    let Some(legacy) = legacy else {
+        return Ok(0);
+    };
+
+    apply_rekey_strategy(&store, &legacy, correct_id).await?;
+    delete_row(&store, Ulid::nil()).await?;
+
+    transaction
+        .await
+        .map_err(|e| migration_err("Migration commit failed", e))?;
+    Ok(1)
+}
+
+/// Decide between reseat (no canonical row) and merge (canonical row exists)
+/// and write the resulting row under the canonical id. The decision is kept
+/// inside the open transaction so a canonical row that appears between the
+/// existence check and the write is still observed atomically.
+async fn apply_rekey_strategy(
+    store: &idb::ObjectStore,
+    legacy: &User,
+    correct_id: Ulid,
+) -> Result<(), OrigaError> {
+    if !row_exists(store, correct_id).await? {
+        // No canonical row yet: simply reseat the legacy row under the
+        // canonical key, preserving all accumulated progress verbatim.
+        let reseated = reseat_user_id(legacy, correct_id);
+        write_row(store, &reseated, correct_id).await?;
+        return Ok(());
+    }
+
+    // A canonical row already exists (e.g. the user logged in on another
+    // device before upgrading this one). The legacy nil-keyed row still holds
+    // progress accumulated on this device; merge it into the canonical row
+    // instead of discarding it. Discarding was the previous behaviour and
+    // silently destroyed local progress.
+    let canonical = read_row(store, correct_id).await?;
+    match canonical {
+        None => {
+            // row_exists said yes but the read returned nothing — a race or
+            // corruption. Fall back to reseating the legacy row so progress is
+            // never silently dropped.
+            tracing::warn!(
+                "Canonical row vanished between count and read for {}; reseating legacy",
+                correct_id
+            );
+            let reseated = reseat_user_id(legacy, correct_id);
+            write_row(store, &reseated, correct_id).await?;
+        },
+        Some(canonical) => {
+            let merged = merge_legacy_progress_into_canonical(&canonical, legacy);
+            tracing::info!(
+                "Merged legacy nil-keyed progress into canonical row for {}",
+                correct_id
+            );
+            write_row(store, &merged, correct_id).await?;
+        },
+    }
+    Ok(())
+}
+
+/// Read the user held under the nil key, but only if its stored id is actually
+/// nil — the key is just a string, so a non-nil id means the row is already
+/// canonical and there is nothing to migrate.
+async fn read_nil_row(store: &idb::ObjectStore) -> Result<Option<User>, OrigaError> {
+    let Some(user) = read_row(store, Ulid::nil()).await? else {
+        return Ok(None);
+    };
+    if user.id() == Ulid::nil() {
+        Ok(Some(user))
+    } else {
+        tracing::debug!("Nil-key slot holds a non-nil user, nothing to migrate");
+        Ok(None)
+    }
+}

--- a/origa_ui/src/repository/legacy_migration_tests.rs
+++ b/origa_ui/src/repository/legacy_migration_tests.rs
@@ -1,0 +1,283 @@
+use super::*;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::Utc;
+use origa::domain::{
+    Card, DailyLoad, JlptProgress, KnowledgeSet, NativeLanguage, PhraseCard, User,
+};
+use std::collections::HashSet;
+
+const CANONICAL_ID_BYTES: [u8; 16] = [
+    0x01, 0x67, 0x4f, 0x3a, 0x4e, 0x32, 0xdf, 0x41, 0x8c, 0x6b, 0x27, 0x4e, 0x73, 0x91, 0x5f, 0xce,
+];
+
+fn canonical_id() -> Ulid {
+    Ulid::from_bytes(CANONICAL_ID_BYTES)
+}
+
+fn build_user_with_id(id: Ulid) -> User {
+    User::from_row(
+        id,
+        "legacy@example.com".to_string(),
+        "legacy".to_string(),
+        JlptProgress::new(),
+        NativeLanguage::Russian,
+        None,
+        KnowledgeSet::new(),
+        Utc::now(),
+        HashSet::new(),
+        DailyLoad::default(),
+        0,
+    )
+}
+
+/// Build a canonical-row user with profile fields deliberately different from
+/// the legacy row, so any accidental clobber during merge is observable in
+/// assertions. Identity is `canonical_id()`; email/username/native_language
+/// are distinct from `build_user_with_id`.
+fn build_canonical_user() -> User {
+    User::from_row(
+        canonical_id(),
+        "canonical@example.com".to_string(),
+        "canonical".to_string(),
+        JlptProgress::new(),
+        NativeLanguage::English,
+        Some(99),
+        KnowledgeSet::new(),
+        Utc::now(),
+        HashSet::new(),
+        DailyLoad::default(),
+        0,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// reseat_user_id
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reseat_user_id_changes_only_id() {
+    let nil_user = build_user_with_id(Ulid::nil());
+
+    let reseated = reseat_user_id(&nil_user, canonical_id());
+
+    assert_eq!(reseated.id(), canonical_id());
+    assert_ne!(reseated.id(), Ulid::nil());
+    assert_eq!(reseated.email(), nil_user.email());
+    assert_eq!(reseated.username(), nil_user.username());
+}
+
+#[test]
+fn reseat_user_id_preserves_all_non_identity_fields() {
+    let original = build_user_with_id(Ulid::nil());
+
+    let reseated = reseat_user_id(&original, Ulid::new());
+
+    assert_eq!(reseated.email(), original.email());
+    assert_eq!(reseated.username(), original.username());
+    assert_eq!(reseated.native_language(), original.native_language());
+    assert_eq!(reseated.known_vocab_hash(), original.known_vocab_hash());
+}
+
+// ---------------------------------------------------------------------------
+// merge_legacy_progress_into_canonical (Common #1 fix)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn merge_keeps_canonical_identity_not_legacy() {
+    // Regression guard for the discard→merge fix: identity must come from the
+    // canonical row, never from the legacy nil-keyed row, otherwise the
+    // cross-device split-progress bug returns.
+    let canonical = build_canonical_user();
+    let legacy = build_user_with_id(Ulid::nil());
+
+    let merged = merge_legacy_progress_into_canonical(&canonical, &legacy);
+
+    assert_eq!(merged.id(), canonical_id());
+    assert_eq!(merged.email(), "canonical@example.com");
+    assert_eq!(merged.username(), "canonical");
+}
+
+#[test]
+fn merge_keeps_canonical_profile_fields() {
+    // native_language and telegram_user_id are profile fields owned by the
+    // remote; the legacy row must not overwrite them even when it was the
+    // source of the user's local progress.
+    let canonical = build_canonical_user();
+    let legacy = build_user_with_id(Ulid::nil());
+
+    let merged = merge_legacy_progress_into_canonical(&canonical, &legacy);
+
+    assert_eq!(*merged.native_language(), NativeLanguage::English);
+    assert_eq!(merged.telegram_user_id(), Some(&99));
+}
+
+#[test]
+fn merge_unions_imported_sets() {
+    let mut canonical = build_canonical_user();
+    canonical.mark_set_as_imported("set_canonical".to_string());
+
+    let mut legacy = build_user_with_id(Ulid::nil());
+    legacy.mark_set_as_imported("set_legacy_a".to_string());
+    legacy.mark_set_as_imported("set_legacy_b".to_string());
+
+    let merged = merge_legacy_progress_into_canonical(&canonical, &legacy);
+
+    let imported: HashSet<&str> = merged.imported_sets().iter().map(String::as_str).collect();
+    assert!(imported.contains("set_canonical"));
+    assert!(imported.contains("set_legacy_a"));
+    assert!(imported.contains("set_legacy_b"));
+    assert_eq!(imported.len(), 3);
+}
+
+#[test]
+fn merge_does_not_drop_legacy_progress_when_canonical_exists() {
+    // The core Common #1 regression: previously, when a canonical row existed,
+    // the legacy nil-keyed row was deleted outright and its accumulated
+    // imported_sets were lost. The merge must preserve every legacy
+    // imported_set marker.
+    let canonical = build_canonical_user();
+    let mut legacy = build_user_with_id(Ulid::nil());
+    legacy.mark_set_as_imported("legacy_only".to_string());
+
+    let merged = merge_legacy_progress_into_canonical(&canonical, &legacy);
+
+    assert!(
+        merged.is_set_imported("legacy_only"),
+        "legacy imported_set must survive the merge, not be discarded"
+    );
+}
+
+#[test]
+fn merge_handles_empty_legacy_without_change() {
+    let canonical = build_canonical_user();
+    let legacy = build_user_with_id(Ulid::nil());
+
+    let merged = merge_legacy_progress_into_canonical(&canonical, &legacy);
+
+    assert_eq!(merged.id(), canonical.id());
+    assert_eq!(merged.email(), canonical.email());
+    assert!(merged.imported_sets().is_empty());
+}
+
+#[test]
+fn merge_touches_updated_at() {
+    // The merged row is a fresh write to IndexedDB; its updated_at must move
+    // forward so subsequent sync sees it as newer than the canonical source.
+    let canonical = build_canonical_user();
+    let canonical_updated_at = *canonical.updated_at();
+    let legacy = build_user_with_id(Ulid::nil());
+
+    let merged = merge_legacy_progress_into_canonical(&canonical, &legacy);
+
+    assert!(*merged.updated_at() >= canonical_updated_at);
+}
+
+#[test]
+fn merge_preserves_legacy_knowledge_set_cards() {
+    // The main progress payload lives in knowledge_set (SRS state for every
+    // card the user studied). A regression that drops the
+    // `merged_knowledge.merge(legacy.knowledge_set())` call would pass every
+    // other merge test, because the other builders leave knowledge_set empty.
+    // PhraseCard::new is dictionary-free, so this test stays hermetic.
+    let canonical = build_canonical_user();
+
+    let mut legacy = build_user_with_id(Ulid::nil());
+    let legacy_card_id = *legacy
+        .create_card(Card::Phrase(PhraseCard::new(Ulid::new())))
+        .unwrap()
+        .card_id();
+
+    let merged = merge_legacy_progress_into_canonical(&canonical, &legacy);
+
+    assert!(
+        merged.knowledge_set().get_card(legacy_card_id).is_some(),
+        "legacy knowledge_set card must survive the merge, not be discarded"
+    );
+    assert_eq!(
+        merged.knowledge_set().study_cards().len(),
+        1,
+        "exactly the legacy card should be present (canonical had none)"
+    );
+}
+
+#[test]
+fn merge_unions_canonical_and_legacy_knowledge_set_cards() {
+    // Both sides contribute cards; the union must keep every card id from
+    // both the canonical and the legacy row.
+    let mut canonical = build_canonical_user();
+    let canonical_card_id = *canonical
+        .create_card(Card::Phrase(PhraseCard::new(Ulid::new())))
+        .unwrap()
+        .card_id();
+
+    let mut legacy = build_user_with_id(Ulid::nil());
+    let legacy_card_id = *legacy
+        .create_card(Card::Phrase(PhraseCard::new(Ulid::new())))
+        .unwrap()
+        .card_id();
+
+    let merged = merge_legacy_progress_into_canonical(&canonical, &legacy);
+
+    assert!(merged.knowledge_set().get_card(canonical_card_id).is_some());
+    assert!(merged.knowledge_set().get_card(legacy_card_id).is_some());
+    assert_eq!(merged.knowledge_set().study_cards().len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// canonical_id_from_trailbase_id (resolve_canonical_id pure half)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn canonical_id_returns_none_for_empty_trailbase_id() {
+    // No session id means we cannot derive a canonical id; deferring the
+    // migration (rather than guessing) is the correct outcome.
+    assert!(canonical_id_from_trailbase_id("").is_none());
+}
+
+#[test]
+fn canonical_id_returns_none_for_undecodable_trailbase_id() {
+    // uuid_to_ulid fails safe to nil for garbage input; the canonical-id
+    // resolver must treat nil as "no id" and return None so the migration
+    // defers instead of re-keying everything under nil again.
+    assert!(canonical_id_from_trailbase_id("not-a-valid-id").is_none());
+}
+
+#[test]
+fn canonical_id_returns_some_for_valid_base64_url_no_pad() {
+    let expected = canonical_id();
+    let encoded = URL_SAFE_NO_PAD.encode(expected.to_bytes());
+
+    let resolved = canonical_id_from_trailbase_id(&encoded);
+
+    assert_eq!(resolved, Some(expected));
+}
+
+#[test]
+fn canonical_id_returns_some_for_valid_hex_uuid() {
+    let expected = canonical_id();
+    let bytes = expected.to_bytes();
+    let hex = format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+    );
+
+    let resolved = canonical_id_from_trailbase_id(&hex);
+
+    assert_eq!(resolved, Some(expected));
+}

--- a/origa_ui/src/repository/mod.rs
+++ b/origa_ui/src/repository/mod.rs
@@ -3,9 +3,11 @@ pub mod cdn_provider;
 mod dictionary_cache;
 mod file_repository;
 mod hybrid_repository;
+pub(crate) mod legacy_migration;
 mod session;
 pub mod trailbase_auth;
 pub mod trailbase_client;
+pub(crate) mod trailbase_id;
 mod trailbase_records;
 mod trailbase_repository;
 pub mod trailbase_session;
@@ -15,7 +17,9 @@ pub use cdn_provider::cdn as cdn_provider;
 pub use dictionary_cache::{get_cached_dictionary_rkyv, save_dictionary_to_cache_rkyv};
 pub use hybrid_repository::HybridUserRepository;
 pub use session::{
-    clear_session, clear_session_async, get_session_async, migrate_session_to_store_if_needed,
-    set_last_sync_time, set_pkce_verifier_async, set_session_async, take_pkce_verifier_async,
+    clear_session, clear_session_async, get_session, get_session_async,
+    migrate_session_to_store_if_needed, set_last_sync_time, set_pkce_verifier_async,
+    set_session_async, take_pkce_verifier_async,
 };
 pub use trailbase_client::{AuthError, OAuthProvider, TrailBaseClient};
+pub(crate) use trailbase_id::{redact as redact_id, uuid_to_ulid};

--- a/origa_ui/src/repository/trailbase_id.rs
+++ b/origa_ui/src/repository/trailbase_id.rs
@@ -1,0 +1,194 @@
+//! Conversion between the TrailBase user id (JWT `sub`) and the `Ulid` used
+//! throughout the app as the canonical user identity.
+//!
+//! TrailBase encodes the user UUID as url-safe base64, but to stay robust across
+//! server/auth-provider changes this module accepts three encodings in order:
+//! url-safe base64 without padding, url-safe base64 with padding, and a
+//! canonical hex UUID with dashes. Any input that does not decode to exactly
+//! 16 bytes fails safe to `Ulid::nil()` and emits a warning so callers can guard
+//! against the nil value (nil is the bug state, not a valid identity).
+
+use base64::Engine;
+use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+use ulid::Ulid;
+
+/// Decode a TrailBase user id from a JWT `sub` claim into a `Ulid`.
+///
+/// Order tried: url-safe base64 no-pad, url-safe base64 padded, hex UUID with
+/// dashes. Returns `Ulid::nil()` (and warns) when no encoding yields 16 bytes;
+/// callers must treat nil as "unknown identity" and avoid propagating it.
+pub(crate) fn uuid_to_ulid(b64_uuid: &str) -> Ulid {
+    if b64_uuid.is_empty() {
+        tracing::warn!("Empty trailbase_id, using nil ULID");
+        return Ulid::nil();
+    }
+
+    if let Some(ulid) = decode_base64_to_ulid(&URL_SAFE_NO_PAD, b64_uuid) {
+        return ulid;
+    }
+    if let Some(ulid) = decode_base64_to_ulid(&URL_SAFE, b64_uuid) {
+        return ulid;
+    }
+    if let Some(ulid) = decode_hex_uuid_to_ulid(b64_uuid) {
+        return ulid;
+    }
+
+    tracing::warn!(
+        "Invalid trailbase_id format (expected 16-byte base64 or hex UUID), using nil ULID: {}",
+        redact(b64_uuid)
+    );
+    Ulid::nil()
+}
+
+fn decode_base64_to_ulid(engine: &impl Engine, input: &str) -> Option<Ulid> {
+    let bytes = engine.decode(input).ok()?;
+    bytes_to_ulid(&bytes)
+}
+
+fn decode_hex_uuid_to_ulid(input: &str) -> Option<Ulid> {
+    let stripped = input.replace('-', "");
+    if stripped.len() != 32 {
+        return None;
+    }
+    let mut bytes = [0u8; 16];
+    for (i, chunk) in stripped.as_bytes().chunks(2).enumerate() {
+        let hex = std::str::from_utf8(chunk).ok()?;
+        bytes[i] = u8::from_str_radix(hex, 16).ok()?;
+    }
+    Some(Ulid::from_bytes(bytes))
+}
+
+fn bytes_to_ulid(bytes: &[u8]) -> Option<Ulid> {
+    if bytes.len() != 16 {
+        return None;
+    }
+    let mut arr = [0u8; 16];
+    arr.copy_from_slice(bytes);
+    Some(Ulid::from_bytes(arr))
+}
+
+/// Reduce an identifier before logging so full user ids do not land in logs.
+pub(crate) fn redact(id: &str) -> String {
+    let len = id.chars().count();
+    if len <= 8 {
+        return "***".to_string();
+    }
+    let first: String = id.chars().take(4).collect();
+    let last: String = id.chars().skip(len.saturating_sub(4)).collect();
+    format!("{first}…{last} ({len} chars)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    fn encode_ulid_as_base64_url_no_pad(ulid: Ulid) -> String {
+        URL_SAFE_NO_PAD.encode(ulid.to_bytes())
+    }
+
+    fn encode_ulid_as_base64_url_padded(ulid: Ulid) -> String {
+        URL_SAFE.encode(ulid.to_bytes())
+    }
+
+    fn encode_ulid_as_hex_uuid(ulid: Ulid) -> String {
+        let bytes = ulid.to_bytes();
+        // Format as 8-4-4-4-12 canonical UUID with dashes.
+        format!(
+            "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            bytes[0],
+            bytes[1],
+            bytes[2],
+            bytes[3],
+            bytes[4],
+            bytes[5],
+            bytes[6],
+            bytes[7],
+            bytes[8],
+            bytes[9],
+            bytes[10],
+            bytes[11],
+            bytes[12],
+            bytes[13],
+            bytes[14],
+            bytes[15]
+        )
+    }
+
+    const KNOWN_BYTES: [u8; 16] = [
+        0x01, 0x67, 0x4f, 0x3a, 0x4e, 0x32, 0xdf, 0x41, 0x8c, 0x6b, 0x27, 0x4e, 0x73, 0x91, 0x5f,
+        0xce,
+    ];
+
+    #[test]
+    fn uuid_to_ulid_decodes_base64_url_no_pad_correctly() {
+        let expected = Ulid::from_bytes(KNOWN_BYTES);
+        let b64 = encode_ulid_as_base64_url_no_pad(expected);
+
+        let decoded = uuid_to_ulid(&b64);
+
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn uuid_to_ulid_decodes_base64_url_padded_correctly() {
+        let expected = Ulid::from_bytes(KNOWN_BYTES);
+        let b64 = encode_ulid_as_base64_url_padded(expected);
+
+        let decoded = uuid_to_ulid(&b64);
+
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn uuid_to_ulid_decodes_hex_uuid_with_dashes_correctly() {
+        let expected = Ulid::from_bytes(KNOWN_BYTES);
+        let hex = encode_ulid_as_hex_uuid(expected);
+
+        let decoded = uuid_to_ulid(&hex);
+
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn uuid_to_ulid_roundtrip_for_random_ulid() {
+        let original = Ulid::new();
+        let b64 = encode_ulid_as_base64_url_no_pad(original);
+
+        let decoded = uuid_to_ulid(&b64);
+
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn uuid_to_ulid_returns_nil_for_invalid_input() {
+        assert_eq!(uuid_to_ulid("not-a-valid-base64-uuid"), Ulid::nil());
+    }
+
+    #[test]
+    fn uuid_to_ulid_returns_nil_for_empty_input() {
+        assert_eq!(uuid_to_ulid(""), Ulid::nil());
+    }
+
+    #[test]
+    fn uuid_to_ulid_returns_nil_for_truncated_base64() {
+        assert_eq!(uuid_to_ulid("AQEBAQEBAQE"), Ulid::nil());
+    }
+
+    #[test]
+    fn uuid_to_ulid_returns_nil_for_hex_wrong_length() {
+        assert_eq!(uuid_to_ulid("550e8400-e29b-41d4"), Ulid::nil());
+    }
+
+    #[test]
+    fn redact_hides_middle_of_long_id() {
+        let redacted = redact("abcdefgh1234567890");
+        assert!(redacted.contains('…'));
+        assert!(!redacted.contains("efgh1234"));
+    }
+
+    #[test]
+    fn redact_masks_short_input() {
+        assert_eq!(redact("abc"), "***");
+    }
+}

--- a/origa_ui/src/repository/trailbase_repository.rs
+++ b/origa_ui/src/repository/trailbase_repository.rs
@@ -1,5 +1,6 @@
+use super::session::{TrailBaseSession, get_session, set_session_async};
 use super::trailbase_client::{AuthError, TrailBaseClient};
-use crate::repository::session::{TrailBaseSession, get_session, set_session_async};
+use super::trailbase_id::uuid_to_ulid;
 use chrono::{DateTime, Utc};
 use origa::domain::{DailyLoad, NativeLanguage, OrigaError, User};
 use origa::traits::UserRepository;
@@ -58,6 +59,16 @@ impl TrailBaseUserRepository {
                 reason: "Record ID missing from database row".to_string(),
             })?;
             let user = row.to_user();
+
+            // A remote row whose trailbase_id does not decode to a real ULID is
+            // corrupt for sync purposes: merging it would poison the local id
+            // with nil (the very bug this code path guards against). Surface it
+            // as an error instead of letting merge propagate the nil identity.
+            if user.id() == Ulid::nil() {
+                return Err(OrigaError::RepositoryError {
+                    reason: "Remote user trailbase_id did not decode to a valid ULID; refusing to sync a nil identity".to_string(),
+                });
+            }
 
             if let Ok(mut cache) = self.user_cache.write() {
                 cache.insert(session.email.clone(), user.clone());
@@ -140,25 +151,6 @@ impl UserRow {
             self.known_vocab_hash.unwrap_or(0) as u32,
         )
     }
-}
-
-fn uuid_to_ulid(uuid_str: &str) -> Ulid {
-    let uuid_bytes = uuid_str
-        .replace('-', "")
-        .as_bytes()
-        .chunks(2)
-        .filter_map(|chunk| {
-            let hex = std::str::from_utf8(chunk).ok()?;
-            u8::from_str_radix(hex, 16).ok()
-        })
-        .collect::<Vec<_>>();
-
-    let mut bytes = [0u8; 16];
-    if uuid_bytes.len() == 16 {
-        bytes.copy_from_slice(&uuid_bytes);
-    }
-
-    Ulid::from_bytes(bytes)
 }
 
 fn user_to_json(user: &User, trailbase_id: &str) -> serde_json::Value {


### PR DESCRIPTION
## Summary

Different browsers showed different "New/Studied" counts for the same account. Root cause: `uuid_to_ulid()` parsed TrailBase's base64-url-safe JWT `sub` as a hex UUID → always `Ulid::nil()` (26 zeros).

## Prove-It
Slice-1 test → FAILED (`left: Ulid(0)`) before fix, PASSES after.

## Fix (5 slices, GATE-approved)
- `uuid_to_ulid()` decodes base64 (URL_SAFE_NO_PAD → URL_SAFE → hex fallback)
- `User::merge()` copies `id` from remote with nil-guard
- `save_sync` propagates remote errors (was silent Ok → split-progress)
- Legacy migration: nil-key records merged into canonical (not discarded)
- E2E: strict `countAfterA === 1` assertion

## Verification
- `cargo test -p origa`: 1324 passed
- `cargo test -p origa_ui`: 159 passed (+14 migration tests)
- clippy/fmt/tsc/prettier: clean
- Code review: approve (0 High after fixes)

Refs: TrailBase commit 7a0be705
