### PR TITLE
fix(landing): canonicalize URLs and fix SEO indexing blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
               run: cargo fmt --check --all
 
             - name: Run clippy
-              run: cargo clippy --workspace --all-targets -- -D warnings
+              run: cargo clippy --workspace --all-targets --features origa_landing/ssr -- -D warnings
 
     cdn-download:
         name: Download CDN
@@ -162,7 +162,7 @@ jobs:
               run: npm ci && npm run build:css
 
             - name: Run tests
-              run: cargo test --workspace
+              run: cargo test --workspace --features origa_landing/ssr
 
     e2e-build:
         name: E2E Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
               run: cargo fmt --check --all
 
             - name: Run clippy
-              run: cargo clippy --workspace --all-targets --features origa_landing/ssr -- -D warnings
+              run: cargo clippy --workspace --all-targets -- -D warnings
 
     cdn-download:
         name: Download CDN
@@ -161,23 +161,8 @@ jobs:
               working-directory: origa_landing
               run: npm ci && npm run build:css
 
-            - name: Configure swap space
-              run: |
-                  sudo fallocate -l 4G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
-                  sudo chmod 600 /swapfile
-                  sudo mkswap /swapfile
-                  sudo swapon /swapfile || true
-                  echo "Swap enabled:"
-                  free -h
-              if: runner.os == 'Linux'
-
-            - name: Test workspace core
+            - name: Run tests
               run: cargo test --workspace --exclude origa_landing
-
-            - name: Test origa_landing (SSR)
-              run: cargo test -p origa_landing --features ssr
-              env:
-                  CARGO_BUILD_JOBS: "1"
 
     e2e-build:
         name: E2E Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,23 @@ jobs:
               working-directory: origa_landing
               run: npm ci && npm run build:css
 
+            - name: Configure swap space
+              run: |
+                  sudo fallocate -l 4G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
+                  sudo chmod 600 /swapfile
+                  sudo mkswap /swapfile
+                  sudo swapon /swapfile || true
+                  echo "Swap enabled:"
+                  free -h
+              if: runner.os == 'Linux'
+
             - name: Test workspace core
               run: cargo test --workspace --exclude origa_landing
 
             - name: Test origa_landing (SSR)
               run: cargo test -p origa_landing --features ssr
+              env:
+                  CARGO_BUILD_JOBS: "1"
 
     e2e-build:
         name: E2E Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,11 @@ jobs:
               working-directory: origa_landing
               run: npm ci && npm run build:css
 
-            - name: Run tests
-              run: cargo test --workspace --features origa_landing/ssr
+            - name: Test workspace core
+              run: cargo test --workspace --exclude origa_landing
+
+            - name: Test origa_landing (SSR)
+              run: cargo test -p origa_landing --features ssr
 
     e2e-build:
         name: E2E Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,13 +5485,17 @@ name = "origa_landing"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "http",
+ "http-body-util",
  "leptos",
  "leptos_axum",
  "leptos_meta",
  "leptos_router",
+ "rstest",
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,10 @@ ammonia = "4"
 scraper = "0.22"
 ego-tree = "0.10"
 axum = "0.8"
