### PR TITLE
fix(csp): allow Tauri IPC in connect-src (release regression from PR #160)

### DIFF
--- a/tauri/build_config.rs
+++ b/tauri/build_config.rs
@@ -33,7 +33,7 @@ pub(crate) const DEFAULT_LANDING: &str = "https://origa.uwuwu.net";
 /// (verified by `build_csp_with_production_defaults_matches_committed_tauri_conf`).
 pub(crate) fn build_csp(cdn: &str, landing: &str, trailbase: &str) -> String {
     format!(
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' {cdn} {landing} {trailbase} https://huggingface.co; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
     )
 }
 

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -21,7 +21,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://s3-proxy-production-52e3.up.railway.app https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co; img-src 'self' data: blob: https://s3-proxy-production-52e3.up.railway.app; media-src 'self' blob: https://s3-proxy-production-52e3.up.railway.app; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost https://s3-proxy-production-52e3.up.railway.app https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co; img-src 'self' data: blob: https://s3-proxy-production-52e3.up.railway.app; media-src 'self' blob: https://s3-proxy-production-52e3.up.railway.app; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
         }
     },
     "bundle": {


### PR DESCRIPTION
## Summary

CSP blocked Tauri IPC in release builds — regression from PR #160 (CSP parameterization). All IPC calls (`http://ipc.localhost/...`) were blocked → deep-link events, commands, plugin-store all silently failed.

## Root cause

After PR #160, CSP is generated via `TAURI_CONFIG` merge patch in `build_config.rs`. Tauri v2 stops auto-adding `ipc.localhost` when CSP is explicitly provided. Result: `connect-src` lacked `ipc:` and `http://ipc.localhost`.

## Fix

Added `ipc: http://ipc.localhost` to `connect-src` in both CSP sources:
- `tauri/build_config.rs` (generated)
- `tauri/tauri.conf.json` (static fallback)

## Platform coverage (Tauri v2.10.3)
- Windows/Android: `http://ipc.localhost` ✅
- macOS/Linux/iOS: `ipc://localhost` (via `ipc:` scheme) ✅

## Verification
- `cargo check -p origa-app`: PASS
- `cargo test -p origa-app --test build_config`: 9 passed (byte-equality preserved)
- Local release test: IPC works, deep-link events arrive, auth_store commands succeed

Refs: regression from PR #160, Tauri v2 CSP docs