### PR TITLE
fix(audio): always-blob-URL playback to bypass Hikari gzip on CDN .opus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ temp_*/
 # Cache
 .cache/
 
+# Internal fix-restore artifacts (status notes from parallel work, not production)
+.audio-fix-backup/
+
 # Graphify knowledge graph output
 graphify-out/
 

--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -3,11 +3,14 @@ use crate::ui_components::{
     stop_current_audio,
 };
 use leptos::prelude::*;
+use leptos::task::spawn_local;
 
 use leptos::wasm_bindgen::JsCast;
 use leptos::wasm_bindgen::closure::Closure;
 use origa::domain::{Card as DomainCard, GrammarInfo, NativeLanguage};
+use std::cell::RefCell;
 use std::collections::HashSet;
+use std::rc::Rc;
 use tracing;
 
 use super::answer_display::extract_card_answer;
@@ -17,6 +20,7 @@ use super::lesson_card_answer::LessonCardAnswer;
 use super::lesson_card_header::LessonCardHeader;
 use super::lesson_card_question::LessonCardQuestion;
 use super::lesson_state::LessonContext;
+use crate::repository::cdn_provider::prefetch_blob_url;
 
 #[component]
 pub fn LessonCard(
@@ -27,7 +31,11 @@ pub fn LessonCard(
     grammar_info: Option<GrammarInfo>,
     native_language: NativeLanguage,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
-    #[prop(into)] audio_src: Option<String>,
+    /// CDN path for the phrase audio (e.g. `phrases/audio/ABC.opus`).
+    /// Prefetched into a `blob:` URL before playback — see
+    /// `cdn_provider::resolve_audio_url` for the gzip-on-CDN root cause.
+    #[prop(into)]
+    audio_path: Option<String>,
 ) -> impl IntoView {
     let card_type = CardType::from(&card);
     let is_phrase = card_type == CardType::Phrase;
@@ -170,7 +178,7 @@ pub fn LessonCard(
         }
     });
 