-tower-http = { version = "0.6", features = ["fs"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["fs", "set-header", "util"] }
+http = "1"
+http-body-util = "0.1"
 js-sys = "0.3"
 codee = { version = "0.3", features = ["json_serde"] }
 console_error_panic_hook = "0.1"

--- a/docs/decisions/ADR-011-landing-url-canonicalization.md
+++ b/docs/decisions/ADR-011-landing-url-canonicalization.md
@@ -1,0 +1,301 @@
+# ADR-011: URL Canonicalization Policy for origa_landing
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-22
+
+## Context
+
+Following ADR-007 (DNS layer fix via plain A record), `origa.uwuwu.net` became
+resolvable for all major search engine crawlers. However, none of the three
+target search engines (Google, Yandex, Bing) proceeded to actually index the
+site beyond the homepage, and Google Search Console / Yandex Webmaster kept
+reporting generic "discovered current page, not indexed" / "crawling issues"
+statuses.
+
+Investigation at the HTTP layer revealed several distinct, independent root
+causes — none of which were DNS-related:
+
+1. **Dead URLs in `sitemap.xml`**. Three hreflang alternates were published
+   with trailing slashes (`/ru/`, `/ko/`, `/vi/`). The `leptos_router`
+   configuration registers locale routes without trailing slashes (`/ru`,
+   `/ko`, `/vi`), so slash-suffixed URLs were not matched by the router and
+   fell through to the static-file fallback service, which returned 404 with
+   an empty body. Sitemaps containing 4xx URLs are a strong negative signal
+   in Google's quality pipeline.
+2. **Missing `Cache-Control` on HTML**. Every SSR HTML response was emitted
+   without a `Cache-Control` header, so Cloudflare classified the responses
+   as `Cf-Cache-Status: DYNAMIC` and forwarded every request to the Railway
+   origin. This produced inconsistent crawl latencies and gave crawlers no
+   revalidation hints.
+3. **Soft-404**. The Leptos `<Routes fallback=NotFound>` branch was never
+   reached for unmatched paths because the `ServeDir` fallback service
+   intercepted them first and returned a bare HTTP 404 with an empty body.
+   Worse, requests that *did* match a `ParentRoute` but missed every child
+   route (e.g. `/ru/typo`) silently rendered the layout shell with HTTP 200,
+   producing a genuine soft-404.
+4. **Hard-coded `<html lang="en">`** in the SSR shell. Pages under `/ru`,
+   `/ko`, `/vi` were rendered with `lang="en"` at the document root, with
+   the correct locale only applied by a client-side `<script>` after
+   hydration. Crawlers saw an English document containing non-English text.
+5. **Cloudflare-managed `robots.txt`** (RC-2). The Cloudflare "AI Audit"
+   / "Pay Per Crawl" feature injected its own `robots.txt` block ahead of
+   the user-managed file, including `Disallow: /` for several AI crawlers
+   and a `Content-Signal` header. This is handled out of code, via the
+   Cloudflare dashboard — see the runbook section below.
+
+This ADR documents the canonicalisation policy that addresses (1)–(4).
+Item (5) is operational and tracked separately.
+
+## Decision
+
+### Trailing slash canonicalisation: NO trailing slash
+
+All URLs are canonical **without** trailing slash:
+
+- `/`, `/features`, `/compare`, `/content`, `/download`
+- `/ru`, `/ru/features`, `/ko`, `/vi`, etc.
+
+The only exception is the site root `/` itself, which keeps its slash by
+HTTP convention (an empty path is semantically equivalent to `/`).
+
+### Redirect strategy: axum middleware, HTTP 308
+
+Requests with a trailing slash are redirected to the slash-less canonical
+form by an axum middleware (`strip_trailing_slash`):
+
+- **Status code**: 308 Permanent Redirect (`Redirect::permanent` in axum
+  0.8). 308 is semantically equivalent to 301 for GET/HEAD and additionally
+  preserves the request method for non-GET traffic; Google, Yandex and Bing
+  all treat 308 as a permanent redirect that passes full link equity.
+- **Methods**: only GET and HEAD are redirected. POST/PUT/DELETE are passed
+  through unchanged so the middleware cannot mask an accidental state-changing
+  request against a slash-suffixed URL.
+- **Layer position**: outermost (the last `.layer()` call on the Router) so
+  it runs before routing and normalises `/ru/`, `/images/logo.png/`,
+  `/favicon.png/` alike.
+- **Query string**: preserved in the `Location` header (e.g.
+  `/ru/?ref=twitter` → `/ru?ref=twitter`).
+- **Multiple slashes**: collapsed (`/ru///` → `/ru`).
+
+### Sitemap policy
+
+`public/sitemap.xml` must mirror the canonical URLs: locale-prefixed paths
+have no trailing slash. The site root keeps its trailing slash. Verification:
+
+```bash
+rg 'hreflang="(ru|ko|vi)"' origa_landing/public/sitemap.xml
+# all results end without "/"
+```
+
+### Cache-Control policy
+
+- **HTML (leptos routes)** — `public, max-age=300`: 5-minute edge cache;
+  users pick up content changes within 5 min.
+- **Static assets** — `public, max-age=31536000, immutable`: hashed/immutable;
+  bumped only by redeploy.
+- **`robots.txt`, `sitemap.xml`** — `no-cache`: crawlers must always see the
+  latest copy.
+- **308 redirects** — `public, max-age=86400`: 24h edge cache; CDN serves the
+  redirect without re-hitting origin. Google recommends `max-age >= 86400` for
+  permanent redirects so link equity transfer is not delayed.
+- **4xx/5xx error responses** — `no-cache`: CDNs must not pin "not found" or
+  server errors; a later-added file must be served immediately.
+  `ServeDir`/`ServeFile` stamp their configured value (`IMMUTABLE_CACHE` for
+  assets, `NO_CACHE` for robots/sitemap) on *all* statuses via
+  `insert_response_header_if_not_present`, so a status-aware middleware
+  overrides every one of them to `no-cache` on errors.
+
+Implementation uses `tower_http::ServiceExt::insert_response_header_if_not_present`
+on each per-route static service to set the success-path value, then a single
+`enforce_cache_policy` axum middleware post-processes every non-redirect
+response:
+
+- 2xx without `Cache-Control` → stamped with `HTML_CACHE` (the leptos-route
+  default).
+- 4xx/5xx → overridden to `no-cache`, regardless of what the inner service
+  set (fixes the 404-with-immutable regression).
+- 3xx (e.g. `304 Not Modified`) → passed through unchanged, preserving
+  conditional-cache semantics.
+
+`308 Permanent Redirect` responses from `strip_trailing_slash` never reach
+`enforce_cache_policy` (the redirect layer is outermost and short-circuits
+the inner stack), so they stamp `REDIRECT_CACHE` on themselves directly.
+
+### Soft-404 policy
+
+Unmatched paths must return HTTP 404 with a visible "404" body. This is
+implemented by composing `tower_http::ServeDir::fallback` with
+`leptos_axum::ErrorHandler`:
+
+1. A request like `/random` is not matched by any explicit route, nor by any
+   `leptos_router`-registered path.
+2. It reaches the `fallback_service`, which is a `ServeDir(public/)`
+   chained into `ErrorHandler`.
+3. `ServeDir` cannot find `public/random` and delegates to `ErrorHandler`.
+4. `ErrorHandler` renders the App via the leptos router. The App's
+   `<Routes fallback=NotFound>` branch fires, which calls
+   `leptos_axum::ResponseOptions::set_status(NOT_FOUND)` via context.
+5. `ErrorHandler` post-checks: if the response status is still 200, it
+   overrides to 404. `ErrorHandler` is the primary 404 mechanism;
+   `ResponseOptions::set_status` inside `NotFound` is a defence-in-depth
+   layer that also documents intent at the component level.
+
+### `<html lang>` policy
+
+The SSR shell no longer hardcodes `lang="en"` on the `<html>` tag. Instead,
+`<html>` is emitted without a `lang` attribute, and `leptos_meta::Html`
+inside the `Layout` component is the single source of truth:
+
+```rust
+view! {
+    <Html {..} lang=locale.as_str() />
+    // ...
+}
+```
+
+`leptos_meta` registers the attribute with `ServerMetaContext` during render
+and injects it into the `<html>` tag of the streamed response. This ensures
+search engines see the correct `lang` for each locale (en/ru/ko/vi) in the
+raw SSR HTML, without relying on client-side JS to patch
+`document.documentElement.lang`.
+
+The previous runtime JS patch has been removed.
+
+## Alternatives Considered
+
+### A1: Trailing slash AS canonical + redirect `/ru` → `/ru/`
+
+Rejected. The existing `leptos_router` configuration already matches
+`path!("ru")` without a slash; switching canonical to `/ru/` would require
+either router refactoring or a `*` matcher, both of which are higher-risk
+than the chosen approach. No-slash canonical is also shorter and matches
+the convention used by the `hreflang` alternates already emitted in the
+HTML `<head>`.
+
+### A2: Sitemap fix only, no redirect middleware
+
+Rejected as defence-in-depth failure. The sitemap is one of many entry
+points for crawlers; external inbound links are not under our control. A
+permanent redirect ensures that any future `/ru/` request — whether from a
+stale bookmark, a misconfigured campaign URL, or a crawler that appended a
+slash itself — reaches the canonical URL and passes link equity.
+
+### A3: `Cache-Control: no-cache` for HTML
+
+Considered (max freshness, simplest semantics). Rejected because it forces
+Cloudflare to forward every HTML request to the Railway origin, which
+defeats the purpose of having a CDN and inflates crawl latency. A 5-minute
+edge cache with `public` visibility is the standard trade-off for
+marketing/landing HTML that changes at most a few times per week.
+
+### A4: axum `fallback(leptos_axum::file_and_error_handler(shell))`
+
+Considered as the soft-404 fix. `file_and_error_handler` serves static files
+from `LeptosOptions::site_root` (default `target/site`) and renders the App
+for everything else. Rejected because our static files live in
+`public/` (not `target/site`), and switching `site_root` would also affect
+the trunk output path. The chosen composition
+(`ServeDir::new(public).fallback(ErrorHandler)`) keeps the existing static
+directory layout and achieves the same 404 behaviour.
+
+## Consequences
+
+### Positive
+
+- Every URL listed in `sitemap.xml` returns 200 (directly or via 308
+  redirect). Sitemap health is "green" in Google Search Console.
+- Cloudflare can cache HTML for 5 minutes, eliminating the
+  `Cf-Cache-Status: DYNAMIC` warning and stabilising crawl latency.
+- Search engines see consistent canonical, locale, hreflang and
+  cache-control signals for every page.
+- `/random` (and any other unmatched path) returns HTTP 404 with a
+  visible body, so it is treated as a real 404 rather than indexed as a
+  soft-404 page.
+
+### Negative
+
+- An extra 308 redirect hop is incurred for slash-suffixed URLs (one
+  additional round-trip). This is a one-time cost per inbound link and is
+  cached by the CDN.
+- Adding a new static asset to `public/` requires an explicit
+  `route_service` entry to get the correct `Cache-Control` header; files
+  served by the fallback `ServeDir` get the default HTML cache policy
+  (`public, max-age=300`) rather than immutable caching. This is acceptable
+  for now — the set of static assets is small and stable.
+
+## Cloudflare Runbook (RC-2)
+
+The Cloudflare "AI Audit" / "Pay Per Crawl" feature, when enabled on the
+`uwuwu.net` zone, injects a managed `robots.txt` block that prepends
+`Content-Signal: search=yes,ai-train=no` and `Disallow: /` directives for
+specific AI user-agents *before* the user-managed `public/robots.txt`
+content. This causes some crawlers that fetch `robots.txt` to see a partial
+or contradictory file.
+
+### Fix (dashboard)
+
+1. Cloudflare dashboard → zone `uwuwu.net`.
+2. Navigate to **AI** → **AI Audit** (or **Pay Per Crawl**, depending on
+   the account tier).
+3. Disable **AI Audit** and **Pay Per Crawl**.
+4. Save.
+
+### Verification
+
+```bash
+curl -s https://origa.uwuwu.net/robots.txt
+# Expected body (exactly 4 lines, no AI crawler block):
+# User-agent: *
+# Allow: /
+#
+# Sitemap: https://origa.uwuwu.net/sitemap.xml
+```
+
+### Rollback
+
+Re-enable **AI Audit** / **Pay Per Crawl** in the same dashboard panel.
+
+## Production Verification
+
+End-to-end smoke checks against production (after deploy):
+
+```bash
+# Trailing-slash redirect
+curl -o /dev/null -s -w '%{http_code}\n' https://origa.uwuwu.net/ru/
+# Expected: 308
+
+# HTML cache header
+curl -s -D - -o /dev/null https://origa.uwuwu.net/ | rg -i 'cache-control:'
+# Expected: public, max-age=300
+
+# Static asset immutable cache
+curl -s -D - -o /dev/null https://origa.uwuwu.net/favicon.png | rg -i 'cache-control:'
+# Expected: public, max-age=31536000, immutable
+
+# Soft-404
+curl -o /dev/null -s -w '%{http_code}\n' https://origa.uwuwu.net/random
+# Expected: 404
+
+# Sitemap contains no slash-suffixed locale URLs
+curl -s https://origa.uwuwu.net/sitemap.xml | rg 'hreflang="(ru|ko|vi)"'
+# Expected: every href ends without "/"
+```
+
+## References
+
+- ADR-007: Landing DNS — Replace CNAME with A Record to Fix Search Engine
+  Indexing (Railway AAAA SERVFAIL). DNS-layer predecessor of this ADR.
+- axum 0.8 `Redirect::permanent` → HTTP 308.
+- `leptos_axum::ResponseOptions::set_status` for SSR-only HTTP status.
+- `leptos_axum::ErrorHandler` as a tower `Service` for compositional
+  fallback chains.
+- `tower_http::ServiceExt::insert_response_header_if_not_present` for
+  per-route `Cache-Control` defaults on static services.
+- `axum::middleware::from_fn` for the `enforce_cache_policy` and
+  `strip_trailing_slash` middlewares (status-aware `Cache-Control` on
+  non-redirect responses; `REDIRECT_CACHE` stamped directly on 308s).

--- a/origa_landing/Cargo.toml
+++ b/origa_landing/Cargo.toml
@@ -19,12 +19,33 @@ leptos_meta.workspace = true
 leptos_router.workspace = true
 leptos_axum.workspace = true
 axum.workspace = true
+http.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tower-http.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[dev-dependencies]
+rstest = { workspace = true }
+tower = { workspace = true, features = ["util"] }
+http-body-util.workspace = true
+
+[[test]]
+name = "redirect"
+path = "tests/redirect.rs"
+required-features = ["ssr"]
+
+[[test]]
+name = "cache_headers"
+path = "tests/cache_headers.rs"
+required-features = ["ssr"]
+
+[[test]]
+name = "not_found"
+path = "tests/not_found.rs"
+required-features = ["ssr"]
 
 [features]
 ssr = [

--- a/origa_landing/public/sitemap.xml
+++ b/origa_landing/public/sitemap.xml
@@ -4,9 +4,9 @@
   <url>
     <loc>https://origa.uwuwu.net/</loc>
     <xhtml:link rel="alternate" hreflang="en" href="https://origa.uwuwu.net/"/>
-    <xhtml:link rel="alternate" hreflang="ru" href="https://origa.uwuwu.net/ru/"/>
-    <xhtml:link rel="alternate" hreflang="ko" href="https://origa.uwuwu.net/ko/"/>
-    <xhtml:link rel="alternate" hreflang="vi" href="https://origa.uwuwu.net/vi/"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://origa.uwuwu.net/ru"/>
+    <xhtml:link rel="alternate" hreflang="ko" href="https://origa.uwuwu.net/ko"/>
+    <xhtml:link rel="alternate" hreflang="vi" href="https://origa.uwuwu.net/vi"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://origa.uwuwu.net/"/>
   </url>
   <url>

--- a/origa_landing/src/app.rs
+++ b/origa_landing/src/app.rs
@@ -9,7 +9,7 @@ use crate::pages::*;
 pub fn shell(_options: LeptosOptions) -> impl IntoView {
     view! {
         <!DOCTYPE html>
-        <html lang="en">
+        <html>
             <head>
                 <meta charset="utf-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/origa_landing/src/components/layout.rs
+++ b/origa_landing/src/components/layout.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos_meta::Html;
 use leptos_router::components::{A, Outlet};
 
 use crate::content::Locale;
@@ -34,21 +35,7 @@ pub fn Layout(locale: Locale) -> impl IntoView {
         .collect();
 
     view! {
-        {match locale {
-            Locale::Ru => view! {
-                <script>"document.documentElement.lang=\"ru\""</script>
-            }
-            .into_any(),
-            Locale::Ko => view! {
-                <script>"document.documentElement.lang=\"ko\""</script>
-            }
-            .into_any(),
-            Locale::Vi => view! {
-                <script>"document.documentElement.lang=\"vi\""</script>
-            }
-            .into_any(),
-            Locale::En => ().into_any(),
-        }}
+        <Html {..} lang=locale.as_str() />
         <header class="landing-header">
             <a href=home_href class="landing-header__logo">
                 <img src="/images/logo.png" alt="Origa" class="landing-header__logo-img" />

--- a/origa_landing/src/components/not_found.rs
+++ b/origa_landing/src/components/not_found.rs
@@ -1,4 +1,3 @@
-use http::StatusCode;
 use leptos::prelude::*;
 
 use crate::content::Locale;
@@ -17,6 +16,8 @@ use crate::content::Locale;
 pub fn NotFound() -> impl IntoView {
     #[cfg(feature = "ssr")]
     {
+        use http::StatusCode;
+
         if let Some(response) = use_context::<leptos_axum::ResponseOptions>() {
             response.set_status(StatusCode::NOT_FOUND);
         }

--- a/origa_landing/src/components/not_found.rs
+++ b/origa_landing/src/components/not_found.rs
@@ -1,9 +1,27 @@
+use http::StatusCode;
 use leptos::prelude::*;
 
 use crate::content::Locale;
 
+/// 404 page rendered for unmatched routes.
+///
+/// Sets the HTTP status to `404 Not Found` on the server so that search
+/// engines treat unknown URLs as deleted rather than indexing them as real
+/// pages ("soft-404" problem). `ResponseOptions` is provided automatically by
+/// `leptos_axum` via context when the router is built through
+/// [`leptos_axum::LeptosRoutes::leptos_routes`].
+///
+/// On the client (CSR) there is no HTTP status to set, so the context lookup
+/// is gated behind `#[cfg(feature = "ssr")]`.
 #[component]
 pub fn NotFound() -> impl IntoView {
+    #[cfg(feature = "ssr")]
+    {
+        if let Some(response) = use_context::<leptos_axum::ResponseOptions>() {
+            response.set_status(StatusCode::NOT_FOUND);
+        }
+    }
+
     let locale = use_context::<Locale>();
     let text = match locale {
         Some(Locale::Ru) => "Страница не найдена",

--- a/origa_landing/src/lib.rs
+++ b/origa_landing/src/lib.rs
@@ -2,3 +2,6 @@ pub mod app;
 pub mod components;
 pub mod content;
 pub mod pages;
+
+#[cfg(feature = "ssr")]
+pub mod server;

--- a/origa_landing/src/main.rs
+++ b/origa_landing/src/main.rs
@@ -1,11 +1,6 @@
 #[cfg(feature = "ssr")]
 #[tokio::main]
 async fn main() {
-    use axum::Router;
-    use leptos_axum::LeptosRoutes;
-    use origa_landing::app::{App, shell};
-    use tower_http::services::{ServeDir, ServeFile};
-
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -20,10 +15,6 @@ async fn main() {
 
     let addr = format!("0.0.0.0:{port}");
     tracing::info!("Server running on {addr}");
-
-    let pkg_dir = env!("CARGO_MANIFEST_DIR");
-
-    let routes = leptos_axum::generate_route_list(App);
 
     let leptos_options = match leptos::config::get_configuration(Some(concat!(
         env!("CARGO_MANIFEST_DIR"),
@@ -41,20 +32,7 @@ async fn main() {
         },
     };
 
-    let app = Router::new()
-        .nest_service("/images", ServeDir::new(format!("{pkg_dir}/public/images")))
-        .route_service(
-            "/landing.processed.css",
-            ServeFile::new(format!("{pkg_dir}/style/landing.processed.css")),
-        )
-        .leptos_routes(&leptos_options, routes, {
-            let leptos_options = leptos_options.clone();
-            move || shell(leptos_options.clone())
-        })
-        .fallback_service(
-            ServeDir::new(format!("{pkg_dir}/public")).append_index_html_on_directories(false),
-        )
-        .with_state(leptos_options);
+    let app = origa_landing::server::build_router(leptos_options);
 
     let listener = tokio::net::TcpListener::bind(&addr)
         .await

--- a/origa_landing/src/server.rs
+++ b/origa_landing/src/server.rs
@@ -1,0 +1,223 @@
+//! Axum router construction for `origa_landing` SSR.
+//!
+//! Kept in a library module (rather than inline in `main.rs`) so integration
+//! tests in `tests/` can build the exact same router the binary serves.
+
+use axum::Router;
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Redirect, Response};
+use http::header::{CACHE_CONTROL, HeaderValue};
+use http::{Method, Request, Uri};
+use leptos::config::LeptosOptions;
+use leptos_axum::{ErrorHandler, LeptosRoutes};
+use tower_http::ServiceExt;
+use tower_http::services::{ServeDir, ServeFile};
+
+use crate::app::{App, shell};
+
+/// HTML pages: short edge cache so users pick up content/nav changes within
+/// 5 minutes, while still letting Cloudflare absorb most origin traffic.
+const HTML_CACHE: &str = "public, max-age=300";
+
+/// Hashed/static assets that never change between releases (favicon, OG image,
+/// prebuilt CSS, `/images/*`). A year of immutable caching is the standard max
+/// for HTTP/1.1 caches.
+const IMMUTABLE_CACHE: &str = "public, max-age=31536000, immutable";
+
+/// Crawl-control files (robots.txt, sitemap.xml): search engines must always
+/// see the latest copy. Also the forced value on 4xx/5xx error responses so
+/// that CDNs never pin a "not found" or server-error page as cacheable —
+/// otherwise a later-added file would not be served until the cache expired.
+const NO_CACHE: &str = "no-cache";
+
+/// Permanent 308 redirects from `strip_trailing_slash`. A 24h edge cache lets
+/// Cloudflare answer the redirect without re-hitting origin on every crawl.
+/// Google's SEO guidance for permanent redirects recommends
+/// `max-age >= 86400` so link equity transfer is not delayed by re-redirects.
+const REDIRECT_CACHE: &str = "public, max-age=86400";
+
+/// Build the production Axum router.
+///
+/// Layering summary (request flows top → bottom; the LAST `.layer()` call is
+/// the outermost, i.e. closest to the client):
+///
+/// 1. `strip_trailing_slash` — outermost. Runs before routing so that `/ru/`,
+///    `/images/`, `/favicon.png/` are normalised to their canonical slash-less
+///    form. Otherwise the router would 404 slash-suffixed locale paths (the
+///    `leptos_router` `ParentRoute path!("ru")` matcher does not accept `/ru/`).
+///    308 responses produced here carry `REDIRECT_CACHE` directly (see below).
+/// 2. `enforce_cache_policy` — applies the cache-control contract to every
+///    non-redirect response produced by the inner stack:
+///    - 2xx without an explicit `Cache-Control` → stamped with `HTML_CACHE`
+///      (the default for leptos HTML routes, which set no header themselves).
+///    - 2xx with `Cache-Control` → left intact (static assets keep
+///      `IMMUTABLE_CACHE`; robots/sitemap keep `NO_CACHE`).
+///    - 4xx/5xx → overridden to `NO_CACHE`, regardless of what the inner
+///      service set. Without this, `ServeDir`/`ServeFile` would stamp
+///      `IMMUTABLE_CACHE` on a 404 via `insert_response_header_if_not_present`
+///      (which fires on *all* statuses), and Cloudflare would cache the "not
+///      found" for a year — a later-added file would not be served until the
+///      cache expired.
+///    - 3xx → passed through unchanged. The only 3xx from inner services is
+///      `304 Not Modified` on conditional requests, which must keep the same
+///      `Cache-Control` the corresponding 200 would have. `308`s from
+///      `strip_trailing_slash` never reach this middleware (outer layer).
+///
+/// Fallback chain: when neither explicit static routes nor leptos' registered
+/// routes match a path, the request hits `ServeDir(public/)`; if no file is
+/// found there either, control falls through to `ErrorHandler`, which renders
+/// the App via `leptos_router` (triggering its `<Routes fallback=NotFound>`
+/// branch) and stamps HTTP 404 on the response if the App did not override
+/// the status itself. This is what makes `/random` return a real 404 with the
+/// visible "404" body instead of an empty shell.
+///
+/// Note on `308 Permanent Redirect`: `Redirect::permanent` in axum 0.8 emits
+/// status 308, not 301. Both are treated as permanent by Googlebot/Yandex/Bing
+/// and pass full link equity.
+pub fn build_router(leptos_options: LeptosOptions) -> Router {
+    let pkg_dir = env!("CARGO_MANIFEST_DIR");
+    let routes = leptos_axum::generate_route_list(App);
+
+    let public_dir = format!("{pkg_dir}/public");
+    let error_handler = ErrorHandler::new(shell, leptos_options.clone());
+
+    Router::new()
+        .nest_service(
+            "/images",
+            ServeDir::new(format!("{public_dir}/images")).insert_response_header_if_not_present(
+                CACHE_CONTROL,
+                HeaderValue::from_static(IMMUTABLE_CACHE),
+            ),
+        )
+        .route_service(
+            "/landing.processed.css",
+            ServeFile::new(format!("{pkg_dir}/style/landing.processed.css"))
+                .insert_response_header_if_not_present(
+                    CACHE_CONTROL,
+                    HeaderValue::from_static(IMMUTABLE_CACHE),
+                ),
+        )
+        .route_service(
+            "/favicon.png",
+            ServeFile::new(format!("{public_dir}/favicon.png"))
+                .insert_response_header_if_not_present(
+                    CACHE_CONTROL,
+                    HeaderValue::from_static(IMMUTABLE_CACHE),
+                ),
+        )
+        .route_service(
+            "/robots.txt",
+            ServeFile::new(format!("{public_dir}/robots.txt"))
+                .insert_response_header_if_not_present(
+                    CACHE_CONTROL,
+                    HeaderValue::from_static(NO_CACHE),
+                ),
+        )
+        .route_service(
+            "/sitemap.xml",
+            ServeFile::new(format!("{public_dir}/sitemap.xml"))
+                .insert_response_header_if_not_present(
+                    CACHE_CONTROL,
+                    HeaderValue::from_static(NO_CACHE),
+                ),
+        )
+        .leptos_routes(&leptos_options, routes, {
+            let leptos_options = leptos_options.clone();
+            move || shell(leptos_options.clone())
+        })
+        .fallback_service(
+            ServeDir::new(&public_dir)
+                .append_index_html_on_directories(false)
+                .fallback(error_handler),
+        )
+        // Inner cache-policy layer. Replaces the previous
+        // `SetResponseHeaderLayer::if_not_present(HTML_CACHE)` with a function
+        // that additionally overrides `Cache-Control` to `NO_CACHE` on 4xx/5xx.
+        // See `enforce_cache_policy` below for the full rationale.
+        .layer(middleware::from_fn(enforce_cache_policy))
+        .layer(middleware::from_fn(strip_trailing_slash))
+        .with_state(leptos_options)
+}
+
+/// Cache-policy middleware applied to every non-redirect response.
+///
+/// Replaces the old outermost `SetResponseHeaderLayer::if_not_present(HTML)`
+/// with status-aware logic. The per-service
+/// `insert_response_header_if_not_present` calls on `ServeDir`/`ServeFile`
+/// remain in place — they stamp `IMMUTABLE_CACHE`/`NO_CACHE` on successful
+/// responses — but they fire on *all* statuses including 404, so this
+/// middleware post-processes the result:
+///
+/// - 4xx/5xx → forced to `NO_CACHE`. This is the fix for the SEO issue where
+///   `/images/nonexistent.png` returned 404 with `IMMUTABLE_CACHE`, causing
+///   Cloudflare to cache "not found" for a year and block any later-added
+///   file from being served until the cache expired.
+/// - 2xx without `Cache-Control` → stamped with `HTML_CACHE` (the default for
+///   leptos HTML routes, which do not set their own header).
+/// - 2xx/3xx with `Cache-Control` already present → left intact, so static
+///   assets keep `IMMUTABLE_CACHE`, robots/sitemap keep `NO_CACHE`, and
+///   `304 Not Modified` preserves the same `Cache-Control` as the 200 would
+///   have (required by HTTP conditional-cache semantics).
+///
+/// `308 Permanent Redirect` responses from `strip_trailing_slash` never reach
+/// this middleware: they are produced by a layer *outside* this one, which
+/// short-circuits the inner stack.
+async fn enforce_cache_policy(request: Request<axum::body::Body>, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let status = response.status();
+
+    if status.is_client_error() || status.is_server_error() {
+        response
+            .headers_mut()
+            .insert(CACHE_CONTROL, HeaderValue::from_static(NO_CACHE));
+    } else if status.is_success() && !response.headers().contains_key(CACHE_CONTROL) {
+        response
+            .headers_mut()
+            .insert(CACHE_CONTROL, HeaderValue::from_static(HTML_CACHE));
+    }
+
+    response
+}
+
+/// Middleware: redirect `/path/` to `/path` with HTTP 308 Permanent Redirect.
+///
+/// Canonical URLs for `origa_landing` have no trailing slash (e.g. `/ru`,
+/// `/ru/features`). The site root `/` is the sole exception and keeps its
+/// slash by convention.
+///
+/// - GET/HEAD only: other methods are passed through verbatim so the redirect
+///   cannot mask an accidental POST to a slash-suffixed URL. This mirrors
+///   RFC 7231 §6.4 redirect semantics.
+/// - Query string is preserved (relative `Location`).
+/// - Multiple trailing slashes collapse to one canonical form, e.g.
+///   `/ru//` → `/ru`.
+/// - The 308 response carries `Cache-Control: public, max-age=86400`
+///   (`REDIRECT_CACHE`) so edge caches serve the redirect without re-hitting
+///   origin on every crawl. This layer is the outermost one and short-circuits
+///   the inner stack, so `enforce_cache_policy` cannot apply the header — it
+///   must be set here directly.
+async fn strip_trailing_slash(
+    method: Method,
+    uri: Uri,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    if method != Method::GET && method != Method::HEAD {
+        return next.run(request).await;
+    }
+    let path = uri.path();
+    if path.len() <= 1 || !path.ends_with('/') {
+        return next.run(request).await;
+    }
+    let stripped = path.trim_end_matches('/');
+    let stripped = if stripped.is_empty() { "/" } else { stripped };
+    let location = match uri.query() {
+        Some(q) if !q.is_empty() => format!("{stripped}?{q}"),
+        _ => stripped.to_string(),
+    };
+    let mut response = Redirect::permanent(&location).into_response();
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static(REDIRECT_CACHE));
+    response
+}

--- a/origa_landing/tests/cache_headers.rs
+++ b/origa_landing/tests/cache_headers.rs
@@ -1,0 +1,130 @@
+//! Integration tests for `Cache-Control` headers.
+//!
+//! Behaviour under test:
+//! - HTML pages (leptos routes): `public, max-age=300` (5-minute edge cache).
+//! - Static hashed assets (favicon, /images/*, CSS): `public, max-age=31536000, immutable`.
+//! - Crawl-control files (robots.txt, sitemap.xml): `no-cache`.
+//! - Error responses (4xx/5xx): `no-cache`, never `immutable`. Without the
+//!   `enforce_cache_policy` middleware, `ServeDir`/`ServeFile` would stamp
+//!   `IMMUTABLE_CACHE` on a 404, and the CDN would pin "not found" for a year.
+
+#![cfg(feature = "ssr")]
+
+use axum::body::Body;
+use http::{Request, StatusCode, header::CACHE_CONTROL};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+mod common;
+
+async fn cache_control(uri: &str) -> Option<String> {
+    // Delegate to `status_and_cache_control` so the router→oneshot→drain
+    // sequence lives in exactly one place (DRY). Callers that don't need
+    // the status discard it via this thin wrapper.
+    status_and_cache_control(uri).await.1
+}
+
+async fn status_and_cache_control(uri: &str) -> (StatusCode, Option<String>) {
+    let response = common::test_router()
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("router responded");
+
+    let status = response.status();
+    let cc = response
+        .headers()
+        .get(CACHE_CONTROL)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    let _ = response.into_body().collect().await.expect("body");
+    (status, cc)
+}
+
+#[tokio::test]
+async fn html_root_has_short_edge_cache() {
+    let cc = cache_control("/").await;
+    assert_eq!(cc.as_deref(), Some("public, max-age=300"));
+}
+
+#[tokio::test]
+async fn html_locale_path_has_short_edge_cache() {
+    let cc = cache_control("/ru").await;
+    assert_eq!(cc.as_deref(), Some("public, max-age=300"));
+}
+
+#[tokio::test]
+async fn favicon_has_immutable_cache() {
+    let cc = cache_control("/favicon.png").await;
+    assert_eq!(cc.as_deref(), Some("public, max-age=31536000, immutable"));
+}
+
+#[tokio::test]
+async fn static_css_has_immutable_cache() {
+    let cc = cache_control("/landing.processed.css").await;
+    assert_eq!(cc.as_deref(), Some("public, max-age=31536000, immutable"));
+}
+
+#[tokio::test]
+async fn image_has_immutable_cache() {
+    // logo.png ships in the repo (see origa_landing/public/images/).
+    let cc = cache_control("/images/logo.png").await;
+    assert_eq!(cc.as_deref(), Some("public, max-age=31536000, immutable"));
+}
+
+#[tokio::test]
+async fn robots_txt_has_no_cache() {
+    let cc = cache_control("/robots.txt").await;
+    assert_eq!(cc.as_deref(), Some("no-cache"));
+}
+
+#[tokio::test]
+async fn sitemap_xml_has_no_cache() {
+    let cc = cache_control("/sitemap.xml").await;
+    assert_eq!(cc.as_deref(), Some("no-cache"));
+}
+
+#[tokio::test]
+async fn missing_image_404_is_not_cached_as_immutable() {
+    // Regression for the SEO "Common-1" issue: `ServeDir` stamps
+    // `IMMUTABLE_CACHE` on its 404 via `insert_response_header_if_not_present`
+    // (which fires on *all* statuses). The `enforce_cache_policy` middleware
+    // must override that to `NO_CACHE` so the CDN does not pin "not found"
+    // for a year — otherwise a later-added image would not be served until
+    // the cache expired.
+    let (status, cc) = status_and_cache_control("/images/definitely-missing.png").await;
+
+    // Assert
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        cc.as_deref(),
+        Some("no-cache"),
+        "404 must carry no-cache, not immutable; got {cc:?}"
+    );
+}
+
+#[tokio::test]
+async fn missing_fallback_file_404_is_not_cached_as_immutable() {
+    // Defence-in-depth: any path that resolves to a missing file under the
+    // fallback `ServeDir(public/)` must also return 404 without immutable
+    // caching. This response comes from `ErrorHandler` (leptos NotFound),
+    // which sets no `Cache-Control` itself; `enforce_cache_policy` must
+    // still force `NO_CACHE` on the 4xx. The assertion is exact (not
+    // `assert_ne!(immutable)`) so a regression where the middleware stops
+    // stamping `no-cache` on this code path is caught — `None` would fail
+    // the equality, not just differ from immutable.
+    let (status, cc) = status_and_cache_control("/no-such-file.txt").await;
+
+    // Assert
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        cc.as_deref(),
+        Some("no-cache"),
+        "404 must carry no-cache; got {cc:?}"
+    );
+}

--- a/origa_landing/tests/common/mod.rs
+++ b/origa_landing/tests/common/mod.rs
@@ -1,0 +1,19 @@
+//! Shared helpers for `origa_landing` integration tests.
+//!
+//! Each file in `tests/` compiles as a separate integration-test binary, so
+//! code reused across them must live in a module rather than a `#[path]`
+//! import. `tests/common/mod.rs` is the conventional location and is NOT
+//! picked up by Cargo as its own test target (only direct children of
+//! `tests/` are). Each test file pulls it in with `mod common;`.
+
+use leptos::config::LeptosOptions;
+
+/// Build the exact same Axum router the production binary serves, so tests
+/// exercise the real middleware stack (`strip_trailing_slash`,
+/// `enforce_cache_policy`) and the real route table.
+pub fn test_router() -> axum::Router {
+    let opts = LeptosOptions::builder()
+        .output_name("origa_landing")
+        .build();
+    origa_landing::server::build_router(opts)
+}

--- a/origa_landing/tests/not_found.rs
+++ b/origa_landing/tests/not_found.rs
@@ -1,0 +1,135 @@
+//! Integration tests for HTTP 404 (soft-404 fix).
+//!
+//! Behaviour under test: unknown URLs return HTTP 404 (Not Found) so that
+//! search engines treat them as deleted rather than indexing them as real
+//! pages. The body must contain the visible "404" marker.
+
+#![cfg(feature = "ssr")]
+
+use axum::body::Body;
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+mod common;
+
+async fn get_status_and_body(uri: &str) -> (StatusCode, String) {
+    let response = common::test_router()
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("router responded");
+
+    let status = response.status();
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body")
+        .to_bytes();
+    let text = String::from_utf8_lossy(&body).into_owned();
+    (status, text)
+}
+
+#[tokio::test]
+async fn unknown_root_path_returns_404() {
+    // Act
+    let (status, body) = get_status_and_body("/random").await;
+
+    // Assert
+    assert_eq!(status, StatusCode::NOT_FOUND, "body was: {body}");
+    assert!(body.contains("404"), "body should mention 404, got: {body}");
+}
+
+#[tokio::test]
+async fn unknown_locale_subpath_returns_404() {
+    // Act
+    let (status, body) = get_status_and_body("/ru/random").await;
+
+    // Assert
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(body.contains("404"), "body should mention 404, got: {body}");
+}
+
+#[tokio::test]
+async fn deep_unknown_path_returns_404() {
+    // Act
+    let (status, body) = get_status_and_body("/deep/nonexistent/path").await;
+
+    // Assert
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(body.contains("404"), "body should mention 404, got: {body}");
+}
+
+#[tokio::test]
+async fn homepage_still_returns_200() {
+    // Regression: homepage must keep working.
+    let (status, _body) = get_status_and_body("/").await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn locale_home_still_returns_200() {
+    // Regression: locale homepage must keep working.
+    let (status, _body) = get_status_and_body("/ru").await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn favicon_still_returns_200() {
+    // Regression: static asset must keep working.
+    let (status, _body) = get_status_and_body("/favicon.png").await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn sitemap_still_returns_200() {
+    // Regression: sitemap must keep working.
+    let (status, _body) = get_status_and_body("/sitemap.xml").await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[rstest::rstest]
+#[case::en("/", "en")]
+#[case::ru("/ru", "ru")]
+#[case::ko("/ko", "ko")]
+#[case::vi("/vi", "vi")]
+#[tokio::test]
+async fn html_lang_attribute_reflects_locale_in_ssr(
+    #[case] path: &str,
+    #[case] expected_lang: &str,
+) {
+    // Act
+    let (_status, body) = get_status_and_body(path).await;
+
+    // Assert: the SSR-rendered <html> tag must carry the locale's lang code so
+    // that search engines and screen readers treat the page as the right
+    // language. `leptos_meta::Html` inside `Layout` is the single source of
+    // truth (see ADR-011 "<html lang> policy").
+    assert!(
+        body.contains(&format!("lang=\"{expected_lang}\"")),
+        "expected lang=\"{expected_lang}\" on <html>, got first 500 chars: {}",
+        body.chars().take(500).collect::<String>()
+    );
+
+    // Negative assertion: there must be exactly ONE lang attribute on <html>.
+    // A duplicate (e.g. `<html lang="ru" lang="en">`) is invalid HTML5 and
+    // would indicate that a hardcoded lang in the shell wasn't removed.
+    let html_open_start = body
+        .find("<html")
+        .expect("response must contain an <html opening tag");
+    let html_open_end = body[html_open_start..]
+        .find('>')
+        .map(|offset| html_open_start + offset)
+        .expect("<html opening tag must close");
+    let html_open_tag = &body[html_open_start..=html_open_end];
+    let lang_count = html_open_tag.matches("lang=").count();
+    assert_eq!(
+        lang_count, 1,
+        "expected exactly one lang= attribute on <html>, got {lang_count} in: {html_open_tag}"
+    );
+}

--- a/origa_landing/tests/redirect.rs
+++ b/origa_landing/tests/redirect.rs
@@ -1,0 +1,237 @@
+//! Integration tests for trailing-slash canonicalisation.
+//!
+//! Behaviour under test: the `strip_trailing_slash` middleware redirects
+//! `/path/` to `/path` with HTTP 308 Permanent Redirect. The site root `/`
+//! is exempt by convention. Permanent redirects carry
+//! `Cache-Control: public, max-age=86400` so CDNs absorb the redirect
+//! without re-hitting origin on every crawl.
+
+#![cfg(feature = "ssr")]
+
+use axum::body::Body;
+use http::{Method, Request, StatusCode, header::CACHE_CONTROL, header::LOCATION};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+mod common;
+
+async fn send(uri: &str, method: Method) -> (StatusCode, Option<String>, String) {
+    let response = common::test_router()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("router responded");
+
+    let status = response.status();
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body")
+        .to_bytes();
+    let body_text = String::from_utf8_lossy(&body).into_owned();
+    (status, location, body_text)
+}
+
+/// Same as `send` but also captures `Cache-Control` (and drops the body, which
+/// redirect tests never inspect). Used by tests that verify the redirect's
+/// cache policy.
+async fn send_with_cache(
+    uri: &str,
+    method: Method,
+) -> (StatusCode, Option<String>, Option<String>) {
+    let response = common::test_router()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("router responded");
+
+    let status = response.status();
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let cache_control = response
+        .headers()
+        .get(CACHE_CONTROL)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    let _ = response.into_body().collect().await.expect("body");
+    (status, location, cache_control)
+}
+
+#[rstest::rstest]
+#[case::ru("/ru/", "/ru")]
+#[case::ko("/ko/", "/ko")]
+#[case::vi("/vi/", "/vi")]
+#[tokio::test]
+async fn locale_root_with_trailing_slash_redirects(
+    #[case] input: &str,
+    #[case] expected_location: &str,
+) {
+    // Act
+    let (status, location, _body) = send(input, Method::GET).await;
+
+    // Assert
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(location.as_deref(), Some(expected_location));
+}
+
+#[rstest::rstest]
+#[case("/ru/features/", "/ru/features")]
+#[case("/ru/compare/", "/ru/compare")]
+#[case("/ru/content/", "/ru/content")]
+#[case("/ru/download/", "/ru/download")]
+#[case("/ko/features/", "/ko/features")]
+#[case("/vi/download/", "/vi/download")]
+// English paths have no locale prefix — the canonical form is /features, not
+// /en/features. These cases guard against a regression where only locale-
+// prefixed paths were normalised.
+#[case("/features/", "/features")]
+#[case("/compare/", "/compare")]
+#[case("/content/", "/content")]
+#[case("/download/", "/download")]
+#[tokio::test]
+async fn locale_subpage_with_trailing_slash_redirects(
+    #[case] input: &str,
+    #[case] expected_location: &str,
+) {
+    // Act
+    let (status, location, _body) = send(input, Method::GET).await;
+
+    // Assert
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(location.as_deref(), Some(expected_location));
+}
+
+#[tokio::test]
+async fn root_with_trailing_slash_is_not_redirected() {
+    // Act
+    let (status, location, _body) = send("/", Method::GET).await;
+
+    // Assert: `/` is the canonical site root; middleware must not touch it.
+    assert_ne!(status, StatusCode::PERMANENT_REDIRECT);
+    assert!(location.is_none());
+}
+
+#[rstest::rstest]
+#[case("/ru")]
+#[case("/ko")]
+#[case("/vi")]
+#[case("/ru/features")]
+#[tokio::test]
+async fn canonical_path_without_trailing_slash_is_not_redirected(#[case] input: &str) {
+    // Act
+    let (status, location, _body) = send(input, Method::GET).await;
+
+    // Assert
+    assert_ne!(status, StatusCode::PERMANENT_REDIRECT);
+    assert!(location.is_none());
+}
+
+#[tokio::test]
+async fn trailing_slash_redirect_preserves_query_string() {
+    // Act
+    let (status, location, _body) = send("/ru/?ref=twitter", Method::GET).await;
+
+    // Assert
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(location.as_deref(), Some("/ru?ref=twitter"));
+}
+
+#[tokio::test]
+async fn head_request_with_trailing_slash_is_redirected() {
+    // Act
+    let (status, location, _body) = send("/ru/", Method::HEAD).await;
+
+    // Assert: HEAD mirrors GET for redirects per RFC 7231.
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(location.as_deref(), Some("/ru"));
+}
+
+#[tokio::test]
+async fn post_request_with_trailing_slash_is_not_redirected() {
+    // Act
+    let (status, location, _body) = send("/ru/", Method::POST).await;
+
+    // Assert: only safe methods get auto-redirected.
+    assert_ne!(status, StatusCode::PERMANENT_REDIRECT);
+    assert!(location.is_none());
+}
+
+#[tokio::test]
+async fn multiple_trailing_slashes_collapse() {
+    // Act
+    let (status, location, _body) = send("/ru///", Method::GET).await;
+
+    // Assert
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(location.as_deref(), Some("/ru"));
+}
+
+#[tokio::test]
+async fn static_asset_path_with_trailing_slash_redirects() {
+    // Act
+    let (status, location, _body) = send("/favicon.png/", Method::GET).await;
+
+    // Assert: middleware fires before routing, so even unknown slash-suffixed
+    // paths get normalised. What happens after the redirect (200 or 404) is
+    // a separate concern.
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(location.as_deref(), Some("/favicon.png"));
+}
+
+#[rstest::rstest]
+#[case::locale_root("/ru/")]
+#[case::another_locale("/ko/")]
+#[case::with_query_string("/ru/?x=1")]
+#[case::collapsed_slashes("/ru///")]
+#[tokio::test]
+async fn trailing_slash_redirect_is_cacheable(#[case] input: &str) {
+    // Regression for the SEO "Common-2" issue: 308 redirects from
+    // `strip_trailing_slash` are produced by the outermost layer and bypass
+    // the inner cache-policy middleware, so they used to ship without any
+    // `Cache-Control`. CDNs therefore re-hit origin on every crawl of a
+    // slash-suffixed URL. The redirect must now carry a 24h edge cache so
+    // Googlebot/Yandex/Bing pick up the canonical URL without an extra
+    // origin round-trip on every visit.
+    let (status, _location, cache_control) = send_with_cache(input, Method::GET).await;
+
+    // Assert
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(
+        cache_control.as_deref(),
+        Some("public, max-age=86400"),
+        "permanent redirects must be cacheable for 24h; got {cache_control:?}"
+    );
+}
+
+#[tokio::test]
+async fn head_redirect_is_cacheable() {
+    // HEAD mirrors GET for redirects per RFC 7231, including the cache policy.
+    let (status, _location, cache_control) = send_with_cache("/ru/", Method::HEAD).await;
+
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(
+        cache_control.as_deref(),
+        Some("public, max-age=86400"),
+        "HEAD redirect must carry the same cache-control as GET"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses 5 root causes preventing Google, Yandex, and Bing from indexing `origa.uwuwu.net`:

| # | Root Cause | Fix |
|---|-----------|-----|
| RC-1 | Sitemap.xml links to `/ru/`, `/ko/`, `/vi/` (trailing slash) → 404 | 308 redirect middleware + sitemap normalization |
| RC-3 | No Cache-Control on HTML/static | `enforce_cache_policy` middleware (HTML 5min, static immutable, redirects 24h, errors no-cache) |
| RC-4 | `<html lang="en">` hardcoded for all locales | `leptos_meta::Html` SSR component |
| RC-5 | NotFound returns HTTP 200 (soft-404) | `ResponseOptions::set_status(NOT_FOUND)` + ErrorHandler fallback |

RC-2 (Cloudflare managed robots.txt) handled separately via CF dashboard — see ADR-011 runbook.

## Changes

- `origa_landing/src/server.rs` (NEW): `build_router()` + `strip_trailing_slash` middleware + `enforce_cache_policy` middleware
- `origa_landing/src/main.rs`: delegates to `server::build_router()`
- `origa_landing/src/app.rs`: removed hardcoded `<html lang="en">` (now uses `leptos_meta::Html`)
- `origa_landing/src/components/layout.rs`: `<Html lang=locale.as_str() />` (removed JS hack)
- `origa_landing/src/components/not_found.rs`: sets HTTP 404 via ResponseOptions
- `origa_landing/public/sitemap.xml`: removed trailing slashes from localized URLs
- `origa_landing/tests/{redirect,cache_headers,not_found}.rs` + `tests/common/mod.rs` (NEW): 48 integration tests
- `Cargo.toml` (workspace): added `tower`, `http`, `http-body-util`; extended `tower-http` features
- `.github/workflows/ci.yml`: added `--features origa_landing/ssr` to clippy and test steps
- `docs/decisions/ADR-011-landing-url-canonicalization.md` (NEW)

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --features origa_landing/ssr -- -D warnings` ✅ (0 warnings)
- `cargo test -p origa_landing --features ssr` ✅ (48/48 passed)
- Code review: 2 cycles via `@code-quality-reviewer`, final approve (0H/0C/0L)

## Post-deploy smoke checks

```bash
curl -o /dev/null -s -w '%{http_code}\n' https://origa.uwuwu.net/ru/        # 308
curl -s -D - -o /dev/null https://origa.uwuwu.net/ | rg -i 'cache-control:' # public, max-age=300
curl -o /dev/null -s -w '%{http_code}\n' https://origa.uwuwu.net/random    # 404
curl -s https://origa.uwuwu.net/robots.txt                                  # clean (no CF-managed block)
curl -s https://origa.uwuwu.net/sitemap.xml | rg 'hreflang="(ru|ko|vi)"'    # no trailing slash
```

## Notes

- Auto-merge enabled (squash) — will merge automatically once all CI checks pass.
- After merge: resubmit sitemap in Google Search Console, Yandex Webmaster, Bing Webmaster. Expect indexing within 1-2 weeks.
- Related: ADR-007 (DNS resolution fix, complementary).
