### PR TITLE
fix(app): restrict App Effect navigate to /login only (E2E regression hotfix)

### DIFF
--- a/docs/decisions/ADR-010-mobile-session-persistence.md
+++ b/docs/decisions/ADR-010-mobile-session-persistence.md
@@ -96,15 +96,29 @@ point.
 
 The redirect Effect is moved from `Login` (which can unmount) to `App()` (always
 mounted). It watches `auth_store.is_authenticated()` and navigates to `/home`
-via `use_navigate()` (SPA, no reload) when the user becomes authenticated. This
-covers **both** paths:
-
-- Email/password: `login()` calls `self.user.set(Some(user))` → Effect fires.
-- OAuth: `set_oauth_session()` writes the session asynchronously and calls
-  `self.user.set(Some(user))` → Effect fires.
+via `use_navigate()` (SPA, no reload) when the user becomes authenticated.
 
 The old `window.location().set_href("/home")` calls in `handle_oauth_result()`
 and `redirect_to_home()` are removed entirely — the Effect replaces them.
+
+> **Amendment (E2E hotfix):** The original Effect navigated to `/home`
+> unconditionally on authentication. This caused two race conditions:
+>
+> 1. **Transient `/home` race** — After email/password login (user on `/`),
+>    the Effect navigated to `/home`, then Home's onboarding guard redirected
+>    new users to `/onboarding`. Playwright's `waitForURL` caught the transient
+>    `/home`, causing E2E tests to miss the onboarding skip button.
+> 2. **Deep-link clobbering** — Reloading on a protected route (`/words`,
+>    `/kanji`, ...) triggered `check_session` → `is_authenticated` false→true →
+>    Effect navigated back to `/home`, clobbering the destination.
+>
+> The Effect now navigates to `/home` **only when `current_path == "/login"`**.
+> The email/password path relies on natural routing: the user is on `/` which
+> renders `<ProtectedRoute><Home/></ProtectedRoute>`, so after `user.set(Some)`
+> the ProtectedRoute renders Home, and Home's onboarding guard redirects to
+> `/onboarding` — no transient `/home`. The pathname is read via
+> `web_sys::window()` (non-reactive) so the Effect only re-runs when
+> `is_authenticated` actually changes.
 
 ### AD-4: `App()` initialization ordering
 

--- a/origa_ui/src/app.rs
+++ b/origa_ui/src/app.rs
@@ -1,7 +1,7 @@
 use leptos::prelude::*;
 use leptos::task::spawn_local;
 use leptos_router::hooks::use_navigate;
-use tracing::{debug, error};
+use tracing::{debug, error, trace};
 
 use crate::core::updater;
 use crate::i18n::{native_language_to_locale, use_i18n};
