### PR TITLE
fix(login): constrain card to 480px max-width on wide screens

### DIFF
--- a/origa_ui/src/pages/login/mod.rs
+++ b/origa_ui/src/pages/login/mod.rs
@@ -72,7 +72,7 @@ pub fn Login() -> impl IntoView {
 
     view! {
         <PageLayout variant=PageLayoutVariant::Full test_id=Signal::derive(|| "login-page".to_string())>
-            <CardLayout size=CardLayoutSize::Adaptive class="px-4 pt-4 pb-8" test_id=Signal::derive(|| "login-card".to_string())>
+            <CardLayout size=CardLayoutSize::Small class="px-4 pt-4 pb-8" test_id=Signal::derive(|| "login-card".to_string())>
                 <LoginLanguageToggle test_id=Signal::derive(|| "login-lang-toggle".to_string()) />
                 <LoginHeader />
                 <div class="space-y-6">

--- a/origa_ui/src/ui_components/layout.rs
+++ b/origa_ui/src/ui_components/layout.rs
@@ -42,7 +42,6 @@ pub fn PageLayout(
 
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub enum CardLayoutSize {
-    #[expect(dead_code, reason = "design system API")]
     Small,
 
     #[expect(dead_code, reason = "design system API")]


### PR DESCRIPTION
## Summary

Login card stretched edge-to-edge on wide monitors. Switched to `CardLayoutSize::Small` (480px max-width + centered).

## Fix
- `login/mod.rs`: `CardLayoutSize::Adaptive` → `CardLayoutSize::Small`
- `layout.rs`: removed `#[expect(dead_code)]` from `Small` variant (now used)

## Verification
- `cargo test -p origa_ui`: 167 passed
- clippy: 0 warnings
- Code review: approve

Manual visual verify recommended at viewport >= 768px.