### PR TITLE
fix(landing): aria-hidden attr: prefix leaks into SSR HTML

### DIFF
--- a/origa_landing/src/pages/features.rs
+++ b/origa_landing/src/pages/features.rs
@@ -42,7 +42,7 @@ pub fn FeaturesPage() -> impl IntoView {
             <div class="feat-hero__decor">
                 <div
                     class="feat-hero__decor-img"
-                    attr:aria-hidden="true"
+                    aria-hidden="true"
                     style=format!("background-image: url({all_in_one_image})")
                 ></div>
             </div>

--- a/origa_landing/src/pages/home.rs
+++ b/origa_landing/src/pages/home.rs
@@ -40,7 +40,7 @@ pub fn HomePage() -> impl IntoView {
             <div class="home-hero__decor">
                 <div
                     class="home-hero__decor-img"
-                    attr:aria-hidden="true"
+                    aria-hidden="true"
                     style=format!("background-image: url(/images/{lang}.hero.png)")
                 ></div>
             </div>

--- a/origa_landing/tests/seo_meta.rs
+++ b/origa_landing/tests/seo_meta.rs
@@ -237,6 +237,11 @@ async fn features_hero_decor_has_aria_hidden() {
     // tag, so we locate the entire enclosing `<div ...>` opening tag (from the
     // nearest preceding `<` to the next `>`) and check it carries the
     // attribute anywhere within.
+    //
+    // Two complementary checks guard against a regression where the RSX
+    // `attr:aria-hidden` form leaks the `attr:` prefix into SSR HTML: the prefix
+    // would satisfy a naive `contains("aria-hidden")` (false positive) while
+    // browsers ignore the resulting invalid attribute.
     let body = get_body("/features").await;
     let class_idx = body
         .find("feat-hero__decor-img")
@@ -249,6 +254,10 @@ async fn features_hero_decor_has_aria_hidden() {
         .map(|offset| class_idx + offset)
         .expect("decor div opening tag must close");
     let decor_open_tag = &body[tag_start..=tag_end];
+    assert!(
+        !decor_open_tag.contains("attr:aria-hidden"),
+        "attr: prefix must not leak into SSR HTML; got: {decor_open_tag}"
+    );
     assert!(
         decor_open_tag.contains(r#"aria-hidden="true""#),
         "decorative background-image div must carry aria-hidden; got: {decor_open_tag}"


### PR DESCRIPTION
## Bug
`attr:aria-hidden="true"` in Leptos 0.8 RSX leaks the `attr:` prefix into SSR HTML as an invalid attribute (`<div attr:aria-hidden="true">`), so browsers ignore it and the real `aria-hidden` never applies. Decorative hero images on `/` and `/features` were being announced by screen readers.

Verified on production: `curl https://origa.uwuwu.net/features` returned `<div attr:aria-hidden="true" class="feat-hero__decor-img">` (invalid). `/download` with `aria-hidden="true"` (no prefix) renders correctly.

## Fix
Drop the `attr:` prefix for hyphenated `aria-*` attributes — matches the working pattern in `download.rs`:
- `home.rs:43`, `features.rs:45`: `attr:aria-hidden="true"` → `aria-hidden="true"`

## Test fix
`features_hero_decor_has_aria_hidden` was false-positive: it searched for substring `"aria-hidden"`, which `attr:aria-hidden` contains. Now asserts valid `aria-hidden` token AND absence of `attr:aria-hidden`.

## Origin
Regression introduced in PR #184 (copied the pre-existing broken `home.rs:43` pattern into `features.rs:45`). Pattern-virus case: bad pattern replicated.
