### PR TITLE
docs: ADR-013/014/007-update for SEO landing work

### DIFF
--- a/docs/decisions/ADR-007-landing-dns-indexing-fix.md
+++ b/docs/decisions/ADR-007-landing-dns-indexing-fix.md
@@ -80,3 +80,30 @@ Report that Railway's authoritative NS return an A record in response to AAAA/MX
 - **No IPv6**: The site has no AAAA record. IPv6-only clients cannot reach it. Acceptable for now — Railway edge is IPv4.
 - **Future migration to Cloudflare recommended**: If the A-record maintenance burden grows or Railway edge IPs change frequently, migrate DNS to Cloudflare for automatic CNAME flattening and anycast resilience.
 - **Monitoring**: Periodically verify that `69.46.46.46` still resolves for `c2qj368z.up.railway.app` and that the site responds 200 OK. If the IP changes, update the A record in the Aeza panel.
+
+## Update (2026-06-24): Cloudflare Proxy Implemented
+
+The "Cloudflare Proxy" alternative listed above as **Deferred** (long-term upgrade)
+has since been **implemented**. The `uwuwu.net` zone was migrated from Aeza
+nameservers to Cloudflare authoritative NS (`ali.ns.cloudflare.com`,
+`clay.ns.cloudflare.com`). `origa.uwuwu.net` now resolves to Cloudflare proxy IPs
+(`104.21.39.177`, `172.67.147.175`) with valid AAAA records, and Cloudflare forwards
+to the Railway origin over IPv4.
+
+This supersedes the plain-A-record workaround as the active solution:
+
+- AAAA queries now return clean NOERROR with real Cloudflare IPv6 — SERVFAIL is no
+  longer reachable for `origa.uwuwu.net` by any resolver.
+- Railway's broken AAAA behaviour is still present (`c2qj368z.up.railway.app` AAAA →
+  SERVFAIL, no IPv6 on Railway origin), but it is **hidden behind the Cloudflare
+  proxy** and no longer affects the public domain.
+
+**⚠️ Operational warning:** Cloudflare is now the **only** layer shielding the domain
+from the Railway DNS protocol bug. If the zone is ever moved back off Cloudflare, or
+`origa.uwuwu.net` is re-pointed directly at Railway via CNAME, the SERVFAIL regression
+returns immediately. Keep the domain behind Cloudflare.
+
+Verified 2026-06-24: A and AAAA queries via Yandex DNS (77.88.8.8), Google (8.8.8.8),
+Cloudflare (1.1.1.1), Quad9 (9.9.9.9), and the authoritative Cloudflare NS all return
+NOERROR with valid records. `robots.txt` is clean (no AI-Audit block), and
+`Google-Extended`/`YandexBot` user-agents receive HTTP 200 with full SSR HTML.

--- a/docs/decisions/ADR-013-favicon-asset-strategy.md
+++ b/docs/decisions/ADR-013-favicon-asset-strategy.md
@@ -1,0 +1,74 @@
+# ADR-013: Favicon Asset Strategy
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-24
+
+## Context
+
+Yandex Webmaster reported "could not load favicon" for `origa.uwuwu.net`. Investigation
+showed `/favicon.ico` returned HTTP 404 — the landing served only `/favicon.png`
+(configured via `<link rel="icon" type="image/png">`). Yandex (and some browsers)
+request `/favicon.ico` by default and treat its absence as a missing favicon, which
+also suppresses the favicon in Yandex search snippets.
+
+The landing had no vector source for the logo: a repository-wide search for `*.svg`
+returned only `origa_ui/public/external_icons/anki.svg` (a third-party brand icon, not
+Origa). The highest-resolution raster source is `tauri/icons/icon-512.png` (512×512 RGBA),
+used by the Tauri desktop build.
+
+## Decision
+
+Generate favicon assets from the canonical raster source via a build script:
+
+- **Canonical source:** `tauri/icons/icon-512.png` (single source of truth for all
+  raster derivatives).
+- **Generator:** `scripts/generate_favicon.py`, run via `uv run --with pillow python
+  scripts/generate_favicon.py`. Produces:
+  - `origa_landing/public/favicon.ico` — multi-size ICO (16×16, 32×32, 48×48, LANCZOS).
+  - `origa_landing/public/apple-touch-icon.png` — 180×180 PNG.
+- **Generated artifacts are committed** (not built at CI time) so deployments do not
+  require Pillow.
+- **Serving:** two explicit `route_service` entries in `server.rs` with
+  `IMMUTABLE_CACHE` (public, max-age=31536000, immutable), alongside the existing
+  `/favicon.png` route.
+- **`<head>` links** (`app.rs` shell):
+  - `<link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48" />`
+  - `<link rel="icon" type="image/png" href="/favicon.png" />` (kept for back-compat)
+  - `<link rel="apple-touch-icon" href="/apple-touch-icon.png" />`
+- **SVG favicon: not added.** No vector source exists; PNG-traced SVG would defeat the
+  purpose of vector scaling. Re-evaluate if a vector logo is produced.
+
+## Alternatives Considered
+
+### SVG favicon traced from PNG
+
+- Rejected: auto-tracing the raster logo produces a large, imprecise SVG that does not
+  scale cleanly. A hand-drawn SVG was out of scope (no designer source available).
+
+### Replace `favicon.png` with the new ICO
+
+- Rejected: `favicon.png` is referenced by external systems and keeps a PNG entry in
+  the `<head>` for clients that prefer it. Keeping both maximises compatibility.
+
+### Generate ICO at CI time (do not commit artifacts)
+
+- Rejected: would require Pillow in every CI/CD image and add a build dependency for a
+  one-time-per-logo operation. Committing the ~8 KB ICO + ~43 KB PNG is cheaper.
+
+## Consequences
+
+- Yandex favicon discovery unblocked (`/favicon.ico` now 200).
+- **Regeneration trigger:** whenever `tauri/icons/icon-512.png` changes, re-run
+  `generate_favicon.py` and commit the new artifacts. This is a manual step — not
+  wired into CI to avoid the Pillow dependency there.
+- **CDN cache rotation trade-off:** because favicon routes use `IMMUTABLE_CACHE`
+  (1-year edge cache per ADR-011), a logo change will not propagate until the cache
+  expires or is purged. If the logo ever rotates, either version the URL
+  (`/favicon.v2.ico`) or purge the Cloudflare cache for these paths.
+- `favicon.png` (32×32, the previous web favicon) is intentionally left in place for
+  backward compatibility.

