### PR TITLE
test(tokenizer): smoke test harness on 771 phrases + fix grammar_label for hiragana-text

### DIFF
--- a/origa/src/domain/furigana_annotator.rs
+++ b/origa/src/domain/furigana_annotator.rs
@@ -1,5 +1,7 @@
 use crate::dictionary::furigana_dict::{self, FuriganaEntry, ReadingSpan, get_furigana_dict};
 use crate::domain::OrigaError;
+use crate::domain::hiragana_to_katakana;
+use crate::domain::katakana_to_hiragana;
 use crate::domain::tokenizer::{TokenInfo, tokenize_text};
 
 #[derive(Debug, Clone)]
@@ -185,68 +187,9 @@ fn sort_by_reading_hint(entries: &mut Vec<&FuriganaEntry>, hint: Option<&str>) {
     });
 }
 
-fn katakana_to_hiragana(text: &str) -> String {
-    text.chars()
-        .map(|c| {
-            if ('\u{30A1}'..='\u{30F6}').contains(&c) {
-                char::from_u32(c as u32 - 0x60)
-                    .expect("katakana→hiragana range 0x3041..0x3096 is valid unicode")
-            } else {
-                c
-            }
-        })
-        .collect()
-}
-
-fn hiragana_to_katakana(text: &str) -> String {
-    text.chars()
-        .map(|c| {
-            if ('\u{3041}'..='\u{3096}').contains(&c) {
-                char::from_u32(c as u32 + 0x60)
-                    .expect("hiragana→katakana range 0x30A1..0x30F6 is valid unicode")
-            } else {
-                c
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn katakana_to_hiragana_converts_standard_range() {
-        assert_eq!(katakana_to_hiragana("タベモノ"), "たべもの");
-        assert_eq!(katakana_to_hiragana("ア"), "あ");
-        assert_eq!(katakana_to_hiragana("ン"), "ん");
-    }
-
-    #[test]
-    fn katakana_to_hiragana_preserves_non_katakana() {
-        assert_eq!(katakana_to_hiragana("hello"), "hello");
-        assert_eq!(katakana_to_hiragana("あいう"), "あいう");
-        assert_eq!(katakana_to_hiragana("123"), "123");
-    }
-
-    #[test]
-    fn katakana_to_hiragana_preserves_prolonged_sound_mark() {
-        assert_eq!(katakana_to_hiragana("バー"), "ばー");
-    }
-
-    #[test]
-    fn hiragana_to_katakana_converts_standard_range() {
-        assert_eq!(hiragana_to_katakana("たべもの"), "タベモノ");
-        assert_eq!(hiragana_to_katakana("あ"), "ア");
-        assert_eq!(hiragana_to_katakana("ん"), "ン");
-    }
-
-    #[test]
-    fn hiragana_to_katakana_preserves_non_hiragana() {
-        assert_eq!(hiragana_to_katakana("hello"), "hello");
-        assert_eq!(hiragana_to_katakana("アイウ"), "アイウ");
-        assert_eq!(hiragana_to_katakana("123"), "123");
-    }
 
     #[test]
     fn sort_by_reading_hint_prioritizes_matching_reading() {

--- a/origa/src/domain/japanese.rs
+++ b/origa/src/domain/japanese.rs
@@ -57,6 +57,47 @@ impl JapaneseText for str {
     }
 }
 
+/// Maps every katakana codepoint in ``text`` to its hiragana counterpart by
+/// subtracting the Unicode offset (``0x60``) between the two blocks.
+///
+/// The range ``0x30A1..=0x30F6`` excludes ``ー`` (long vowel, ``U+30FC``), the
+/// katakana middle dot ``・`` (``U+30FB``) and the voiced ``ヷ..ヺ`` row
+/// (``U+30F7..=U+30FA``) on purpose: those have no clean hiragana counterpart
+/// and are passed through unchanged. ``ヴ`` (``U+30F4``) lands on the
+/// rarely-used but valid hiragana ``ゔ`` (``U+3094``).
+///
+/// Shared by ``furigana_annotator`` (reading-hint comparison) and the
+/// translation pipeline (hiragana-base fallback for grammar_label resolution).
+pub fn katakana_to_hiragana(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            if ('\u{30A1}'..='\u{30F6}').contains(&c) {
+                char::from_u32(c as u32 - 0x60)
+                    .expect("katakana→hiragana range 0x3041..0x3096 is valid unicode")
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+/// Maps every hiragana codepoint in ``text`` to its katakana counterpart by
+/// adding the Unicode offset (``0x60``) between the two blocks.
+///
+/// Inverse of [`katakana_to_hiragana`]; same block boundaries apply.
+pub fn hiragana_to_katakana(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            if ('\u{3041}'..='\u{3096}').contains(&c) {
+                char::from_u32(c as u32 + 0x60)
+                    .expect("hiragana→katakana range 0x30A1..0x30F6 is valid unicode")
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,5 +216,38 @@ mod tests {
         assert!('？'.is_japanese(), "？ should be classified as Japanese");
         assert!('！'.is_japanese(), "！ should be classified as Japanese");
         assert!('…'.is_japanese(), "… should be classified as Japanese");
+    }
+
+    #[test]
+    fn katakana_to_hiragana_converts_standard_range() {
+        assert_eq!(katakana_to_hiragana("タベモノ"), "たべもの");
+        assert_eq!(katakana_to_hiragana("ア"), "あ");
+        assert_eq!(katakana_to_hiragana("ン"), "ん");
+    }
+
+    #[test]
+    fn katakana_to_hiragana_preserves_non_katakana() {
+        assert_eq!(katakana_to_hiragana("hello"), "hello");
+        assert_eq!(katakana_to_hiragana("あいう"), "あいう");
+        assert_eq!(katakana_to_hiragana("123"), "123");
+    }
+
+    #[test]
+    fn katakana_to_hiragana_preserves_prolonged_sound_mark() {
+        assert_eq!(katakana_to_hiragana("バー"), "ばー");
+    }
+
+    #[test]
+    fn hiragana_to_katakana_converts_standard_range() {
+        assert_eq!(hiragana_to_katakana("たべもの"), "タベモノ");
+        assert_eq!(hiragana_to_katakana("あ"), "ア");
+        assert_eq!(hiragana_to_katakana("ん"), "ン");
+    }
+
+    #[test]
+    fn hiragana_to_katakana_preserves_non_hiragana() {
+        assert_eq!(hiragana_to_katakana("hello"), "hello");
+        assert_eq!(hiragana_to_katakana("アイウ"), "アイウ");
+        assert_eq!(hiragana_to_katakana("123"), "123");
     }
 }

--- a/origa/src/domain/mod.rs
+++ b/origa/src/domain/mod.rs
@@ -26,6 +26,7 @@ pub use grammar::quiz_generation::{
 };
 pub use grammar::{detect_format_map_rules, detect_grammar_rules_in_text, detect_keyword_rules};
 pub use japanese::{JapaneseChar, JapaneseText};
+pub use japanese::{hiragana_to_katakana, katakana_to_hiragana};
 pub use jlpt_content::{JlptContent, JlptContentError};
 pub use jlpt_progress::{CategoryProgress, JlptProgress, LevelProgressDetail};
 pub use knowledge::{

--- a/origa/src/domain/tokenizer/translation.rs
+++ b/origa/src/domain/tokenizer/translation.rs
@@ -3,8 +3,10 @@ use serde::Serialize;
 use super::{PartOfSpeech, TokenInfo};
 use crate::dictionary::grammar::GRAMMAR_RULES;
 use crate::dictionary::vocabulary::get_translation;
+use crate::domain::JapaneseChar;
 use crate::domain::NativeLanguage;
 use crate::domain::grammar::find_format_map_matches;
+use crate::domain::katakana_to_hiragana;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TokenTranslation {
@@ -26,13 +28,7 @@ pub fn lookup_tokens_translations(
         .map(|token| {
             let base_form = token.orthographic_base_form().to_string();
             let translation = get_translation(&base_form, native_language);
-            let grammar_label = resolve_grammar_label(
-                token.orthographic_surface_form(),
-                &base_form,
-                token.part_of_speech(),
-                native_language,
-                original_text,
-            );
+            let grammar_label = resolve_grammar_label(token, native_language, original_text);
 
             TokenTranslation {
                 surface_form: token.orthographic_surface_form().to_string(),
@@ -47,16 +43,18 @@ pub fn lookup_tokens_translations(
 }
 
 fn resolve_grammar_label(
-    surface: &str,
-    base: &str,
-    pos: &PartOfSpeech,
+    token: &TokenInfo,
     native_language: &NativeLanguage,
     original_text: &str,
 ) -> Option<String> {
     let rules = GRAMMAR_RULES.get()?;
+    let surface = token.orthographic_surface_form();
+    let base = token.orthographic_base_form();
+    let pos = token.part_of_speech();
+    let is_vocab = pos.is_vocabulary_word();
 
     // Keyword matching for non-vocabulary tokens (particles, auxiliaries, etc.)
-    if !pos.is_vocabulary_word() {
+    if !is_vocab {
         for rule in rules.iter() {
             for group in rule.keywords().iter() {
                 if group.iter().any(|kw| surface == kw) {
@@ -68,12 +66,39 @@ fn resolve_grammar_label(
 
     // FormatAction detection for vocabulary tokens where surface != base (conjugated forms).
     // When multiple rules match, the most specific (longest formatted form) is preferred.
-    if pos.is_vocabulary_word() && surface != base {
-        let matches = find_format_map_matches(base, pos, original_text, rules);
-        if let Some(best) = matches
-            .into_iter()
-            .max_by_key(|rule| rule.format(base, pos).map_or(0, |f| f.len()))
-        {
+    if is_vocab && surface != base {
+        let mut matches = find_format_map_matches(base, pos, original_text, rules);
+
+        // Lindera prefers the kanji lemma as ``base`` even when the user's
+        // phrase is written entirely in hiragana. ``find_format_map_matches``
+        // formats the base into its conjugated surface (e.g. ``分かる`` →
+        // ``分かって``) and checks the original text — but the kanji-formatted
+        // string never appears in a hiragana phrase, so the match silently
+        // fails. Retry the same chain with the hiragana-equivalent base
+        // derived from the katakana reading so ``分かる`` becomes ``わかる`` and
+        // the formatted ``わかって`` does occur inside ``わかってるなら``.
+        let hiragana_base = if base.chars().any(|c| c.is_kanji()) {
+            Some(katakana_to_hiragana(token.phonological_base_form()))
+        } else {
+            None
+        };
+
+        if let Some(ref hira) = hiragana_base {
+            matches.extend(find_format_map_matches(hira, pos, original_text, rules));
+        }
+
+        // Score each candidate by the longest format it produces across both
+        // bases (kanji + hiragana-equivalent) so rules that only match through
+        // the hiragana retry are not penalised when ``rule.format(base, pos)``
+        // happens to error on the kanji lemma.
+        if let Some(best) = matches.into_iter().max_by_key(|rule| {
+            let kanji_len = rule.format(base, pos).map_or(0, |f| f.len());
+            let hira_len = hiragana_base
+                .as_ref()
+                .map(|h| rule.format(h, pos).map_or(0, |f| f.len()))
+                .unwrap_or(0);
+            kanji_len.max(hira_len)
+        }) {
             return Some(best.content(native_language).title().to_string());
         }
     }

--- a/origa/tests/translation_smoke.rs
+++ b/origa/tests/translation_smoke.rs
@@ -1,0 +1,120 @@
+//! Smoke test for the translation pipeline over the p0000.json phrase corpus.
+//!
+//! Runs every phrase in `cdn/phrases/data/p0000.json` (~771 entries) through
+//! `tokenize_text` + `lookup_tokens_translations` and classifies anomalies
+//! using the FAIL/WARN taxonomy defined in `harness::ProblemKind`.
+//!
+//! - Slice-1 entry point: `should_load_phrase_chunk_and_tokenize_first_phrase`.
+//! - Slice-2 discovery harness: `discover_translation_problems_russian` and
+//!   `discover_translation_problems_english` (`#[ignore]`, run with
+//!   `--nocapture --ignored`).
+//! - Slice-3 regression tests: parameterized cases that pin down fixes.
+
+#[path = "translation_smoke/bootstrap.rs"]
+mod bootstrap;
+#[path = "translation_smoke/classify.rs"]
+mod classify;
+#[path = "translation_smoke/data.rs"]
+mod data;
+#[path = "translation_smoke/harness.rs"]
+mod harness;
+#[path = "translation_smoke/report.rs"]
+mod report;
+
+use rstest::rstest;
+
+use origa::domain::{JapaneseChar, NativeLanguage, lookup_tokens_translations, tokenize_text};
+
+use bootstrap::ensure_all_dictionaries;
+use data::load_phrase_texts_from_chunk;
+
+#[test]
+fn should_load_phrase_chunk_and_tokenize_first_phrase() {
+    if !ensure_all_dictionaries() {
+        eprintln!(
+            "skip: cdn/ artifacts absent \
+             (cdn/ is gitignored; restore via scripts/deploy_cdn.py)"
+        );
+        return;
+    }
+
+    let phrases = match load_phrase_texts_from_chunk("p0000.json") {
+        Some(texts) => texts,
+        None => {
+            eprintln!(
+                "skip: cdn/phrases/data/p0000.json absent \
+                 (cdn/ is gitignored; restore via scripts/deploy_cdn.py)"
+            );
+            return;
+        },
+    };
+
+    assert!(
+        !phrases.is_empty(),
+        "p0000.json must contain at least one phrase"
+    );
+
+    let first = &phrases[0];
+    let tokens = tokenize_text(first).expect("first phrase must tokenize");
+    let translations = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, first);
+
+    assert!(
+        !translations.is_empty(),
+        "first phrase must produce at least one token translation"
+    );
+}
+
+/// Slice-3 RED tests: when a phrase is written in hiragana but Lindera resolves
+/// the lemma in kanji (e.g. ``わかる`` → base ``分かる``), the grammar_label
+/// resolver must still match conjugated forms. ``find_format_map_matches``
+/// formats the base into its conjugated surface (``分かって``) and checks the
+/// original text — but the kanji-formatted string never appears in a hiragana
+/// phrase, so the match silently fails.
+///
+/// Discovered by the smoke harness (W2 category) across 1k+ phrases. Each case
+/// below is a minimal hiragana-only reproduction (text contains no kanji) so
+/// the new hiragana-base fallback path is the only way the resolver can
+/// succeed.
+#[rstest]
+#[case("わかってる", "分かる")]
+#[case("もらっている", "貰う")]
+#[case("わかってるなら", "分かる")]
+fn should_resolve_grammar_label_for_hiragana_phrase_with_kanji_base(
+    #[case] phrase: &str,
+    #[case] expected_base: &str,
+) {
+    // Arrange — guard against accidental kanji in the fixture itself
+    assert!(
+        !phrase.chars().any(|c| c.is_kanji()),
+        "test fixture '{phrase}' must be pure hiragana, \
+         otherwise the new fallback path is not exercised"
+    );
+    if !ensure_all_dictionaries() {
+        eprintln!(
+            "skip: cdn/ artifacts absent \
+             (cdn/ is gitignored; restore via scripts/deploy_cdn.py)"
+        );
+        return;
+    }
+
+    // Act
+    let tokens = tokenize_text(phrase).expect("phrase must tokenize");
+    let translations = lookup_tokens_translations(&tokens, &NativeLanguage::English, phrase);
+
+    // Assert
+    let target = translations
+        .iter()
+        .find(|t| t.base_form == expected_base)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected base_form 「{expected_base}」 in tokenization of 「{phrase}」, \
+                 got: {translations:?}"
+            )
+        });
+
+    assert!(
+        target.grammar_label.is_some(),
+        "「{expected_base}」 conjugated inside the hiragana phrase 「{phrase}」 \
+         must carry a grammar_label, got: {target:?}"
+    );
+}

--- a/origa/tests/translation_smoke/bootstrap.rs
+++ b/origa/tests/translation_smoke/bootstrap.rs
@@ -1,0 +1,162 @@
+//! Process-wide dictionary bootstrap shared by every test in this binary.
+//!
+//! Mirrors the Once-based race-safe pattern used by `grammar_regression_checks`
+//! and the in-crate `integration_tests`: parallel test threads share the
+//! `GRAMMAR_RULES` / `VOCABULARY_DICTIONARY` / `TOKENIZER` `OnceLock`s, so the
+//! first load must run exactly once per binary via `Once::call_once`.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::sync::Once;
+
+use flate2::read::DeflateDecoder;
+use origa::dictionary::grammar::{GrammarData, init_grammar, is_grammar_loaded};
+use origa::dictionary::vocabulary::{VocabularyChunkData, init_vocabulary, is_vocabulary_loaded};
+use origa::domain::{DictionaryData, init_dictionary, is_dictionary_loaded};
+
+static BOOTSTRAP: Once = Once::new();
+
+pub fn cdn_dir() -> PathBuf {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by cargo");
+    PathBuf::from(manifest_dir)
+        .parent()
+        .expect("workspace root is parent of the origa crate manifest")
+        .join("cdn")
+}
+
+pub fn cdn_path(components: &[&str]) -> PathBuf {
+    let mut path = cdn_dir();
+    for component in components {
+        path.push(component);
+    }
+    path
+}
+
+/// Loads tokenizer / vocabulary / grammar dictionaries exactly once.
+///
+/// Returns ``true`` when all three stores end up loaded, ``false`` when any of
+/// the gitignored ``cdn/`` artifacts is absent so callers can decide whether
+/// to skip the test gracefully. A malformed store still panics — corrupt data
+/// is a real error, not a missing-environment condition.
+pub fn ensure_all_dictionaries() -> bool {
+    if is_dictionary_loaded() && is_vocabulary_loaded() && is_grammar_loaded() {
+        return true;
+    }
+
+    let mut loaded = true;
+    BOOTSTRAP.call_once(|| {
+        loaded = try_load_tokenizer_dictionary()
+            && try_load_vocabulary_dictionary()
+            && try_load_grammar_dictionary();
+    });
+    loaded && is_dictionary_loaded() && is_vocabulary_loaded() && is_grammar_loaded()
+}
+
+fn try_load_tokenizer_dictionary() -> bool {
+    if is_dictionary_loaded() {
+        return true;
+    }
+
+    let dict_dir = cdn_path(&["dictionaries"]);
+    let exists = |name: &str| dict_dir.join(name).exists();
+    let required = [
+        "char_def.bin",
+        "matrix.mtx",
+        "dict.da",
+        "dict.vals",
+        "unk.bin",
+        "dict.wordsidx",
+        "dict.words",
+        "metadata.json",
+    ];
+    if !required.iter().all(|name| exists(name)) {
+        return false;
+    }
+
+    let read_file = |name: &str| {
+        std::fs::read(dict_dir.join(name)).unwrap_or_else(|e| panic!("{name} read: {e}"))
+    };
+    let decompress = |data: Vec<u8>| -> Vec<u8> {
+        let mut decoder = DeflateDecoder::new(&data[..]);
+        let mut decompressed = Vec::new();
+        decoder
+            .read_to_end(&mut decompressed)
+            .unwrap_or_else(|e| panic!("dictionary decompress: {e}"));
+        decompressed
+    };
+
+    let data = DictionaryData {
+        char_def: decompress(read_file("char_def.bin")),
+        matrix: decompress(read_file("matrix.mtx")),
+        dict_da: decompress(read_file("dict.da")),
+        dict_vals: decompress(read_file("dict.vals")),
+        unk: decompress(read_file("unk.bin")),
+        words_idx: decompress(read_file("dict.wordsidx")),
+        words: decompress(read_file("dict.words")),
+        metadata: read_file("metadata.json"),
+    };
+
+    init_dictionary(data).expect("init_dictionary must succeed on valid data");
+    true
+}
+
+fn try_load_vocabulary_dictionary() -> bool {
+    if is_vocabulary_loaded() {
+        return true;
+    }
+
+    let vocab_dir = cdn_path(&["dictionary"]);
+    let mut chunks = Vec::with_capacity(11);
+    for n in 1..=11u8 {
+        let name = format!("chunk_{n:02}.json");
+        match std::fs::read_to_string(vocab_dir.join(name)) {
+            Ok(body) => chunks.push(body),
+            Err(_) => return false,
+        }
+    }
+
+    let mut iter = chunks.into_iter();
+    let vocab_data = VocabularyChunkData {
+        chunk_01: iter.next().expect("11 chunks"),
+        chunk_02: iter.next().expect("11 chunks"),
+        chunk_03: iter.next().expect("11 chunks"),
+        chunk_04: iter.next().expect("11 chunks"),
+        chunk_05: iter.next().expect("11 chunks"),
+        chunk_06: iter.next().expect("11 chunks"),
+        chunk_07: iter.next().expect("11 chunks"),
+        chunk_08: iter.next().expect("11 chunks"),
+        chunk_09: iter.next().expect("11 chunks"),
+        chunk_10: iter.next().expect("11 chunks"),
+        chunk_11: iter.next().expect("11 chunks"),
+    };
+
+    // Tolerate the OnceLock init race: a concurrent test thread may have
+    // initialized the vocabulary first with identical data. Only a genuinely
+    // unset dictionary indicates a real failure.
+    if let Err(err) = init_vocabulary(vocab_data) {
+        if !is_vocabulary_loaded() {
+            panic!("vocabulary dictionary failed to load: {err:?}");
+        }
+    }
+    true
+}
+
+fn try_load_grammar_dictionary() -> bool {
+    if is_grammar_loaded() {
+        return true;
+    }
+
+    let grammar_path = cdn_path(&["grammar", "grammar.json"]);
+    let grammar_json = match std::fs::read_to_string(&grammar_path) {
+        Ok(body) => body,
+        Err(_) => return false,
+    };
+
+    if let Err(err) = init_grammar(GrammarData { grammar_json }) {
+        if !is_grammar_loaded() {
+            panic!("grammar dictionary failed to load: {err:?}");
+        }
+    }
+    true
+}

--- a/origa/tests/translation_smoke/classify.rs
+++ b/origa/tests/translation_smoke/classify.rs
@@ -1,0 +1,309 @@
+//! Per-token anomaly classification.
+//!
+//! ``classify_token`` inspects one ``TokenTranslation`` against the FAIL/WARN
+//! taxonomy defined in ``super::ProblemKind`` and emits one report per
+//! ``(token, problem_kind)`` pair so a single token can surface multiple
+//! issues (e.g. W2 + W4 simultaneously).
+
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use origa::dictionary::grammar::iter_grammar_rules;
+use origa::domain::{JapaneseChar, PartOfSpeech, TokenTranslation};
+
+use super::harness::{ProblemKind, ProblemReport};
+
+/// Union of every grammar keyword across all rules. Used by F3 to detect
+/// particles/auxiliaries that *should* have a grammar_label but don't.
+fn grammar_keywords_union() -> &'static HashSet<String> {
+    static UNION: OnceLock<HashSet<String>> = OnceLock::new();
+    UNION.get_or_init(|| {
+        iter_grammar_rules()
+            .flat_map(|rule| rule.keywords().iter().flatten().cloned())
+            .collect()
+    })
+}
+
+fn is_katakana_only(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|c| c.is_katakana() || c == 'ー')
+}
+
+fn is_primary_vocab(pos: &PartOfSpeech) -> bool {
+    matches!(
+        pos,
+        PartOfSpeech::Noun | PartOfSpeech::Verb | PartOfSpeech::IAdjective
+    )
+}
+
+fn is_aux_like(pos: &PartOfSpeech) -> bool {
+    matches!(pos, PartOfSpeech::Particle | PartOfSpeech::AuxiliaryVerb)
+}
+
+pub fn classify_token(
+    translation: &TokenTranslation,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+) -> Vec<ProblemReport> {
+    let mut reports = Vec::new();
+    let pos = &translation.pos;
+    let aux_like = is_aux_like(pos);
+    let keywords = grammar_keywords_union();
+
+    check_empty_base(
+        translation,
+        phrase_idx,
+        phrase_text,
+        token_idx,
+        &mut reports,
+    );
+    check_missing_grammar_label_for_keyword(
+        translation,
+        aux_like,
+        keywords,
+        phrase_idx,
+        phrase_text,
+        token_idx,
+        &mut reports,
+    );
+    check_suspicious_katakana_base(
+        translation,
+        pos,
+        aux_like,
+        phrase_idx,
+        phrase_text,
+        token_idx,
+        &mut reports,
+    );
+    check_unknown_word_no_translation(
+        translation,
+        pos,
+        phrase_idx,
+        phrase_text,
+        token_idx,
+        &mut reports,
+    );
+    check_conjugated_no_grammar_label(
+        translation,
+        pos,
+        phrase_idx,
+        phrase_text,
+        token_idx,
+        &mut reports,
+    );
+    check_aux_no_grammar_label(
+        translation,
+        aux_like,
+        keywords,
+        phrase_idx,
+        phrase_text,
+        token_idx,
+        &mut reports,
+    );
+    check_incomplete_dictionary_entry(
+        translation,
+        phrase_idx,
+        phrase_text,
+        token_idx,
+        &mut reports,
+    );
+
+    reports
+}
+
+fn make_report(
+    kind: ProblemKind,
+    detail: String,
+    translation: &TokenTranslation,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+) -> ProblemReport {
+    ProblemReport {
+        phrase_idx,
+        phrase_text: phrase_text.to_string(),
+        token_idx,
+        surface: translation.surface_form.clone(),
+        base: translation.base_form.clone(),
+        pos: format!("{:?}", translation.pos),
+        kind,
+        detail,
+    }
+}
+
+fn check_empty_base(
+    translation: &TokenTranslation,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+    reports: &mut Vec<ProblemReport>,
+) {
+    if translation.base_form.is_empty() {
+        reports.push(make_report(
+            ProblemKind::EmptyBaseForm,
+            "base_form is empty".into(),
+            translation,
+            phrase_idx,
+            phrase_text,
+            token_idx,
+        ));
+    }
+}
+
+fn check_missing_grammar_label_for_keyword(
+    translation: &TokenTranslation,
+    aux_like: bool,
+    keywords: &HashSet<String>,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+    reports: &mut Vec<ProblemReport>,
+) {
+    if aux_like
+        && keywords.contains(&translation.surface_form)
+        && translation.grammar_label.is_none()
+    {
+        reports.push(make_report(
+            ProblemKind::MissingGrammarLabelKnownAux,
+            format!(
+                "「{}」 matches a grammar keyword but grammar_label is None",
+                translation.surface_form
+            ),
+            translation,
+            phrase_idx,
+            phrase_text,
+            token_idx,
+        ));
+    }
+}
+
+fn check_suspicious_katakana_base(
+    translation: &TokenTranslation,
+    pos: &PartOfSpeech,
+    aux_like: bool,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+    reports: &mut Vec<ProblemReport>,
+) {
+    let verb_or_iadj = matches!(pos, PartOfSpeech::Verb | PartOfSpeech::IAdjective);
+    if !verb_or_iadj && !aux_like {
+        return;
+    }
+    if !is_katakana_only(&translation.base_form) {
+        return;
+    }
+
+    let label = if verb_or_iadj {
+        format!("katakana-only base_form '{}'", translation.base_form)
+    } else {
+        format!(
+            "aux-like katakana-only base_form '{}'",
+            translation.base_form
+        )
+    };
+    reports.push(make_report(
+        ProblemKind::SuspiciousKatakanaBase,
+        label,
+        translation,
+        phrase_idx,
+        phrase_text,
+        token_idx,
+    ));
+}
+
+fn check_unknown_word_no_translation(
+    translation: &TokenTranslation,
+    pos: &PartOfSpeech,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+    reports: &mut Vec<ProblemReport>,
+) {
+    if is_primary_vocab(pos) && translation.translation.is_none() {
+        reports.push(make_report(
+            ProblemKind::UnknownWordNoTranslation,
+            "primary vocab word has no translation".into(),
+            translation,
+            phrase_idx,
+            phrase_text,
+            token_idx,
+        ));
+    }
+}
+
+fn check_conjugated_no_grammar_label(
+    translation: &TokenTranslation,
+    pos: &PartOfSpeech,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+    reports: &mut Vec<ProblemReport>,
+) {
+    if is_primary_vocab(pos)
+        && translation.surface_form != translation.base_form
+        && translation.grammar_label.is_none()
+    {
+        reports.push(make_report(
+            ProblemKind::ConjugatedNoGrammarLabel,
+            format!(
+                "conjugated ({} -> {}) without grammar_label",
+                translation.base_form, translation.surface_form
+            ),
+            translation,
+            phrase_idx,
+            phrase_text,
+            token_idx,
+        ));
+    }
+}
+
+fn check_aux_no_grammar_label(
+    translation: &TokenTranslation,
+    aux_like: bool,
+    keywords: &HashSet<String>,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+    reports: &mut Vec<ProblemReport>,
+) {
+    if aux_like
+        && !keywords.contains(&translation.surface_form)
+        && translation.grammar_label.is_none()
+    {
+        reports.push(make_report(
+            ProblemKind::AuxiliaryNoGrammarLabel,
+            format!(
+                "aux-like '{}' outside grammar keyword union",
+                translation.surface_form
+            ),
+            translation,
+            phrase_idx,
+            phrase_text,
+            token_idx,
+        ));
+    }
+}
+
+fn check_incomplete_dictionary_entry(
+    translation: &TokenTranslation,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+    reports: &mut Vec<ProblemReport>,
+) {
+    if translation
+        .translation
+        .as_ref()
+        .is_some_and(|t| t.trim().is_empty())
+    {
+        reports.push(make_report(
+            ProblemKind::IncompleteDictionaryEntry,
+            "translation is Some but empty/whitespace".into(),
+            translation,
+            phrase_idx,
+            phrase_text,
+            token_idx,
+        ));
+    }
+}

--- a/origa/tests/translation_smoke/data.rs
+++ b/origa/tests/translation_smoke/data.rs
@@ -1,0 +1,33 @@
+//! Phrase corpus loader for the smoke test.
+//!
+//! Reads `cdn/phrases/data/pNNNN.json` files directly via ``serde_json``
+//! (already a normal dependency of the crate). The on-disk schema is
+//! ``[{ "i": ulid, "x": japanese_text, "ru": .., "en": .. }]`` per the
+//! architect's confirmation; only ``x`` is needed for tokenization.
+
+use serde::Deserialize;
+
+use super::bootstrap::cdn_path;
+
+#[derive(Deserialize)]
+struct PhraseRaw {
+    x: String,
+}
+
+/// Loads the ``x`` (japanese text) field of every phrase in ``chunk_filename``.
+///
+/// Returns ``None`` when the gitignored file is absent so callers can decide
+/// whether to skip the test gracefully. A malformed file still panics — bad
+/// JSON in a present file is a real error.
+pub fn load_phrase_texts_from_chunk(chunk_filename: &str) -> Option<Vec<String>> {
+    let path = cdn_path(&["phrases", "data", chunk_filename]);
+    let body = std::fs::read_to_string(&path).ok()?;
+    let phrases: Vec<PhraseRaw> = serde_json::from_str(&body).unwrap_or_else(|err| {
+        panic!(
+            "failed to parse {}: {err} — check that the file matches the \
+             [{{i, x, ru, en}}, ...] schema",
+            path.display()
+        )
+    });
+    Some(phrases.into_iter().map(|p| p.x).collect())
+}

--- a/origa/tests/translation_smoke/harness.rs
+++ b/origa/tests/translation_smoke/harness.rs
@@ -1,0 +1,155 @@
+//! Discovery harness for translation pipeline anomalies.
+//!
+//! Run with:
+//!   ``cargo test -p origa --test translation_smoke -- --nocapture --ignored``
+//!
+//! The harness classifies every token of every phrase in ``p0000.json`` into
+//! the FAIL/WARN categories formalised by the architect:
+//!
+//! - FAIL (TDD targets, deterministic detection):
+//!   - **F1** ``TokenizeError`` — ``tokenize_text`` returned ``Err``.
+//!   - **F3** ``MissingGrammarLabelKnownAux`` — ``Particle``/``AuxiliaryVerb``
+//!     whose surface matches a grammar keyword but ``grammar_label`` is unset.
+//!   - **F4** ``EmptyBaseForm`` — ``base_form`` is empty.
+//!   - **F5** ``SuspiciousKatakanaBase`` — katakana-only ``base_form`` for a
+//!     Verb/IAdj/Particle/AuxiliaryVerb (Lindera mixed-script limitation).
+//!
+//! - WARN (manual triage):
+//!   - **W1** ``UnknownWordNoTranslation`` — Noun/Verb/IAdj with no translation.
+//!   - **W2** ``ConjugatedNoGrammarLabel`` — Noun/Verb/IAdj with ``surface !=
+//!     base`` and no grammar_label (format_map gap or kanji↔kana alternation).
+//!   - **W3** ``AuxiliaryNoGrammarLabel`` — Particle/AuxiliaryVerb outside the
+//!     grammar keyword union with no grammar_label.
+//!   - **W4** ``IncompleteDictionaryEntry`` — ``translation`` is ``Some`` but
+//!     empty/whitespace.
+//!
+//! F2 ("missing translation for a known word") is intentionally absent: the
+//! architect proved it is structurally impossible — ``translation`` and
+//! ``get_translation`` read the same vocabulary_map.
+//!
+//! Known findings on ``p0000.json`` (771 phrases):
+//! - **F1 / F3 / F4** stayed at 0 from the first run — pipeline invariants hold.
+//! - **F5** shows 3 hits, all ``AuxiliaryVerb`` rendered in katakana (e.g.
+//!   ``デス`` for ``です`` in stylised speech, ``ム`` mis-tagged as aux by
+//!   Lindera). These are upstream-Lindera / input-data quirks, not bugs in
+//!   ``translation.rs``; the cases are logged for visibility but not TDD-fixed.
+//! - **W2** dropped from 1367 → 901 after the
+//!   ``should_resolve_grammar_label_for_hiragana_phrase_with_kanji_base``
+//!   fix in ``translation.rs``. The residual is dominated by kanji↔kana
+//!   alternations (``事 → こと``, ``為る → する``) and legitimate grammar-rule
+//!   gaps; the harness reports them but cannot distinguish the two without
+//!   ``phonological_base_form`` exposed on ``TokenTranslation``.
+//! - **W3** (~4k) is by design: ``grammar.json`` keyword rules describe
+//!   multi-token patterns (``～は～です``), not bare particles, so ``は / が / を``
+//!   etc. never receive a grammar_label.
+//! - **W4** stayed at 0 — every vocabulary entry that resolves to ``Some`` has
+//!   at least one non-whitespace line.
+
+use origa::domain::{NativeLanguage, tokenize_text};
+
+use super::bootstrap::ensure_all_dictionaries;
+use super::classify::classify_token;
+use super::data::load_phrase_texts_from_chunk;
+use super::report::print_report;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProblemKind {
+    TokenizeError,
+    MissingGrammarLabelKnownAux,
+    EmptyBaseForm,
+    SuspiciousKatakanaBase,
+    UnknownWordNoTranslation,
+    ConjugatedNoGrammarLabel,
+    AuxiliaryNoGrammarLabel,
+    IncompleteDictionaryEntry,
+}
+
+impl ProblemKind {
+    pub fn as_code(self) -> &'static str {
+        match self {
+            ProblemKind::TokenizeError => "F1",
+            ProblemKind::MissingGrammarLabelKnownAux => "F3",
+            ProblemKind::EmptyBaseForm => "F4",
+            ProblemKind::SuspiciousKatakanaBase => "F5",
+            ProblemKind::UnknownWordNoTranslation => "W1",
+            ProblemKind::ConjugatedNoGrammarLabel => "W2",
+            ProblemKind::AuxiliaryNoGrammarLabel => "W3",
+            ProblemKind::IncompleteDictionaryEntry => "W4",
+        }
+    }
+
+    pub fn is_fail(self) -> bool {
+        matches!(
+            self,
+            ProblemKind::TokenizeError
+                | ProblemKind::MissingGrammarLabelKnownAux
+                | ProblemKind::EmptyBaseForm
+                | ProblemKind::SuspiciousKatakanaBase
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProblemReport {
+    pub phrase_idx: usize,
+    pub phrase_text: String,
+    pub token_idx: usize,
+    pub surface: String,
+    pub base: String,
+    pub pos: String,
+    pub kind: ProblemKind,
+    pub detail: String,
+}
+
+/// Runs the full phrase corpus through the pipeline and collects every
+/// anomaly. F1 errors short-circuit per-phrase (no token classification).
+fn analyze_corpus(lang: NativeLanguage) -> Vec<ProblemReport> {
+    let loaded = ensure_all_dictionaries();
+    let phrases = match load_phrase_texts_from_chunk("p0000.json") {
+        Some(texts) if loaded => texts,
+        _ => {
+            eprintln!(
+                "skip discovery: cdn artifacts absent \
+                 (cdn/ is gitignored; restore via scripts/deploy_cdn.py)"
+            );
+            return Vec::new();
+        },
+    };
+
+    let mut reports = Vec::new();
+    for (idx, text) in phrases.iter().enumerate() {
+        match tokenize_text(text) {
+            Ok(tokens) => {
+                let translations = origa::domain::lookup_tokens_translations(&tokens, &lang, text);
+                for (token_idx, translation) in translations.iter().enumerate() {
+                    reports.extend(classify_token(translation, idx, text, token_idx));
+                }
+            },
+            Err(err) => reports.push(ProblemReport {
+                phrase_idx: idx,
+                phrase_text: text.clone(),
+                token_idx: 0,
+                surface: String::new(),
+                base: String::new(),
+                pos: String::new(),
+                kind: ProblemKind::TokenizeError,
+                detail: format!("tokenize_text failed: {err:?}"),
+            }),
+        }
+    }
+    reports
+}
+
+#[test]
+#[ignore = "discovery harness: dumps TSV + summary for Russian, run explicitly"]
+pub fn discover_translation_problems_russian() {
+    let reports = analyze_corpus(NativeLanguage::Russian);
+    print_report(&reports);
+}
+
+#[test]
+#[ignore = "discovery harness: dumps TSV + summary for English, run explicitly"]
+pub fn discover_translation_problems_english() {
+    let reports = analyze_corpus(NativeLanguage::English);
+    print_report(&reports);
+}

--- a/origa/tests/translation_smoke/report.rs
+++ b/origa/tests/translation_smoke/report.rs
@@ -1,0 +1,76 @@
+//! TSV + summary printer for ``ProblemReport`` collections.
+//!
+//! Output format (spaces instead of tabs in this doc-comment to satisfy
+//! clippy::tabs_in_doc_comments):
+//!
+//! ```text
+//! === TSV ===
+//! kind    phrase_idx    token_idx    pos    surface    base    detail    phrase_text
+//! F5      300           0            AuxiliaryVerb    ム    ム    aux-like katakana ...
+//! ...
+//!
+//! === SUMMARY ===
+//! total problems: 1234
+//! F1    FAIL    0 (TokenizeError)
+//! ...
+//! ```
+
+use super::harness::{ProblemKind, ProblemReport};
+
+const SUMMARY_ORDER: &[ProblemKind] = &[
+    ProblemKind::TokenizeError,
+    ProblemKind::MissingGrammarLabelKnownAux,
+    ProblemKind::EmptyBaseForm,
+    ProblemKind::SuspiciousKatakanaBase,
+    ProblemKind::UnknownWordNoTranslation,
+    ProblemKind::ConjugatedNoGrammarLabel,
+    ProblemKind::AuxiliaryNoGrammarLabel,
+    ProblemKind::IncompleteDictionaryEntry,
+];
+
+pub fn print_report(reports: &[ProblemReport]) {
+    print_tsv(reports);
+    print_summary(reports);
+}
+
+fn print_tsv(reports: &[ProblemReport]) {
+    eprintln!();
+    eprintln!("kind\tphrase_idx\ttoken_idx\tpos\tsurface\tbase\tdetail\tphrase_text");
+    for r in reports {
+        eprintln!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            r.kind.as_code(),
+            r.phrase_idx,
+            r.token_idx,
+            r.pos,
+            r.surface,
+            r.base,
+            r.detail,
+            r.phrase_text.chars().take(60).collect::<String>()
+        );
+    }
+}
+
+fn print_summary(reports: &[ProblemReport]) {
+    eprintln!();
+    eprintln!("=== SUMMARY ===");
+    eprintln!("total problems: {}", reports.len());
+
+    for kind in SUMMARY_ORDER {
+        let matching: Vec<&ProblemReport> = reports.iter().filter(|r| r.kind == *kind).collect();
+        let fail_marker = if kind.is_fail() { "FAIL" } else { "WARN" };
+        eprintln!(
+            "{}\t{}\t{} ({:?})",
+            kind.as_code(),
+            fail_marker,
+            matching.len(),
+            kind
+        );
+        for r in matching.iter().take(5) {
+            eprintln!(
+                "    [phrase#{} tok#{}] 「{}」 (base 「{}」) — {}",
+                r.phrase_idx, r.token_idx, r.surface, r.base, r.detail
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Smoke test harness for `translation.rs` pipeline on 771 real Japanese phrases. Found and fixed a real bug: `resolve_grammar_label` silently dropped `grammar_label` for 466 conjugations where input was hiragana but base was kanji.

## Bug fix

Lindera returns kanji lemma (`分かる`) even for pure-hiragana input (`わかってる`). `find_format_map_matches` formats base→conjugated in kanji, checks `text.contains(formatted)` — kanji string never appears in hiragana text → silent match failure.

Fix: convert `phonological_base_form` (katakana) to hiragana and retry when base contains kanji.

## Results on 771 phrases

| Category | Count | Status |
|----------|-------|--------|
| F1 TokenizeError | 0 | ✅ |
| F3 MissingGrammarLabelKnownAux | 0 | ✅ |
| F4 EmptyBaseForm | 0 | ✅ |
| F5 SuspiciousKatakanaBase | 3 | Lindera quirks |
| W1 UnknownWord | 1 | invented name |
| W2 ConjugatedNoGrammarLabel | **901** (was 1367, -466) | residual = kanji↔kana alternations |
| W3 AuxiliaryNoGrammarLabel | 4140 | by design |
| W4 IncompleteDictionaryEntry | 0 | ✅ |

## Verification
- `cargo test -p origa`: 1346 passed
- clippy: 0 warnings
- Code review: approve (0H/0C/3L)

## Run discovery harness manually

```powershell
cargo test -p origa --test translation_smoke -- --nocapture --ignored
```