-    let phrase_audio_src = audio_src.clone();
+    let phrase_audio_path = audio_path.clone();
     let lesson_ctx_phrase = lesson_ctx.clone();
 
     Effect::new(move |_| {
@@ -179,22 +187,14 @@ pub fn LessonCard(
             .map(|ctx| ctx.is_muted.get_untracked())
             .unwrap_or(false);
         if !show_answer && is_phrase && !is_muted {
-            if let Some(ref src) = phrase_audio_src {
+            if let Some(path) = phrase_audio_path.as_ref() {
                 stop_current_audio();
-                if let Ok(audio) = web_sys::HtmlAudioElement::new_with_src(src) {
-                    let _ = audio.set_attribute("preload", "auto");
-
-                    let question_val = question.get_value();
-                    let on_error = Closure::<dyn FnMut()>::new(move || {
-                        tracing::warn!("CDN phrase audio failed, falling back to TTS");
-                        let reading = get_reading_from_text(&question_val);
-                        let _ = speak_tts_text(&reading, 1.0);
-                    });
-                    audio.set_onerror(Some(on_error.as_ref().unchecked_ref()));
-
-                    let _ = audio.play();
-                    register_audio(audio, None, vec![on_error]);
-                }
+                let path_owned = path.clone();
+                let question_val = question.get_value();
+                // Bug A fix: prefetch CDN bytes into a blob: URL before playback.
+                spawn_local(async move {
+                    play_phrase_in_lesson(&path_owned, &question_val).await;
+                });
             }
         } else if is_phrase || show_answer {
             stop_current_audio();
@@ -239,7 +239,7 @@ pub fn LessonCard(
                 question_text=if is_reversed { answer.get_value() } else { display_question.get_value() }
                 grammar_info=grammar_info.clone()
                 show_answer=show_answer
-                audio_src=audio_src
+                audio_path=audio_path
             />
 
             <div class="flex-1 flex flex-col justify-center">
@@ -278,5 +278,71 @@ pub fn LessonCard(
                 </Show>
             </div>
         </Card>
+    }
+}
+
+/// Prefetch the phrase audio into a `blob:` URL and play it through a
+/// fresh `HTMLAudioElement`, falling back to TTS on any failure. See
+/// `cdn_provider::resolve_audio_url` for the Bug A/B root cause.
+async fn play_phrase_in_lesson(path: &str, question_text: &str) {
+    use wasm_bindgen_futures::JsFuture;
+
+    // Shared single-shot TTS fallback used by the drain-pattern below.
+    type TtsFallback = Rc<RefCell<Option<Box<dyn FnMut()>>>>;
+
+    let blob_url = match prefetch_blob_url(path).await {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::warn!(path = %path, error = ?e, "CDN phrase audio prefetch failed, falling back to TTS");
+            let reading = get_reading_from_text(question_text);
+            let _ = speak_tts_text(&reading, 1.0);
+            return;
+        },
+    };
+
+    let Ok(audio) = web_sys::HtmlAudioElement::new_with_src(&blob_url) else {
+        let reading = get_reading_from_text(question_text);
+        let _ = speak_tts_text(&reading, 1.0);
+        return;
+    };
+    let _ = audio.set_attribute("preload", "auto");
+
+    let question_owned = question_text.to_string();
+    let path_owned = path.to_string();
+
+    // Drain-pattern: Chromium emits BOTH an `error` event AND a play() Promise
+    // rejection on decode failure, so calling TTS independently in onerror and
+    // in the rejection branch would speak twice. The first branch to fire
+    // drains the shared Option; the second observes `None` and is a no-op.
+    let tts_fallback: TtsFallback = {
+        let question_for_tts = question_owned.clone();
+        Rc::new(RefCell::new(Some(Box::new(move || {
+            let reading = get_reading_from_text(&question_for_tts);
+            let _ = speak_tts_text(&reading, 1.0);
+        }))))
+    };
+
+    let tts_for_error = Rc::clone(&tts_fallback);
+    let on_error = Closure::<dyn FnMut()>::new(move || {
+        tracing::warn!(path = %path_owned, "CDN phrase audio failed during playback, falling back to TTS");
+        if let Some(mut cb) = tts_for_error.borrow_mut().take() {
+            cb();
+        }
+    });
+    audio.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+
+    register_audio(audio.clone(), None, vec![on_error]);
+
+    // Bug B fix: consume the play() Promise. onerror does NOT fire for
+    // autoplay-policy NotAllowedError, so on rejection we still need to fire
+    // TTS. We drain the shared fallback rather than calling TTS directly: on
+    // decode errors onerror has already drained it, preventing the double-TTS.
+    if let Ok(promise) = audio.play() {
+        if JsFuture::from(promise).await.is_err() {
+            tracing::warn!(path = %path, "audio.play() rejected, falling back to TTS");
+            if let Some(mut cb) = tts_fallback.borrow_mut().take() {
+                cb();
+            }
+        }
     }
 }

--- a/origa_ui/src/pages/lesson/lesson_card_header.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_header.rs
@@ -12,7 +12,7 @@ pub fn LessonCardHeader(
     question_text: String,
     grammar_info: Option<GrammarInfo>,
     show_answer: bool,
-    #[prop(into)] audio_src: Option<String>,
+    #[prop(into)] audio_path: Option<String>,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let grammar_info = StoredValue::new(grammar_info);
@@ -35,7 +35,7 @@ pub fn LessonCardHeader(
                 </Show>
             </div>
             <Show when=move || card_type != CardType::Kanji>
-                <AudioButtons text=question_text.clone() audio_src=audio_src.clone() class=Signal::derive(|| "".to_string())/>
+                <AudioButtons text=question_text.clone() audio_path=audio_path.clone() class=Signal::derive(|| "".to_string())/>
             </Show>
         </div>
     }

--- a/origa_ui/src/pages/lesson/lesson_card_renderer.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_renderer.rs
@@ -64,10 +64,8 @@ pub(in crate::pages::lesson) fn render_lesson_card(
     let is_phrase = matches!(params.card, Card::Phrase(_));
 
     if is_phrase {
-        let phrase_audio_src = match &params.card {
-            Card::Phrase(pc) => Some(crate::repository::cdn_provider::resolve_audio_url(
-                &format!("phrases/audio/{}.opus", pc.phrase_id()),
-            )),
+        let phrase_audio_path = match &params.card {
+            Card::Phrase(pc) => Some(format!("phrases/audio/{}.opus", pc.phrase_id())),
             _ => None,
         };
 
@@ -80,7 +78,7 @@ pub(in crate::pages::lesson) fn render_lesson_card(
                 grammar_info=params.grammar_info
                 native_language=native_language.get()
                 known_kanji=Signal::from(known_kanji)
-                audio_src=phrase_audio_src
+                audio_path=phrase_audio_path
             />
 
             <Show when=move || show_answer>
@@ -102,7 +100,7 @@ pub(in crate::pages::lesson) fn render_lesson_card(
                 grammar_info=params.grammar_info
                 native_language=native_language.get()
                 known_kanji=Signal::from(known_kanji)
-                audio_src=None
+                audio_path=None
             />
 
             <Show when=move || show_answer>

--- a/origa_ui/src/pages/lesson/phrase_card.rs
+++ b/origa_ui/src/pages/lesson/phrase_card.rs
@@ -28,10 +28,9 @@ pub fn PhraseCardView(
     on_next_card: Callback<()>,
 ) -> impl IntoView {
     let i18n = use_i18n();
-    let audio_src = crate::repository::cdn_provider::resolve_audio_url(&format!(
-        "phrases/audio/{}",
-        audio_file
-    ));
+    // Bug A fix: pass the CDN path (not the resolved URL) to AudioPlayer so it
+    // can prefetch into a `blob:` URL — see cdn_provider::resolve_audio_url.
+    let audio_path = format!("phrases/audio/{}", audio_file);
     let options_stored = StoredValue::new(options);
     let phrase_text_stored = StoredValue::new(phrase_text);
     let phrase_translation_stored = StoredValue::new(phrase_translation);
@@ -69,7 +68,7 @@ pub fn PhraseCardView(
             <div class="flex-1 flex flex-col justify-center">
                 <div class="text-center mb-3 sm:mb-6">
                     <AudioPlayer
-                        src=audio_src
+                        path=audio_path
                         autoplay=true
                         test_id=Signal::derive(|| "phrase-audio-player".to_string())
                     />

--- a/origa_ui/src/pages/lesson/quiz_card_header.rs
+++ b/origa_ui/src/pages/lesson/quiz_card_header.rs
@@ -39,7 +39,7 @@ pub fn QuizCardHeader(
             <Show when=move || card_type != CardType::Kanji>
                 <AudioButtons
                     text=question_text.clone()
-                    audio_src=None
+                    audio_path=None
                     class=Signal::derive(|| "".to_string())
                 />
             </Show>

--- a/origa_ui/src/pages/onboarding/scoring_step.rs
+++ b/origa_ui/src/pages/onboarding/scoring_step.rs
@@ -268,7 +268,7 @@ pub fn ScoringStep(
                                     <div class="absolute right-0 top-1/2 -translate-y-1/2">
                                         <AudioButtons
                                             text=card.question.clone()
-                                            audio_src=None
+                                            audio_path=None
                                             class=Signal::derive(|| "".to_string())
                                             test_id=Signal::derive(|| "scoring-step-audio".to_string())
                                         />

--- a/origa_ui/src/pages/phrases/phrase_card_item.rs
+++ b/origa_ui/src/pages/phrases/phrase_card_item.rs
@@ -46,10 +46,12 @@ pub fn PhraseCardItem(
         }
     });
 
-    let audio_src = match study_card.card() {
-        DomainCard::Phrase(phrase_card) => crate::repository::cdn_provider::resolve_audio_url(
-            &format!("phrases/audio/{}.opus", phrase_card.phrase_id()),
-        ),
+    // Bug A fix: pass the CDN path (not the resolved URL) to AudioPlayer so it
+    // can prefetch into a `blob:` URL — see cdn_provider::resolve_audio_url.
+    let audio_path = match study_card.card() {
+        DomainCard::Phrase(phrase_card) => {
+            format!("phrases/audio/{}.opus", phrase_card.phrase_id())
+        },
         _ => String::new(),
     };
 
@@ -64,7 +66,7 @@ pub fn PhraseCardItem(
     });
 
     let status = CardStatus::from_study_card(&study_card);
-    let has_audio = !audio_src.is_empty();
+    let has_audio = !audio_path.is_empty();
     let known_kanji_for_markdown = known_kanji;
 
     view! {
@@ -109,7 +111,7 @@ pub fn PhraseCardItem(
                         <Show when=move || has_audio>
                             <div class="phrase-card-audio">
                                 <AudioPlayer
-                                    src=audio_src.clone()
+                                    path=audio_path.clone()
                                     autoplay=false
                                     test_id=Signal::derive(|| "phrases-card-audio".to_string())
                                 />

--- a/origa_ui/src/repository/cdn_provider.rs
+++ b/origa_ui/src/repository/cdn_provider.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 
-use leptos::task::spawn_local;
 use leptos::wasm_bindgen::JsCast;
 use origa::domain::OrigaError;
 use origa::traits::CdnProvider;
@@ -21,12 +21,58 @@ pub fn cdn() -> &'static CacheFirstCdnProvider {
     CDN_PROVIDER.get_or_init(|| CacheFirstCdnProvider)
 }
 
-static BLOB_URL_CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+static BLOB_URL_CACHE: OnceLock<Mutex<BlobUrlCache>> = OnceLock::new();
 
+/// Ceiling on the number of retained `blob:` URLs. Each entry holds an
+/// underlying `Blob` + `ArrayBuffer` alive in JS heap until the URL is
+/// `revoke_object_url`'d. Bounded to keep memory predictable on low-end
+/// Android WebViews: ~500 phrases × ~3-50 KB/opus ≈ 1.5-25 MB ceiling. When
+/// the limit is reached the oldest entry is evicted and its blob URL revoked.
 const MAX_BLOB_URL_CACHE_SIZE: usize = 500;
 
-fn blob_url_cache() -> &'static Mutex<HashMap<String, String>> {
-    BLOB_URL_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+/// Insertion-ordered blob URL cache with bounded LRU-ish (FIFO) eviction.
+/// Tracks keys in `order` so the oldest materialised URL can be revoked when
+/// the cap is reached, preventing unbounded `Blob`/`ArrayBuffer` leaks.
+struct BlobUrlCache {
+    urls: HashMap<String, String>,
+    order: VecDeque<String>,
+}
+
+impl BlobUrlCache {
+    fn get(&self, key: &str) -> Option<&String> {
+        self.urls.get(key)
+    }
+
+    fn insert(&mut self, key: String, url: String) {
+        if self.urls.insert(key.clone(), url).is_some() {
+            return;
+        }
+        while self.order.len() >= MAX_BLOB_URL_CACHE_SIZE {
+            let Some(evicted_key) = self.order.pop_front() else {
+                break;
+            };
+            if let Some(evicted_url) = self.urls.remove(&evicted_key) {
+                let _ = web_sys::Url::revoke_object_url(&evicted_url);
+            }
+        }
+        self.order.push_back(key);
+    }
+
+    #[cfg(test)]
+    fn remove(&mut self, key: &str) {
+        if self.urls.remove(key).is_some() {
+            self.order.retain(|k| k != key);
+        }
+    }
+}
+
+fn blob_url_cache() -> &'static Mutex<BlobUrlCache> {
+    BLOB_URL_CACHE.get_or_init(|| {
+        Mutex::new(BlobUrlCache {
+            urls: HashMap::new(),
+            order: VecDeque::new(),
+        })
+    })
 }
 
 async fn open_cache() -> Result<web_sys::Cache, OrigaError> {
@@ -278,6 +324,24 @@ pub fn get_cached_blob_url(path: &str) -> Option<String> {
     cache.get(&key).cloned()
 }
 
+/// Derive the Blob MIME type from the CDN path extension. Hardcoding
+/// `audio/opus` couples decoding to a CDN filename convention; if a non-opus
+/// record ever lands on the CDN the decoder would break silently. Falling back
+/// to `audio/opus` matches the current CDN content while keeping other formats
+/// decodeable if they appear.
+fn mime_type_for_path(path: &str) -> &'static str {
+    let ext = path.rsplit('.').next().map(str::to_ascii_lowercase);
+    match ext.as_deref() {
+        Some("opus") => "audio/opus",
+        Some("mp3") => "audio/mpeg",
+        Some("wav") => "audio/wav",
+        Some("ogg") | Some("oga") => "audio/ogg",
+        Some("m4a") | Some("mp4") | Some("aac") => "audio/mp4",
+        Some("webm") => "audio/webm",
+        _ => "audio/opus",
+    }
+}
+
 pub async fn prefetch_blob_url(path: &str) -> Result<String, OrigaError> {
     let key = ensure_leading_slash(path);
 
@@ -288,7 +352,7 @@ pub async fn prefetch_blob_url(path: &str) -> Result<String, OrigaError> {
     let bytes = cdn().fetch_bytes(&key).await?;
 
     let blob_options = web_sys::BlobPropertyBag::new();
-    blob_options.set_type("audio/opus");
+    blob_options.set_type(mime_type_for_path(&key));
 
     let uint8_array = js_sys::Uint8Array::new_with_length(bytes.len() as u32);
     uint8_array.copy_from(&bytes);
@@ -310,29 +374,34 @@ pub async fn prefetch_blob_url(path: &str) -> Result<String, OrigaError> {
             .map_err(|e| OrigaError::RepositoryError {
                 reason: format!("Failed to lock blob URL cache: {:?}", e),
             })?;
-        if cache.len() < MAX_BLOB_URL_CACHE_SIZE {
-            cache.insert(key, blob_url.clone());
-        }
+        cache.insert(key, blob_url.clone());
     }
 
     Ok(blob_url)
 }
 
-pub fn resolve_audio_url(path: &str) -> String {
+/// Resolve a playable audio URL for the given CDN path.
+///
+/// # Bug A root cause (see module-level `tests` doc)
+///
+/// The Railway Hikari reverse proxy gzip-encodes `.opus` responses on-the-fly,
+/// and Chromium's `<audio>` element does not apply transport decompression —
+/// feeding the raw gzip bytes to the Opus decoder yields
+/// `ERR_CONTENT_DECODING_FAILED`. The only correct way to feed `<audio>` is
+/// therefore a `blob:` URL produced from `fetch()`-decompressed bytes.
+///
+/// # Contract
+///
+/// Returns `Some(blob_url)` only when the blob URL has already been materialised
+/// in the in-memory cache; returns `None` otherwise. Callers MUST NOT
+/// substitute the CDN URL when this returns `None`: they must either await
+/// `prefetch_blob_url` directly (preferred for playback paths) or fall back to
+/// TTS. This function is a **pure synchronous lookup** with no side effects —
+/// callers own the async prefetch, which avoids a double-fetch race when a
+/// consumer needs the blob URL reactively.
+pub fn resolve_audio_url(path: &str) -> Option<String> {
     let key = ensure_leading_slash(path);
-
-    if let Some(blob_url) = get_cached_blob_url(&key) {
-        return blob_url;
-    }
-
-    let path_owned = key.clone();
-    spawn_local(async move {
-        if let Err(e) = prefetch_blob_url(&path_owned).await {
-            tracing::warn!(path = %path_owned, error = ?e, "Failed to prefetch blob URL");
-        }
-    });
-
-    cdn_url(&key)
+    get_cached_blob_url(&key)
 }
 
 pub async fn prefetch_to_cache(path: &str) -> Result<(), OrigaError> {
@@ -399,4 +468,132 @@ pub async fn is_cached(path: &str) -> bool {
         return false;
     };
     !result.is_null() && !result.is_undefined()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Bug A — root cause (proven via curl by the architect):
+    //
+    // Railway's Hikari reverse proxy applies `Content-Encoding: gzip` to `.opus`
+    // responses on-the-fly whenever the client advertises `Accept-Encoding` (every
+    // browser / WebView does this automatically; it is a "forbidden header name"
+    // and cannot be disabled from JS).
+    //
+    //   curl -H 'Accept-Encoding: identity'  → no Content-Encoding, 3139 bytes ✅
+    //   curl -H 'Accept-Encoding: gzip'      → Content-Encoding: gzip, 3145 bytes ❌
+    //   curl -H 'Accept-Encoding: br'        → Content-Encoding: gzip (!), 3145 bytes ❌
+    //
+    // Gzip makes the file LARGER (3145 > 3139) — negative compression for an
+    // already-compressed Opus stream. Chromium's <audio> element historically
+    // does not apply transport-layer decompression (crbug 1029876 / 596361 /
+    // 1247420), so it hands the raw gzip bytes to the media decoder which then
+    // fails with `ERR_CONTENT_DECODING_FAILED`.
+    //
+    // The fix is "always-blob-URL playback": the Fetch API transparently
+    // decompresses `Content-Encoding`, after which the resulting bytes are
+    // stored in a Blob. The `blob:` URL handed to <audio> therefore has no
+    // transport encoding and decodes correctly.
+    //
+    // As a consequence, `resolve_audio_url` must NEVER return the raw CDN URL
+    // as a synchronous fallback. The contract below is a compile-time
+    // regression guard: callers must receive `Option<String>` and either await
+    // the prefetched blob URL or fall back to TTS — never play the CDN URL.
+
+    /// Compile-time contract: `resolve_audio_url` returns `Option<String>`.
+    ///
+    /// Before Slice-2 this function returned `String` (the CDN URL when the
+    /// blob URL had not been prefetched yet). That is precisely the code path
+    /// that triggered `ERR_CONTENT_DECODING_FAILED`. If this test fails to
+    /// compile, the contract has regressed.
+    #[test]
+    fn resolve_audio_url_contract_returns_option() {
+        let _type_witness: fn(&str) -> Option<String> = resolve_audio_url;
+        // Touch the symbol so the assignment is not dead-code eliminated.
+        let _ = _type_witness as fn(&str) -> Option<String>;
+    }
+
+    #[test]
+    fn ensure_leading_slash_adds_missing() {
+        assert_eq!(
+            ensure_leading_slash("phrases/audio/x.opus"),
+            "/phrases/audio/x.opus"
+        );
+    }
+
+    #[test]
+    fn ensure_leading_slash_preserves_existing() {
+        assert_eq!(
+            ensure_leading_slash("/phrases/audio/x.opus"),
+            "/phrases/audio/x.opus"
+        );
+    }
+
+    #[test]
+    fn blob_url_cache_returns_none_for_uncached_key() {
+        // Bug A contract: cache miss MUST surface as None to the caller so the
+        // caller can fall back to TTS or await prefetch — it MUST NOT be silently
+        // substituted with the raw CDN URL (see module-level root cause comment).
+        let unique = "/blob-cache-probe-uncached-7e3a9f1c-e2d4-4b8a-9c11-1f5a2c7e9b8d";
+        // Defensive cleanup in case a prior test populated this slot.
+        if let Ok(mut cache) = blob_url_cache().lock() {
+            cache.remove(unique);
+        }
+        let result = get_cached_blob_url(unique);
+        assert!(
+            result.is_none(),
+            "uncached path must resolve to None; got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn blob_url_cache_round_trips_inserted_value() {
+        let key = "/blob-cache-probe-roundtrip-3f8a1c0b-9d2e-4a6f-b117-2c4d8e1f0a3b";
+        let value = "blob:roundtrip-test";
+        {
+            let mut cache = blob_url_cache().lock().expect("blob cache poisoned");
+            cache.insert(key.to_string(), value.to_string());
+        }
+        assert_eq!(get_cached_blob_url(key).as_deref(), Some(value));
+        // Cleanup so this test remains idempotent.
+        if let Ok(mut cache) = blob_url_cache().lock() {
+            cache.remove(key);
+        }
+    }
+
+    #[test]
+    fn mime_type_for_path_known_extensions() {
+        assert_eq!(mime_type_for_path("phrases/audio/abc.opus"), "audio/opus");
+        assert_eq!(mime_type_for_path("/x.mp3"), "audio/mpeg");
+        assert_eq!(mime_type_for_path("/x.wav"), "audio/wav");
+        assert_eq!(mime_type_for_path("/x.ogg"), "audio/ogg");
+        assert_eq!(mime_type_for_path("/x.m4a"), "audio/mp4");
+        assert_eq!(mime_type_for_path("/x.webm"), "audio/webm");
+    }
+
+    #[test]
+    fn mime_type_for_path_unknown_defaults_to_opus() {
+        // Current CDN only serves opus; the default keeps decode working for
+        // the existing content while other extensions map explicitly above.
+        assert_eq!(mime_type_for_path("noext"), "audio/opus");
+        assert_eq!(mime_type_for_path("file.unknown"), "audio/opus");
+    }
+
+    #[test]
+    fn blob_url_cache_insert_updates_existing_key_without_duplication() {
+        let key = "/blob-cache-probe-update-1a2b3c4d-1111-2222-3333-444455556666";
+        {
+            let mut cache = blob_url_cache().lock().expect("blob cache poisoned");
+            cache.insert(key.to_string(), "blob:first".to_string());
+            // Re-inserting the same key must not append a duplicate order entry.
+            cache.insert(key.to_string(), "blob:second".to_string());
+            assert_eq!(cache.order.iter().filter(|k| *k == key).count(), 1);
+        }
+        assert_eq!(get_cached_blob_url(key).as_deref(), Some("blob:second"));
+        if let Ok(mut cache) = blob_url_cache().lock() {
+            cache.remove(key);
+        }
+    }
 }

--- a/origa_ui/src/ui_components/audio_buttons.rs
+++ b/origa_ui/src/ui_components/audio_buttons.rs
@@ -1,9 +1,12 @@
 use leptos::prelude::*;
+use leptos::task::spawn_local;
 use leptos_icons::Icon;
 use wasm_bindgen::JsCast;
-use wasm_bindgen::prelude::Closure;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen_futures::JsFuture;
 
 use super::word_audio::{register_audio, stop_current_audio};
+use crate::repository::cdn_provider::prefetch_blob_url;
 use crate::ui_components::{get_reading_from_text, is_speech_supported, speak_word_with_callback};
 
 #[component]
@@ -11,12 +14,20 @@ pub fn AudioButtons(
     #[prop(into)] text: String,
     #[prop(optional, into)] class: Signal<String>,
     #[prop(optional, into)] test_id: Signal<String>,
-    #[prop(into)] audio_src: Option<String>,
+    /// CDN path (e.g. `phrases/audio/ABC.opus`). Always prefetched into a
+    /// `blob:` URL before being handed to `<audio>` — see
+    /// `cdn_provider::resolve_audio_url` for the gzip-on-CDN root cause.
+    #[prop(into)]
+    audio_path: Option<String>,
 ) -> impl IntoView {
-    let has_content = audio_src.is_some() || !get_reading_from_text(&text).is_empty();
-    let has_audio_src = audio_src.is_some();
+    let has_content = audio_path.is_some() || !get_reading_from_text(&text).is_empty();
+    let has_audio_path = audio_path.is_some();
     let is_playing = RwSignal::new(false);
-    let src = audio_src;
+    // Store inputs in RwSignals so the click closure can satisfy Leptos 0.8's
+    // `TypedChildrenFn` bound (`Fn + Send + Sync`). `Rc` is neither Send nor
+    // Sync; signals are Copy and yield owned values via `.get()`.
+    let path: RwSignal<Option<String>> = RwSignal::new(audio_path);
+    let text_signal: RwSignal<String> = RwSignal::new(text);
 
     let test_id_val = move || {
         let val = test_id.get();
@@ -29,38 +40,27 @@ pub fn AudioButtons(
                 <button
                     class="audio-btn"
                     data-testid=test_id_val
-                    on:click={
-                        let text = text.clone();
-                        let src = src.clone();
-                        move |_| {
-                            if is_playing.get() { return; }
+                    on:click=move |_| {
+                        if is_playing.get() { return; }
+                        if let Some(audio_path) = path.get() {
+                            // Stop synchronously before the async prefetch so the
+                            // currently-playing phrase does not overlap the new
+                            // one during the network round-trip.
+                            stop_current_audio();
                             is_playing.set(true);
-                            if let Some(audio_url) = &src {
-                                stop_current_audio();
-                                let Ok(audio) = web_sys::HtmlAudioElement::new_with_src(audio_url) else {
-                                    is_playing.set(false);
-                                    return;
-                                };
-                                let is_playing_clone = is_playing;
-                                let on_end = Closure::<dyn FnMut()>::new(move || {
-                                    is_playing_clone.set(false);
-                                });
-                                audio.set_onended(Some(on_end.as_ref().unchecked_ref()));
-                                let is_playing_clone2 = is_playing;
-                                register_audio(audio.clone(), Some(Box::new(move || {
-                                    is_playing_clone2.set(false);
-                                })), vec![on_end]);
-
-                                let _ = audio.play();
-                            } else if is_speech_supported() {
-                                stop_current_audio();
-                                speak_word_with_callback(&text, 1.0, move || {
-                                    is_playing.set(false);
-                                });
-                            }
+                            spawn_local(async move {
+                                play_phrase_audio(&audio_path, is_playing).await;
+                            });
+                        } else if is_speech_supported() {
+                            stop_current_audio();
+                            is_playing.set(true);
+                            let text_owned = text_signal.get();
+                            speak_word_with_callback(&text_owned, 1.0, move || {
+                                is_playing.set(false);
+                            });
                         }
                     }
-                    disabled=move || is_playing.get() || (!has_audio_src && !is_speech_supported())
+                    disabled=move || is_playing.get() || (!has_audio_path && !is_speech_supported())
                 >
                     <Show when=move || is_playing.get() fallback=|| view! {
                         <Icon icon=icondata::LuPlay width="1em" height="1em" />
@@ -70,5 +70,73 @@ pub fn AudioButtons(
                 </button>
             </div>
         </Show>
+    }
+}
+
+/// Prefetch the CDN audio into a `blob:` URL and play it through an
+/// `HTMLAudioElement`. Updates `is_playing` based on lifecycle events.
+///
+/// Uses the same promise-absorbing pattern as `AudioPlayer` to avoid Bug B
+/// (`Uncaught (in promise) NotSupportedError`). If the prefetch fails the
+/// signal is reset so the user can retry.
+async fn play_phrase_audio(path: &str, is_playing: RwSignal<bool>) {
+    let blob_url = match prefetch_blob_url(path).await {
+        Ok(url) => url,
+        Err(e) => {
+            tracing::warn!(path = %path, error = ?e, "AudioButtons prefetch failed");
+            is_playing.set(false);
+            return;
+        },
+    };
+
+    let Ok(audio) = web_sys::HtmlAudioElement::new_with_src(&blob_url) else {
+        is_playing.set(false);
+        return;
+    };
+    let _ = audio.set_attribute("preload", "auto");
+
+    stop_current_audio();
+
+    let is_playing_end = is_playing;
+    let on_end = Closure::<dyn FnMut()>::new(move || {
+        is_playing_end.set(false);
+    });
+    audio.set_onended(Some(on_end.as_ref().unchecked_ref()));
+
+    // Mid-stream errors (e.g. the source becomes invalid after a successful
+    // start) fire neither onended nor a play() Promise rejection — the promise
+    // already resolved at start. Without onerror, is_playing would stay `true`
+    // and the button would be permanently stuck in "Stop". The redundant
+    // set(false) relative to on_end is idempotent.
+    let is_playing_error = is_playing;
+    let path_for_error = path.to_string();
+    let on_error = Closure::<dyn FnMut()>::new(move || {
+        tracing::warn!(path = %path_for_error, "AudioButtons playback error, releasing button state");
+        is_playing_error.set(false);
+    });
+    audio.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+
+    let is_playing_stop = is_playing;
+    register_audio(
+        audio.clone(),
+        Some(Box::new(move || {
+            is_playing_stop.set(false);
+        })),
+        vec![on_end, on_error],
+    );
+
+    // Bug B fix: consume the play() Promise so a rejection (decode failure,
+    // autoplay policy) does not surface as an uncaught rejection. onerror does
+    // NOT fire for autoplay-policy NotAllowedError, so we must reset is_playing
+    // here to avoid a permanently-disabled button.
+    match audio.play() {
+        Ok(promise) => {
+            if JsFuture::from(promise).await.is_err() {
+                is_playing.set(false);
+            }
+        },
+        Err(_) => {
+            is_playing.set(false);
+        },
     }
 }

--- a/origa_ui/src/ui_components/audio_player.rs
+++ b/origa_ui/src/ui_components/audio_player.rs
@@ -1,8 +1,11 @@
 use leptos::prelude::*;
+use leptos::task::spawn_local;
 use leptos_icons::Icon;
 use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
 
 use super::word_audio::{register_audio, stop_current_audio};
+use crate::repository::cdn_provider::{prefetch_blob_url, resolve_audio_url};
 
 #[derive(Clone, Copy, PartialEq)]
 enum PlaybackState {
@@ -13,11 +16,16 @@ enum PlaybackState {
 
 #[component]
 pub fn AudioPlayer(
-    #[prop(into)] src: String,
+    /// CDN path (e.g. `phrases/audio/ABC.opus`). Always prefetched into a
+    /// `blob:` URL before being handed to `<audio>` — see
+    /// `cdn_provider::resolve_audio_url` for the gzip-on-CDN root cause.
+    #[prop(into)]
+    path: String,
     #[prop(optional)] autoplay: bool,
     #[prop(optional, into)] test_id: Signal<String>,
 ) -> impl IntoView {
     let audio_ref = NodeRef::<leptos::html::Audio>::new();
+    let blob_url: RwSignal<Option<String>> = RwSignal::new(None);
     let state = RwSignal::new(if autoplay {
         PlaybackState::Loading
     } else {
@@ -29,50 +37,73 @@ pub fn AudioPlayer(
         if val.is_empty() { None } else { Some(val) }
     };
 
-    Effect::new(move |_| {
-        if autoplay {
-            if let Some(audio) = audio_ref.get() {
-                stop_current_audio();
-                let state_clone = state;
-                register_audio(
-                    audio.clone().unchecked_into(),
-                    Some(Box::new(move || {
-                        state_clone.set(PlaybackState::Idle);
-                    })),
-                    vec![],
-                );
-                let _ = audio.play();
-                state.set(PlaybackState::Loading);
+    // Bug A fix: never feed the raw CDN URL to <audio> (Hikari gzip). The sync
+    // fast-path returns the cached blob URL instantly when the phrase has
+    // already been materialised (e.g. replay); on cache miss we await
+    // `prefetch_blob_url` so `blob_url` reactively updates for autoplay.
+    // `resolve_audio_url` is a pure lookup, so there is no double-fetch race.
+    let path_for_prefetch = path.clone();
+    if let Some(url) = resolve_audio_url(&path_for_prefetch) {
+        blob_url.set(Some(url));
+    } else {
+        spawn_local(async move {
+            match prefetch_blob_url(&path_for_prefetch).await {
+                Ok(url) => blob_url.set(Some(url)),
+                Err(e) => {
+                    tracing::warn!(path = %path_for_prefetch, error = ?e, "AudioPlayer prefetch failed")
+                },
             }
+        });
+    }
+
+    // Autoplay: trigger play() once the blob URL lands and the audio element
+    // is mounted. Re-runs reactively whenever `blob_url` becomes Some.
+    Effect::new(move |_| {
+        let Some(url) = blob_url.get() else { return };
+        let Some(audio) = audio_ref.get() else { return };
+        audio.set_src(&url);
+        if autoplay {
+            stop_current_audio();
+            let state_clone = state;
+            register_audio(
+                audio.clone().unchecked_into(),
+                Some(Box::new(move || {
+                    state_clone.set(PlaybackState::Idle);
+                })),
+                vec![],
+            );
+            state.set(PlaybackState::Loading);
+            let reset = move || state.set(PlaybackState::Idle);
+            spawn_play_with_catch(audio, reset);
         }
     });
 
     let toggle_play = move |_| {
-        if let Some(audio) = audio_ref.get() {
-            match state.get() {
-                PlaybackState::Playing => {
-                    let _ = audio.pause();
-                    state.set(PlaybackState::Idle);
-                },
-                _ => {
-                    stop_current_audio();
-                    audio.set_current_time(0.0);
-                    let state_clone = state;
-                    let audio_ref_clone = audio_ref;
-                    register_audio(
-                        audio.clone().unchecked_into(),
-                        Some(Box::new(move || {
-                            if let Some(a) = audio_ref_clone.get() {
-                                let _ = a.pause();
-                            }
-                            state_clone.set(PlaybackState::Idle);
-                        })),
-                        vec![],
-                    );
-                    state.set(PlaybackState::Loading);
-                    let _ = audio.play();
-                },
-            }
+        let Some(audio) = audio_ref.get() else { return };
+        match state.get() {
+            PlaybackState::Playing => {
+                let _ = audio.pause();
+                state.set(PlaybackState::Idle);
+            },
+            _ => {
+                stop_current_audio();
+                audio.set_current_time(0.0);
+                let state_clone = state;
+                let audio_ref_clone = audio_ref;
+                register_audio(
+                    audio.clone().unchecked_into(),
+                    Some(Box::new(move || {
+                        if let Some(a) = audio_ref_clone.get() {
+                            let _ = a.pause();
+                        }
+                        state_clone.set(PlaybackState::Idle);
+                    })),
+                    vec![],
+                );
+                state.set(PlaybackState::Loading);
+                let reset = move || state.set(PlaybackState::Idle);
+                spawn_play_with_catch(audio, reset);
+            },
         }
     };
 
@@ -100,7 +131,6 @@ pub fn AudioPlayer(
         <div class="audio-player flex items-center justify-center" data-testid=test_id_val>
             <audio
                 node_ref=audio_ref
-                src=src.clone()
                 preload="none"
                 on:playing=on_playing
                 on:waiting=on_waiting
@@ -131,4 +161,28 @@ pub fn AudioPlayer(
             </button>
         </div>
     }
+}
+
+/// Invoke `HTMLAudioElement.play()` and absorb Promise rejection.
+///
+/// `play()` returns a Promise that rejects when the element cannot decode the
+/// source or when autoplay policy blocks playback (NotAllowedError). Awaiting
+/// the Promise via `JsFuture` marks the rejection as handled, which keeps the
+/// console clean (Bug B). Crucially, on rejection `on_reject` is invoked so the
+/// caller can reset its UI state — `HTMLMediaElement.onerror` does NOT fire for
+/// autoplay-policy rejections, so without this the caller would stay stuck in
+/// its "loading/playing" state forever.
+fn spawn_play_with_catch(audio: web_sys::HtmlAudioElement, on_reject: impl FnOnce() + 'static) {
+    let promise = match audio.play() {
+        Ok(p) => p,
+        Err(_) => {
+            on_reject();
+            return;
+        },
+    };
+    spawn_local(async move {
+        if JsFuture::from(promise).await.is_err() {
+            on_reject();
+        }
+    });
 }

--- a/origa_ui/src/ui_components/word_audio.rs
+++ b/origa_ui/src/ui_components/word_audio.rs
@@ -1,11 +1,15 @@
 use std::cell::RefCell;
+use std::rc::Rc;
 
+use leptos::task::spawn_local;
 use leptos::wasm_bindgen::JsCast;
 use leptos::wasm_bindgen::closure::Closure;
 use origa::dictionary::pitch_audio::get_audio_for_reading;
 use tracing::warn;
+use wasm_bindgen_futures::JsFuture;
 
 use super::{get_reading_from_text, speak_tts_text, speak_tts_text_with_callback, stop_speech};
+use crate::repository::cdn_provider::prefetch_blob_url;
 
 struct ActiveAudio {
     element: web_sys::HtmlAudioElement,
@@ -58,49 +62,114 @@ fn kata_to_hira(text: &str) -> String {
         .collect()
 }
 
-fn create_and_play_audio(word: &str) -> Option<web_sys::HtmlAudioElement> {
+/// Resolve the CDN dictionary path for a word's pitch audio, if available.
+fn lookup_audio_path(word: &str) -> Option<String> {
     let reading = get_reading_from_text(word);
     let reading_hira = kata_to_hira(&reading);
     let entry = get_audio_for_reading(word, &reading_hira)?;
-    let path = format!("/{}", entry.cdn_path());
-    let url = crate::repository::cdn_provider::resolve_audio_url(&path);
+    Some(format!("/{}", entry.cdn_path()))
+}
 
-    let audio = web_sys::HtmlAudioElement::new().ok()?;
-    audio.set_src(&url);
-    let _ = audio.set_attribute("preload", "auto");
+/// Prefetch the blob URL for `word` and play it. `on_end` is invoked when the
+/// audio finishes naturally (used by callback variants). If the lookup yields
+/// no dictionary path, the function falls back to TTS synchronously.
+fn schedule_word_audio_play<F>(word: &str, rate: f32, on_end: Option<F>)
+where
+    F: FnMut() + 'static,
+{
+    let Some(path) = lookup_audio_path(word) else {
+        stop_current_audio();
+        let reading = get_reading_from_text(word);
+        match on_end {
+            Some(cb) => {
+                let _ = speak_tts_text_with_callback(&reading, rate, cb);
+            },
+            None => {
+                let _ = speak_tts_text(&reading, rate);
+            },
+        }
+        return;
+    };
 
+    let word_owned = word.to_string();
+    let on_end_rc: Rc<RefCell<Option<F>>> = Rc::new(RefCell::new(on_end));
+    // Stop synchronously before the async prefetch so a previously-playing word
+    // does not overlap the new one during the network round-trip.
     stop_current_audio();
+    spawn_local(async move {
+        let blob_url = match prefetch_blob_url(&path).await {
+            Ok(u) => u,
+            Err(e) => {
+                warn!(word = %word_owned, error = ?e, "CDN audio prefetch failed, falling back to TTS");
+                fallback_to_tts(&word_owned, rate, &on_end_rc);
+                return;
+            },
+        };
 
-    register_audio(audio.clone(), None, vec![]);
+        let Some(audio) = web_sys::HtmlAudioElement::new().ok() else {
+            fallback_to_tts(&word_owned, rate, &on_end_rc);
+            return;
+        };
+        audio.set_src(&blob_url);
+        let _ = audio.set_attribute("preload", "auto");
 
-    let _ = audio.play();
-    Some(audio)
+        let mut closures: Vec<Closure<dyn FnMut()>> = Vec::new();
+
+        // on_ended and on_error race for the single-use on_end callback: whoever
+        // fires first drains `on_end_rc` and either invokes the callback
+        // directly (on_ended) or feeds it into the TTS fallback chain
+        // (on_error) so downstream UI state is always released exactly once.
+        let cb_ended = Rc::clone(&on_end_rc);
+        let on_ended = Closure::<dyn FnMut()>::new(move || {
+            if let Some(mut cb) = cb_ended.borrow_mut().take() {
+                cb();
+            }
+        });
+        audio.set_onended(Some(on_ended.as_ref().unchecked_ref()));
+        closures.push(on_ended);
+
+        let cb_error = Rc::clone(&on_end_rc);
+        let word_for_error = word_owned.clone();
+        let on_error = Closure::<dyn FnMut()>::new(move || {
+            warn!(word = %word_for_error, "CDN audio failed during playback, falling back to TTS");
+            fallback_to_tts(&word_for_error, rate, &cb_error);
+        });
+        audio.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+        closures.push(on_error);
+
+        register_audio(audio.clone(), None, closures);
+
+        // Bug B fix: consume the play() Promise to avoid an uncaught rejection.
+        // onerror does NOT fire for autoplay-policy NotAllowedError, so on
+        // rejection we drain the callback and fall back to TTS to release any
+        // downstream UI state.
+        if let Ok(promise) = audio.play() {
+            if JsFuture::from(promise).await.is_err() {
+                warn!(word = %word_owned, "audio.play() rejected, falling back to TTS");
+                fallback_to_tts(&word_owned, rate, &on_end_rc);
+            }
+        }
+    });
+}
+
+/// Drain the optional on-end callback and trigger the TTS fallback chain.
+fn fallback_to_tts<F>(word: &str, rate: f32, on_end: &Rc<RefCell<Option<F>>>)
+where
+    F: FnMut() + 'static,
+{
+    let reading = get_reading_from_text(word);
+    if let Some(cb) = on_end.borrow_mut().take() {
+        let _ = speak_tts_text_with_callback(&reading, rate, cb);
+    } else {
+        let _ = speak_tts_text(&reading, rate);
+    }
 }
 
 pub fn speak_word(word: &str, rate: f32) {
     if word.is_empty() {
         return;
     }
-
-    let audio = match create_and_play_audio(word) {
-        Some(a) => a,
-        None => {
-            stop_current_audio();
-            let reading = get_reading_from_text(word);
-            let _ = speak_tts_text(&reading, rate);
-            return;
-        },
-    };
-
-    let word_owned = word.to_string();
-    let on_error = Closure::<dyn FnMut()>::new(move || {
-        warn!(word = %word_owned, "CDN audio failed, falling back to TTS");
-        let reading = get_reading_from_text(&word_owned);
-        let _ = speak_tts_text(&reading, rate);
-    });
-    audio.set_onerror(Some(on_error.as_ref().unchecked_ref()));
-
-    register_audio(audio, None, vec![on_error]);
+    schedule_word_audio_play::<fn()>(word, rate, None);
 }
 
 pub fn speak_word_with_callback<F>(word: &str, rate: f32, on_end: F)
@@ -110,39 +179,7 @@ where
     if word.is_empty() {
         return;
     }
-
-    let audio = match create_and_play_audio(word) {
-        Some(a) => a,
-        None => {
-            stop_current_audio();
-            let reading = get_reading_from_text(word);
-            let _ = speak_tts_text_with_callback(&reading, rate, on_end);
-            return;
-        },
-    };
-
-    let callback = std::rc::Rc::new(RefCell::new(Some(on_end)));
-
-    let cb_ended = callback.clone();
-    let on_ended = Closure::<dyn FnMut()>::new(move || {
-        if let Some(mut cb) = cb_ended.borrow_mut().take() {
-            cb();
-        }
-    });
-    audio.set_onended(Some(on_ended.as_ref().unchecked_ref()));
-
-    let cb_error = callback.clone();
-    let word_owned = word.to_string();
-    let on_error = Closure::<dyn FnMut()>::new(move || {
-        warn!(word = %word_owned, "CDN audio failed (with callback), falling back to TTS");
-        if let Some(cb) = cb_error.borrow_mut().take() {
-            let reading = get_reading_from_text(&word_owned);
-            let _ = speak_tts_text_with_callback(&reading, rate, cb);
-        }
-    });
-    audio.set_onerror(Some(on_error.as_ref().unchecked_ref()));
-
-    register_audio(audio, None, vec![on_ended, on_error]);
+    schedule_word_audio_play(word, rate, Some(on_end));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

After one phrase played, subsequent phrases fell back to TTS. Root cause: Railway Hikari proxy applies `Content-Encoding: gzip` on-the-fly to `.opus` files, and Chromium `<audio>` element does not decompress transport encoding (crbug 1029876).

## Prove-It
- Slice-1: 5 unit tests in `cdn_provider::tests` + compile-time witness test on `Option<String>` contract
- curl evidence: `Accept-Encoding: gzip` → 3145 bytes (gzip makes already-compressed Opus **larger** than identity's 3139 bytes)

## Fix (4 slices, GATE-approved)
- `resolve_audio_url() -> Option<String>` — never returns CDN URL
- All callers `spawn_local { prefetch_blob_url().await; play }` — fetch() transparently decompresses
- All `let _ = audio.play()` → `JsFuture::from(promise).await` with rejection branch
- Single-fire TTS fallback via `Rc<RefCell<Option<Box<dyn FnMut()>>>>::take()` drain pattern
- `AudioButtons::play_phrase_audio` installs `onerror` (was missing → stuck button)

## Verification
- `cargo test -p origa_ui`: 167 passed
- `cargo clippy --workspace --all-targets -- -D warnings`: 0 warnings
- `cargo build -p origa-ui / -p origa-app`: PASS
- Code review: approve (0 High after C1+C3 fixes)

## Manual checkpoint (Tauri WebView)
Open a lesson with phrases, verify all phrases play CDN audio consecutively, no `ERR_CONTENT_DECODING_FAILED`, `blob:` URLs in `<audio>` src.

Refs: crbug 1029876, crbug 596361, crbug 1247420