--- a/docs/decisions/ADR-014-sitemap-build-time-lastmod.md
+++ b/docs/decisions/ADR-014-sitemap-build-time-lastmod.md
@@ -1,0 +1,81 @@
+# ADR-014: Sitemap Build-Time <lastmod> Generation
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-24
+
+## Context
+
+`origa_landing/public/sitemap.xml` listed five canonical URLs with `hreflang`
+alternates but no `<lastmod>` element. Google largely ignores `lastmod`, but Yandex
+uses it to prioritise crawl frequency. Without it, Yandex had no freshness signal and
+treated every URL as equally (un)likely to have changed.
+
+The sitemap is served as a static file via `tower_http::ServeFile` with `NO_CACHE`
+(per ADR-011), so adding `lastmod` had to preserve the static-serving model rather
+than introduce a dynamic Axum handler.
+
+## Decision
+
+Generate `sitemap.xml` at **build time** from a template:
+
+- **Template:** `public/sitemap.xml` was renamed to `public/sitemap.xml.tmpl` with a
+  `{{LASTMOD}}` placeholder inserted immediately after each `<loc>`, before the
+  `<xhtml:link>` alternates (per sitemaps.org 0.9 element ordering).
+- **Generator:** `build.rs::generate_sitemap(manifest_dir)`, wired with
+  `cargo:rerun-if-changed=public/sitemap.xml.tmpl` and
+  `cargo:rerun-if-env-changed=ORIGA_BUILD_DATE`. Performs
+  `template.replace("{{LASTMOD}}", &date)` and writes `public/sitemap.xml`.
+- **`lastmod` source — fallback chain:**
+  1. `ORIGA_BUILD_DATE` env var (set by CI). Authoritative for Docker/production
+     builds, gives bit-for-bit reproducibility.
+  2. `git log -1 --format=%cd --date=short --follow -- public/sitemap.xml.tmpl` via
+     `std::process::Command`. Local-dev convenience only; the Docker builder stage has
+     no git, so this path is never reached in production.
+  3. `"1970-01-01"` literal + `cargo:warning=...`. Explicit sentinel meaning "no
+     freshness data available" — does not mislead Yandex with a fabricated recent
+     date.
+- **Output is gitignored:** `origa_landing/.gitignore` ignores
+  `public/sitemap.xml` (it is a build artefact, regenerated every build).
+- **CI wiring:** `Dockerfile` gained `ARG/ENV ORIGA_BUILD_DATE`; `.github/workflows/
+  docker.yml` passes `ORIGA_BUILD_DATE` in the landing image build args, reusing the
+  existing `version` job's `build_date` output.
+- **Production URLs in the template are intentionally hardcoded** (not env-derived):
+  the sitemap must advertise stable canonical public URLs for crawlers independent of
+  the build environment. A comment in the template documents this rationale.
+
+## Alternatives Considered
+
+### Static hardcoded `<lastmod>`, updated manually per release
+
+- Rejected: a manual step before every release is fragile and easy to forget. Stale
+  `lastmod` is worse than none (signals false freshness).
+
+### Runtime Axum handler generating `sitemap.xml` on each request
+
+- Rejected: would abandon the `ServeFile` static model (ADR-011), add per-request work,
+  and require serialising XML in Rust on every hit. The static file with build-time
+  substitution keeps serving zero-cost.
+
+### Use the build timestamp always (`Utc::now()` in `build.rs`)
+
+- Rejected: breaks reproducible builds — two builds of the same commit produce
+  different `lastmod` values. The `ORIGA_BUILD_DATE` env path gives reproducibility;
+  the git path gives commit-accurate dates locally.
+
+## Consequences
+
+- Every build emits a `sitemap.xml` with accurate `<lastmod>` for all five URLs.
+- **Production reproducibility** depends on CI always setting `ORIGA_BUILD_DATE`. The
+  Docker builder has no git, so if the env var is unset in CI, the sentinel
+  `1970-01-01` is emitted with a `cargo:warning` — a visible signal, not a silent
+  failure.
+- **Local dev** gets commit-accurate dates via git; no env var needed.
+- The `.tmpl` file is the source of truth; `public/sitemap.xml` is never edited
+  directly (it is gitignored).
+- Adding a new URL to the sitemap means editing `sitemap.xml.tmpl` and adding the
+  `<lastmod>` placeholder in the correct position.


### PR DESCRIPTION
Documents the architectural decisions behind PR #184 (On-Page SEO).

- **ADR-013** Favicon Asset Strategy — canonical source (icon-512.png), generate_favicon.py, IMMUTABLE_CACHE routes, SVG rationale, CDN rotation trade-off.
- **ADR-014** Sitemap Build-Time `<lastmod>` Generation — template + gitignored output, env→git→1970 fallback chain, CI-wiring.
- **ADR-007 update** — the "Cloudflare Proxy" deferred alternative is now implemented (zone migrated to Cloudflare NS); plain-A-record workaround superseded. Includes operational warning that Cloudflare is the only shield from the Railway AAAA SERVFAIL bug.