### PR TITLE
fix(tauri): add beforeBuildCommand + release-devtools feature

### DIFF
--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -14,6 +14,12 @@ readme.workspace = true
 name = "origa_ui_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+# Enable DevTools in release builds for debugging.
+# Usage: cargo build --release --features release-devtools
+# Without this flag, DevTools are disabled in release (Tauri v2 default).
+release-devtools = ["tauri/devtools"]
+
 [build-dependencies]
 tauri-build.workspace = true
 serde_json.workspace = true

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -119,6 +119,15 @@ pub fn run() {
             }
 
             tracing::info!("[deep-link] setup complete");
+
+            #[cfg(feature = "release-devtools")]
+            {
+                if let Some(window) = app.get_webview_window("main") {
+                    window.open_devtools();
+                    tracing::info!("[devtools] DevTools opened (release-devtools feature enabled)");
+                }
+            }
+
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -8,6 +8,10 @@
             "script": "trunk serve",
             "cwd": "../origa_ui"
         },
+        "beforeBuildCommand": {
+            "script": "trunk build --release",
+            "cwd": "../origa_ui"
+        },
         "devUrl": "http://localhost:1420",
         "frontendDist": "../origa_ui/dist"
     },


### PR DESCRIPTION
## Summary

Two release-mode debugging improvements:
1. **`beforeBuildCommand`** — `cargo tauri build` now auto-runs `trunk build --release`. Fixes silent stale-WASM bug (dev worked, release didn't).
2. **`release-devtools` feature** — opt-in DevTools for release. Usage: `cargo tauri build --features release-devtools`. DevTools open automatically on startup.

## Files
- `tauri/tauri.conf.json` — beforeBuildCommand
- `tauri/Cargo.toml` — `[features] release-devtools = ["tauri/devtools"]`
- `tauri/src/lib.rs` — auto-open DevTools in setup (cfg-gated)

## Verification
- `cargo check -p origa-app` (default): PASS
- `cargo check -p origa-app --features release-devtools`: PASS
- qlty: clean

## Usage
```powershell
$env:ORIGA_CDN_BASE_URL = "https://s3.origa.uwuwu.net"
$env:TRAILBASE_URL = "https://app.origa.uwuwu.net"
$env:ORIGA_LANDING_BASE_URL = "https://origa.uwuwu.net"
cd tauri
cargo tauri build --features release-devtools
```