@@ -71,17 +71,51 @@ pub fn App() -> impl IntoView {
 
     // AD-3: SPA navigate Effect — always mounted in App() (unlike the Login
     // page which can unmount). Watches is_authenticated() and navigates to
-    // /home when the user becomes authenticated. This covers BOTH the
-    // email/password path (where user.set is called explicitly in login())
-    // and the OAuth path (where set_oauth_session writes the session
-    // asynchronously via IPC + Store::save()). Replaces the old
-    // window.location.set_href("/home") which caused a full WebView reload
-    // with loss of reactive state.
+    // /home ONLY when the user is on /login. This covers the OAuth path where
+    // set_oauth_session writes the session asynchronously via IPC + Store and
+    // the /login route renders Login directly (outside ProtectedRoute), so
+    // without an explicit navigate the user would stay on /login after
+    // authentication.
+    //
+    // The email/password path does NOT need this Effect: the user is on /
+    // (root), which renders <ProtectedRoute><Home/></ProtectedRoute>. After
+    // user.set(Some), ProtectedRoute renders Home, and Home's onboarding guard
+    // redirects new users to /onboarding. Navigating to /home from / would
+    // create a transient /home URL that races with E2E waitForURL assertions.
+    //
+    // The URL guard also prevents the Effect from clobbering deep links when a
+    // user reloads on a protected route (/words, /kanji, ...): check_session
+    // flips is_authenticated false→true, but current_path is /words (not
+    // /login), so no navigate fires. The pathname is read via web_sys (no
+    // reactive subscription) so the Effect only re-runs when is_authenticated
+    // actually changes.
+    //
+    // KNOWN LIMITATION: the OAuth path still produces a transient /home URL
+    // (/login → /home → /onboarding for new users). This is the same race
+    // window that was fixed for email/password, but there are currently no
+    // OAuth E2E tests with URL assertions that would catch it. If such tests
+    // are added, the OAuth callback handler should navigate directly to
+    // /onboarding for new users (or the Effect should be replaced with a
+    // route-level guard).
+    const LOGIN_REDIRECT_PATH: &str = "/login";
     let auth_store_for_nav = auth_store.clone();
     Effect::new(move |_| {
         if auth_store_for_nav.is_authenticated().get() {
-            debug!("redirect_decision: authenticated → navigate to /home");
-            navigate("/home", Default::default());
+            let current_path = web_sys::window()
+                .and_then(|w| w.location().pathname().ok())
+                .unwrap_or_default();
+            if current_path == LOGIN_REDIRECT_PATH {
+                debug!(
+                    current_path,
+                    "redirect_decision: on /login → navigate to /home"
+                );
+                navigate("/home", Default::default());
+            } else {
+                trace!(
+                    current_path,
+                    "redirect_decision: authenticated but not on /login, no navigate"
+                );
+            }
         }
     });
 

--- a/origa_ui/src/pages/login/mod.rs
+++ b/origa_ui/src/pages/login/mod.rs
@@ -37,9 +37,13 @@ pub fn Login() -> impl IntoView {
 
     let auth_store_for_view = auth_store.clone();
 
-    // Navigation after successful login is handled by the App()-level Effect
-    // that watches is_authenticated() (see app.rs). This covers both the
-    // email/password and OAuth paths uniformly.
+    // Navigation after successful email/password login is handled by natural
+    // routing: user.set(Some) flips is_authenticated, ProtectedRoute (which
+    // wraps the / route) renders Home, and Home's onboarding guard redirects
+    // new users to /onboarding. This avoids a transient /home URL that races
+    // with E2E waitForURL assertions. The App()-level Effect (see app.rs)
+    // covers the OAuth path where the user is on /login (outside
+    // ProtectedRoute) and must be navigated explicitly.
     let on_email_submit = Callback::new({
         move |(email, password): (String, String)| {
             let auth_store = auth_store.clone();


### PR DESCRIPTION
## 🚨 Hotfix: E2E regression from PR #161

Master is broken — 10/12 E2E suites fail with "element(s) not found". git-bisect confirmed PR #161 (`edb03981`) introduced the regression.

## Root cause (TWO race conditions)

1. **Transient `/home` race (primary):** After email/password login on `/`, App Effect navigated to `/home` → Home redirected new users to `/onboarding` → Playwright caught transient `/home` → skip button not clicked → cascade.
2. **Deep-link clobbering:** Page reload on `/words` → `is_authenticated` false→true → Effect navigated to `/home`, overwriting `/words`.

## Fix

Effect now only navigates when `current_path == "/login"`. Email/password login on `/` handled by natural routing through `ProtectedRoute` (URL flow: `/` → `/onboarding`, no transient `/home`). Deep-link reloads preserved.

## Verification

| Check | Status |
|-------|--------|
| `cargo test --workspace` | ✅ 1522 passed |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ 0 warnings |
| Local E2E | ✅ 155/155 PASS |
| git-bisect | ✅ cae63a8b PASS → edb03981 FAIL → hotfix PASS |
| Code review | ✅ approve (0H/0C after fixes) |

## Known limitation

OAuth path (`/login` → `/home` → `/onboarding`) retains transient race window. No OAuth E2E with URL assertions currently. Documented in ADR-010 amendment.

Refs: regression from PR #161 (edb03981)
