### PR TITLE
fix(ci): skip artifact signing for Dependabot PRs

### DIFF
--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -69,8 +69,16 @@ jobs:
             ORIGA_VERSION: ${{ inputs.version }}
             ORIGA_COMMIT: ${{ inputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ inputs.build_date }}
-            TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.tauri-signing-private-key }}
-            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.tauri-signing-private-key-password }}
+            # Skip updater signing for Dependabot PRs. GitHub hides repository
+            # `secrets.*` from Dependabot runs, but caller workflows pass a
+            # dummy private key via `vars.TAURI_CI_DUMMY_PRIVATE_KEY` (vars are
+            # visible to Dependabot). The dummy key reaches the build, yet its
+            # password is empty — Tauri fails with "incorrect updater private
+            # key password: Wrong password for that key". Short-circuiting to
+            # an empty value makes Tauri skip the updater signing step entirely,
+            # which is the desired behaviour for compile-only verification.
+            TAURI_SIGNING_PRIVATE_KEY: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key || '' }}
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key-password || '' }}
             XWIN_CACHE_DIR: ${{ github.workspace }}/.xwin-cache
 
         steps:
@@ -165,8 +173,10 @@ jobs:
             ORIGA_VERSION: ${{ inputs.version }}
             ORIGA_COMMIT: ${{ inputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ inputs.build_date }}
-            TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.tauri-signing-private-key }}
-            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.tauri-signing-private-key-password }}
+            # Skip updater signing for Dependabot PRs — see build-windows for
+            # the full rationale.
+            TAURI_SIGNING_PRIVATE_KEY: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key || '' }}
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key-password || '' }}
 
         steps:
             - name: Checkout repository
@@ -259,8 +269,10 @@ jobs:
             ORIGA_VERSION: ${{ inputs.version }}
             ORIGA_COMMIT: ${{ inputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ inputs.build_date }}
-            TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.tauri-signing-private-key }}
-            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.tauri-signing-private-key-password }}
+            # Skip updater signing for Dependabot PRs — see build-windows for
+            # the full rationale.
+            TAURI_SIGNING_PRIVATE_KEY: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key || '' }}
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key-password || '' }}
 
         steps:
             - name: Checkout repository
@@ -349,7 +361,12 @@ jobs:
 
     build-android:
         name: Build Android
-        if: contains(inputs.platforms, 'android') && inputs.skip_android != true
+        # Defense-in-depth: caller workflows already pass `skip_android: true`
+        # for Dependabot, but adding the actor check here makes this reusable
+        # workflow self-sufficient — Android release APKs cannot build without a
+        # valid keystore, which GitHub never exposes to Dependabot runs. See
+        # build-windows for the broader signing-secret rationale.
+        if: contains(inputs.platforms, 'android') && inputs.skip_android != true && github.actor != 'dependabot[bot]'
         runs-on: ubuntu-24.04
         permissions:
             contents: read


### PR DESCRIPTION
## Summary

All Dependabot PRs fail during Tauri bundle signing: `incorrect updater private key password`. GitHub doesn't pass secrets to Dependabot runs by default.

## Fix

Conditional signing env vars + Android job-level skip for `github.actor == 'dependabot[bot]'`.

## Verification
- YAML valid
- qlty clean
- Code review: approve

## After merge

Rerun all 8 Dependabot PR runs — they'll pick up the new workflow from master.