### PR TITLE
refactor(cdn): extract S3 transport to _cdn_s3 and add scoped refresh

### DIFF
--- a/scripts/_cdn_s3.py
+++ b/scripts/_cdn_s3.py
@@ -2,9 +2,9 @@
 
 Centralises ``aws`` CLI invocation (shelled out via ``pwsh`` on Windows because
 that is how the operator's PowerShell environment resolves the AWS wrapper on
-the deployment host) so that ``deploy_cdn.py`` stays a deployment orchestrator
-rather than a transport layer. All S3 paths route through here: upload, sync,
-manifest download.
+the deployment host) so that ``deploy_cdn.py`` and
+``refresh_cache_control.py`` stay orchestrators rather than a transport layer.
+All shared S3 paths route through here: upload, sync, manifest download.
 """
 
 from __future__ import annotations
@@ -14,10 +14,29 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import NamedTuple
 
 S3_BUCKET = "adaptable-foodbox-ucep7wx"
 S3_PROFILE = "origa"
 S3_ENDPOINT = "https://t3.storageapi.dev"
+
+# copy-object caps at 5 GiB; surfaced so callers can skip oversize objects with
+# a clear message instead of an opaque T3 error mid-walk.
+COPY_OBJECT_MAX_BYTES = 5 * 1024 * 1024 * 1024
+
+# The aws CLI is invoked through ``pwsh -Command`` (see run_aws_raw), which
+# re-parses argv as a PowerShell script. A key containing a PowerShell
+# metacharacter could therefore execute as a command/statement rather than a
+# literal argument. This is a DENYLIST, not an ASCII allowlist: CJK and other
+# Unicode letters are not command separators and pass through safely, which
+# matters because kanji_animations/ uses the kanji themselves as filenames
+# (一.svg, 丁.svg, ...).
+_UNSAFE_KEY_CHARS = frozenset(" \t\r\n;|&`$\"'<>()@\\")
+
+
+class ObjectMetadata(NamedTuple):
+    cache_control: str | None
+    content_length: int | None
 
 
 def s3_uri(key: str) -> str:
@@ -87,3 +106,141 @@ def download_remote_manifest(dry_run: bool) -> dict[str, object] | None:
         return json.loads(content)
     finally:
         tmp_path.unlink(missing_ok=True)
+
+
+def is_safe_key(key: str) -> bool:
+    return bool(key) and not any(ch in _UNSAFE_KEY_CHARS for ch in key)
+
+
+def filter_safe_keys(keys: list[str]) -> tuple[list[str], list[str]]:
+    safe = [k for k in keys if is_safe_key(k)]
+    unsafe = [k for k in keys if not is_safe_key(k)]
+    return safe, unsafe
+
+
+def _list_key_page(
+    token: str | None, prefix: str | None = None
+) -> tuple[list[str], str | None, bool]:
+    """Fetch one list-objects-v2 page.
+
+    Returns the page's keys, the continuation token for the next page (None if
+    not truncated), and whether more pages remain.
+    """
+    args = [
+        "s3api",
+        "list-objects-v2",
+        "--bucket",
+        S3_BUCKET,
+        "--profile",
+        S3_PROFILE,
+        "--endpoint-url",
+        S3_ENDPOINT,
+    ]
+    if prefix:
+        args += ["--prefix", prefix]
+    if token:
+        args += ["--continuation-token", token]
+    result = run_aws_raw(args)
+    if result.returncode != 0:
+        print("ERROR: list-objects-v2 failed", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    data = json.loads(result.stdout) if result.stdout.strip() else {}
+    keys = [
+        obj["Key"]
+        for obj in data.get("Contents", [])
+        if isinstance(obj.get("Key"), str)
+    ]
+    return keys, data.get("NextContinuationToken"), bool(data.get("IsTruncated"))
+
+
+def list_keys(prefix: str | None = None) -> tuple[list[str], int]:
+    """List object keys (optionally under ``prefix``), paginating fully.
+
+    Returns the safe keys plus a count of keys dropped as unsafe (shell
+    metacharacters). Aborts if S3 signals truncation without a continuation
+    token — that would silently lose keys.
+    """
+    raw: list[str] = []
+    token: str | None = None
+    while True:
+        keys, next_token, truncated = _list_key_page(token, prefix)
+        raw.extend(keys)
+        if not truncated:
+            break
+        if not next_token:
+            print(
+                "ERROR: S3 returned IsTruncated without NextContinuationToken; "
+                "cannot paginate safely",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        token = next_token
+
+    safe, unsafe = filter_safe_keys(raw)
+    for key in unsafe:
+        print(f"  WARNING: dropping unsafe key: {key!r}", file=sys.stderr)
+    return safe, len(unsafe)
+
+
+def head_object(key: str) -> ObjectMetadata | None:
+    result = run_aws_raw(
+        [
+            "s3api",
+            "head-object",
+            "--bucket",
+            S3_BUCKET,
+            "--key",
+            key,
+            "--profile",
+            S3_PROFILE,
+            "--endpoint-url",
+            S3_ENDPOINT,
+        ]
+    )
+    if result.returncode != 0:
+        print(f"  WARNING: head-object failed for {key}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return None
+    data = json.loads(result.stdout) if result.stdout.strip() else {}
+    length = data.get("ContentLength")
+    return ObjectMetadata(
+        cache_control=data.get("CacheControl"),
+        content_length=int(length) if isinstance(length, int) else None,
+    )
+
+
+def copy_object_cache_control(key: str, target_cc: str, dry_run: bool) -> bool:
+    """Rewrite one object's Cache-Control via a server-side self-copy.
+
+    Returns True if applied (or previewed in dry-run), False if the copy
+    failed — the caller continues with the remaining objects rather than
+    aborting the whole walk.
+    """
+    args = [
+        "s3api",
+        "copy-object",
+        "--bucket",
+        S3_BUCKET,
+        "--key",
+        key,
+        "--copy-source",
+        f"{S3_BUCKET}/{key}",
+        "--profile",
+        S3_PROFILE,
+        "--endpoint-url",
+        S3_ENDPOINT,
+        "--metadata-directive",
+        "REPLACE",
+        "--cache-control",
+        target_cc,
+    ]
+    if dry_run:
+        return True
+    result = run_aws_raw(args)
+    if result.returncode != 0:
+        print(f"  ERROR: copy-object failed for {key}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return False
+    return True

--- a/scripts/refresh_cache_control.py
+++ b/scripts/refresh_cache_control.py
@@ -1,14 +1,39 @@
-"""One-time refresh of Cache-Control metadata on existing S3 objects.
+"""Refresh Cache-Control metadata on existing S3 objects to match the tiered policy.
 
 After the tiered policy (``_cdn_cache``) ships, fresh uploads get the right
 header, but objects already in the bucket keep whatever Cache-Control they
-were originally given. This script walks every object, compares its current
-Cache-Control against the policy, and rewrites the metadata in place via an
-``s3api copy-object --metadata-directive REPLACE`` self-copy where they differ.
+were originally given. This script fetches each target object's metadata,
+compares its current Cache-Control against the policy, and rewrites the
+metadata in place via an ``s3api copy-object --metadata-directive REPLACE``
+self-copy where they differ.
 
 Only metadata changes — object bytes are copied server-side by S3, never
-downloaded. Listing and HEAD always run (even in ``--dry-run``) so the preview
-reflects what would actually change; only the copy is gated by ``--dry-run``.
+downloaded. HEAD always runs (even in ``--dry-run``) so the preview reflects
+what would actually change; only the copy is gated by ``--dry-run``.
+
+Scope
+-----
+Three scopes select which objects to refresh. The default avoids walking the
+bucket's 100k+ truly-static objects (audio, kanji art, ML models), which took
+hours and incurred real S3 LIST/HEAD cost when the original implementation
+listed the whole bucket:
+
+- **default** — download ``manifest.json`` and refresh only the files it lists
+  plus ``manifest.json`` itself (~33 keys). Fast and effectively free.
+- ``--prefix PREFIX`` — walk objects under one S3 prefix. Small content
+  prefixes (``grammar/``, ``dictionary/``) run without a prompt; a prefix into
+  a heavy directory (``kanji_animations/``, ``phrases/audio/``, ...) holds the
+  same 100k+ objects as ``--all`` and gets the same cost-guard.
+- ``--all`` — walk EVERY object in the bucket. Always prompts for explicit
+  confirmation, including under ``--dry-run``: the cost is LIST+HEAD on 100k+
+  objects, which ``--dry-run`` does NOT avoid (it only gates the copy).
+
+The manifest tracks release-updated versioned files plus the immutable
+lindera ``dictionaries/`` binaries; the latter are HEAD'd as no-ops (already
+``immutable``) but cost nothing at ~33 keys. The truly-static bulk that is
+never in the manifest — ``kanji_animations/``, ``kanji_frames/``, ``ndlocr/``,
+``phrases/audio/``, ``whisper/`` — keeps an immutable Cache-Control that does
+not change between releases, so the default scope deliberately skips it.
 
 Recovery: the walk is idempotent — ``needs_update`` decides per object from
 live metadata, so re-running after a partial failure picks up exactly the
@@ -16,47 +41,60 @@ objects still mis-configured. A failure on one object (HEAD error, oversize,
 copy error) is reported and skipped, not fatal; the run exits non-zero only if
 any object failed, so a re-run completes the remainder.
 
+S3 transport (list / HEAD / copy-object, key-safety) lives in ``_cdn_s3``;
+this module is the scope selector + decision layer.
+
 Usage::
 
-    python scripts/refresh_cache_control.py --dry-run   # preview (read-only)
-    python scripts/refresh_cache_control.py              # apply
+    python scripts/refresh_cache_control.py --dry-run                  # manifest only
+    python scripts/refresh_cache_control.py                             # manifest only, apply
+    python scripts/refresh_cache_control.py --dry-run --prefix grammar/
+    python scripts/refresh_cache_control.py --all                      # prompts even with --dry-run
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from collections import Counter
 from typing import NamedTuple
 
 import _cdn_cache
-from _cdn_s3 import S3_BUCKET, S3_ENDPOINT, S3_PROFILE, run_aws_raw
+from _cdn_s3 import (
+    COPY_OBJECT_MAX_BYTES,
+    S3_BUCKET,
+    copy_object_cache_control,
+    download_remote_manifest,
+    filter_safe_keys,
+    head_object,
+    is_safe_key,
+    list_keys,
+)
 
-# copy-object caps at 5 GiB. Only objects whose Cache-Control changes get
-# copied, and those are the small release-updated JSON — but guard anyway so
-# a future large object with wrong metadata fails with a clear message
-# instead of an opaque T3 error mid-walk.
-COPY_OBJECT_MAX_BYTES = 5 * 1024 * 1024 * 1024
-
-# The aws CLI is invoked through ``pwsh -Command`` (see _cdn_s3.run_aws_raw),
-# which re-parses argv as a PowerShell script. A key containing a PowerShell
-# metacharacter could therefore execute as a command/statement rather than a
-# literal argument. This is a DENYLIST, not an ASCII allowlist: CJK and other
-# Unicode letters are not command separators and pass through safely, which
-# matters because kanji_animations/ and kanji_frames/ use the kanji themselves
-# as filenames (一.svg, 丁.svg, ...).
-_UNSAFE_KEY_CHARS = frozenset(" \t\r\n;|&`$\"'<>()@\\")
-
-
-class ObjectMetadata(NamedTuple):
-    cache_control: str | None
-    content_length: int | None
+# Prefixes under these directories hold the 100k+ truly-static objects
+# (kanji art, audio, ML models). A ``--prefix`` into them is as expensive as
+# ``--all``, so it shares the same cost-guard; content prefixes skip it.
+_HEAVY_PREFIXES = frozenset(
+    {
+        "kanji_animations/",
+        "kanji_frames/",
+        "ndlocr/",
+        "phrases/audio/",
+        "whisper/",
+    }
+)
 
 
 class WalkOutcome(NamedTuple):
     category: str
     failed: bool
+
+
+class WalkSummary(NamedTuple):
+    scanned: int
+    counts: Counter[str]
+    retriable: list[str]
+    oversize: list[str]
 
 
 def normalize_cache_control(cc: str | None) -> str:
@@ -73,138 +111,42 @@ def needs_update(current_cc: str | None, target_cc: str) -> bool:
     return normalize_cache_control(current_cc) != normalize_cache_control(target_cc)
 
 
-def is_safe_key(key: str) -> bool:
-    return bool(key) and not any(ch in _UNSAFE_KEY_CHARS for ch in key)
+def is_heavy_prefix(prefix: str) -> bool:
+    """Whether ``--prefix`` points into a 100k+ truly-static directory."""
+    normalized = prefix if prefix.endswith("/") else prefix + "/"
+    return any(normalized.startswith(heavy) for heavy in _HEAVY_PREFIXES)
 
 
-def filter_safe_keys(keys: list[str]) -> tuple[list[str], list[str]]:
-    safe = [k for k in keys if is_safe_key(k)]
-    unsafe = [k for k in keys if not is_safe_key(k)]
-    return safe, unsafe
+def load_manifest_files() -> tuple[list[str], int]:
+    """Default scope: keys listed in remote ``manifest.json`` plus the manifest itself.
 
-
-def _request_key_page(token: str | None) -> tuple[list[str], str | None, bool]:
-    """Fetch one list-objects-v2 page.
-
-    Returns the page's keys, the continuation token for the next page (None if
-    not truncated), and whether more pages remain.
+    The manifest tracks release-updated versioned files (and the immutable
+    ``dictionaries/`` binaries, which HEAD as no-ops). The truly-static bulk —
+    kanji art, audio, ML models — lives in SYNC_DIRS and never appears here, so
+    this refreshes exactly the files whose Cache-Control policy changed with
+    PR #182 at ~33 keys. Downloading the manifest is read-only and runs even
+    under ``--dry-run``.
     """
-    args = [
-        "s3api",
-        "list-objects-v2",
-        "--bucket",
-        S3_BUCKET,
-        "--profile",
-        S3_PROFILE,
-        "--endpoint-url",
-        S3_ENDPOINT,
-    ]
-    if token:
-        args += ["--continuation-token", token]
-    result = run_aws_raw(args)
-    if result.returncode != 0:
-        print("ERROR: list-objects-v2 failed", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
+    print("Downloading remote manifest.json ...")
+    manifest = download_remote_manifest(dry_run=False)
+    if manifest is None:
+        print(
+            "ERROR: remote manifest.json not found. Run deploy_cdn.py first, "
+            "or use --all / --prefix to refresh by listing.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
-    data = json.loads(result.stdout) if result.stdout.strip() else {}
-    keys = [
-        obj["Key"]
-        for obj in data.get("Contents", [])
-        if isinstance(obj.get("Key"), str)
-    ]
-    return keys, data.get("NextContinuationToken"), bool(data.get("IsTruncated"))
+    files = manifest.get("files") if isinstance(manifest, dict) else None
+    if not isinstance(files, dict) or not files:
+        print("ERROR: manifest has no 'files' object to enumerate", file=sys.stderr)
+        sys.exit(1)
 
-
-def list_all_keys() -> tuple[list[str], int]:
-    """List every object key in the bucket, paginating fully.
-
-    Returns the safe keys plus a count of keys dropped as unsafe (shell
-    metacharacters). Aborts if S3 signals truncation without a continuation
-    token — that would silently lose keys.
-    """
-    raw: list[str] = []
-    token: str | None = None
-    while True:
-        keys, next_token, truncated = _request_key_page(token)
-        raw.extend(keys)
-        if not truncated:
-            break
-        if not next_token:
-            print(
-                "ERROR: S3 returned IsTruncated without NextContinuationToken; "
-                "cannot paginate safely",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        token = next_token
-
+    raw = [*files.keys(), "manifest.json"]
     safe, unsafe = filter_safe_keys(raw)
     for key in unsafe:
         print(f"  WARNING: dropping unsafe key: {key!r}", file=sys.stderr)
     return safe, len(unsafe)
-
-
-def head_object(key: str) -> ObjectMetadata | None:
-    result = run_aws_raw(
-        [
-            "s3api",
-            "head-object",
-            "--bucket",
-            S3_BUCKET,
-            "--key",
-            key,
-            "--profile",
-            S3_PROFILE,
-            "--endpoint-url",
-            S3_ENDPOINT,
-        ]
-    )
-    if result.returncode != 0:
-        print(f"  WARNING: head-object failed for {key}", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-        return None
-    data = json.loads(result.stdout) if result.stdout.strip() else {}
-    length = data.get("ContentLength")
-    return ObjectMetadata(
-        cache_control=data.get("CacheControl"),
-        content_length=int(length) if isinstance(length, int) else None,
-    )
-
-
-def update_cache_control(key: str, target_cc: str, dry_run: bool) -> bool:
-    """Rewrite one object's Cache-Control via a server-side self-copy.
-
-    Returns True if applied (or previewed in dry-run), False if the copy
-    failed — the caller continues with the remaining objects rather than
-    aborting the whole walk.
-    """
-    args = [
-        "s3api",
-        "copy-object",
-        "--bucket",
-        S3_BUCKET,
-        "--key",
-        key,
-        "--copy-source",
-        f"{S3_BUCKET}/{key}",
-        "--profile",
-        S3_PROFILE,
-        "--endpoint-url",
-        S3_ENDPOINT,
-        "--metadata-directive",
-        "REPLACE",
-        "--cache-control",
-        target_cc,
-    ]
-    if dry_run:
-        return True
-    result = run_aws_raw(args)
-    if result.returncode != 0:
-        print(f"  ERROR: copy-object failed for {key}", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-        return False
-    return True
 
 
 def _walk_one(key: str, dry_run: bool) -> WalkOutcome:
@@ -227,68 +169,162 @@ def _walk_one(key: str, dry_run: bool) -> WalkOutcome:
 
     current_display = meta.cache_control or "(none)"
     print(f"  UPDATE {key}  [{current_display} -> {target}]")
-    if update_cache_control(key, target, dry_run):
+    if copy_object_cache_control(key, target, dry_run):
         return WalkOutcome("updated", failed=False)
     return WalkOutcome("copy_failed", failed=True)
 
 
-def main() -> None:
+def _confirm_expensive_walk(scope_desc: str) -> bool:
+    """Gate an expensive LIST+HEAD walk behind explicit confirmation.
+
+    The cost this PR eliminates is LIST+HEAD across 100k+ objects — NOT the
+    copy-object, which ``--dry-run`` gates. So confirmation is required for
+    ``--all`` (and heavy ``--prefix``) regardless of ``--dry-run``. A missing
+    interactive stdin fails closed (abort) rather than crashing.
+    """
+    print(
+        f"WARNING: {scope_desc} will LIST + HEAD every matching S3 object "
+        "(~100k+ audio/kanji/model files). This may take hours and incur "
+        "significant S3 API costs (dry-run does NOT avoid listing cost).",
+        file=sys.stderr,
+    )
+    try:
+        answer = input("Continue? [y/N] ").strip().lower()
+    except EOFError:
+        print("\nAborted (no interactive stdin).", file=sys.stderr)
+        return False
+    if answer != "y":
+        print("Aborted.", file=sys.stderr)
+        return False
+    return True
+
+
+def collect_targets(args: argparse.Namespace) -> tuple[list[str], int]:
+    """Resolve which S3 keys to refresh for the selected scope.
+
+    Precedence: ``--all`` > ``--prefix`` > default (manifest files).
+    ``--all`` and ``--prefix`` are mutually exclusive at the argparse layer;
+    the if-chain here is the dispatch logic and stays defensive. Returns
+    ``(safe_keys, unsafe_count)``.
+    """
+    if args.all:
+        print(f"Listing ALL objects in s3://{S3_BUCKET} ...")
+        if not _confirm_expensive_walk("--all"):
+            sys.exit(0)
+        return list_keys(prefix=None)
+    if args.prefix:
+        print(f"Listing objects under s3://{S3_BUCKET}/{args.prefix} ...")
+        if is_heavy_prefix(args.prefix) and not _confirm_expensive_walk(
+            f"--prefix {args.prefix}"
+        ):
+            sys.exit(0)
+        return list_keys(prefix=args.prefix)
+    return load_manifest_files()
+
+
+def _run_walk(keys: list[str], dry_run: bool) -> WalkSummary:
+    counts: Counter[str] = Counter()
+    retriable: list[str] = []
+    oversize: list[str] = []
+    for key in keys:
+        outcome = _walk_one(key, dry_run)
+        counts[outcome.category] += 1
+        if outcome.category == "oversize":
+            oversize.append(key)
+        elif outcome.failed:
+            retriable.append(key)
+    return WalkSummary(
+        scanned=len(keys),
+        counts=counts,
+        retriable=retriable,
+        oversize=oversize,
+    )
+
+
+def _print_summary(summary: WalkSummary, dropped: int, dry_run: bool) -> None:
+    counts = summary.counts
+    print("\nSummary:")
+    print(f"  scanned:           {summary.scanned}")
+    print(f"  updated:           {counts['updated']}")
+    print(f"  already OK:        {counts['already_ok']}")
+    print(f"  dropped (unsafe):  {dropped}")
+
+    if summary.retriable:
+        print(f"  failed (retriable): {len(summary.retriable)}")
+        for key in summary.retriable:
+            print(f"    - {key}")
+    if summary.oversize:
+        print(f"  oversize (> 5 GiB, manual): {len(summary.oversize)}")
+        for key in summary.oversize:
+            print(f"    - {key}")
+
+    if dry_run:
+        print("\n(dry-run: no metadata rewritten)")
+    elif summary.retriable:
+        print("\nRe-run to retry the failed objects (walk is idempotent).")
+    if summary.oversize:
+        print(
+            "\nOversize objects exceed the 5 GiB copy-object limit and need a "
+            "manual metadata update (re-running will not fix them)."
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Refresh Cache-Control on existing S3 objects to match "
-        "the tiered policy (read-only listing/HEAD always runs).",
+        "the tiered policy (HEAD always runs; copy gated by --dry-run).",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Show what would change without rewriting metadata",
     )
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument(
+        "--prefix",
+        default=None,
+        help="Refresh only objects under this S3 prefix (e.g. 'grammar/' or "
+        "'phrases/data/'). Faster than --all for a single directory; a prefix "
+        "into a heavy dir (kanji_animations/, audio/) prompts like --all.",
+    )
+    scope.add_argument(
+        "--all",
+        action="store_true",
+        help="Walk ALL S3 objects, not just manifest files. WARNING: with "
+        "100k+ audio files this can take hours and incur significant S3 API "
+        "costs. Prompts for confirmation (even with --dry-run). Use only when "
+        "changing Cache-Control for truly-static files (kanji_animations, "
+        "audio, models).",
+    )
+    return parser
+
+
+def _validate_prefix(prefix: str) -> None:
+    if not is_safe_key(prefix):
+        print(
+            f"ERROR: --prefix contains unsafe characters: {prefix!r}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def main() -> None:
+    parser = _build_parser()
     args = parser.parse_args()
+
+    if args.prefix is not None:
+        _validate_prefix(args.prefix)
 
     if args.dry_run:
         print("=== DRY RUN ===\n")
 
-    print(f"Listing objects in s3://{S3_BUCKET} ...")
-    keys, dropped = list_all_keys()
-    print(f"  {len(keys)} safe, {dropped} dropped (unsafe charset)\n")
+    keys, dropped = collect_targets(args)
+    print(f"  {len(keys)} target(s), {dropped} dropped (unsafe charset)\n")
 
-    counts: Counter[str] = Counter()
-    retriable: list[str] = []
-    oversize: list[str] = []
+    summary = _run_walk(keys, args.dry_run)
+    _print_summary(summary, dropped, args.dry_run)
 
-    for key in keys:
-        outcome = _walk_one(key, args.dry_run)
-        counts[outcome.category] += 1
-        if outcome.category == "oversize":
-            oversize.append(key)
-        elif outcome.failed:
-            retriable.append(key)
-
-    print("\nSummary:")
-    print(f"  scanned:           {len(keys)}")
-    print(f"  updated:           {counts['updated']}")
-    print(f"  already OK:        {counts['already_ok']}")
-    print(f"  dropped (unsafe):  {dropped}")
-
-    needs_attention = bool(retriable or oversize)
-    if retriable:
-        print(f"  failed (retriable): {len(retriable)}")
-        for key in retriable:
-            print(f"    - {key}")
-    if oversize:
-        print(f"  oversize (> 5 GiB, manual): {len(oversize)}")
-        for key in oversize:
-            print(f"    - {key}")
-
-    if args.dry_run:
-        print("\n(dry-run: no metadata rewritten)")
-    elif retriable:
-        print("\nRe-run to retry the failed objects (walk is idempotent).")
-    if oversize:
-        print(
-            "\nOversize objects exceed the 5 GiB copy-object limit and need a "
-            "manual metadata update (re-running will not fix them)."
-        )
-    if needs_attention:
+    if summary.retriable or summary.oversize:
         sys.exit(1)
 
 

--- a/scripts/tests/test_refresh_cache_control.py
+++ b/scripts/tests/test_refresh_cache_control.py
@@ -1,19 +1,40 @@
-"""Unit tests for ``refresh_cache_control.py`` decision logic.
+"""Unit tests for ``refresh_cache_control.py``.
 
-Only the pure helpers are exercised — S3 transport (list/HEAD/copy-object)
-is an operator-run side effect and is not mocked here.
+Pure decision helpers are exercised directly. Scope dispatch
+(``collect_targets`` / ``load_manifest_files`` / ``_confirm_expensive_walk``)
+and the walk aggregation (``_run_walk`` / ``_print_summary``) are tested with
+the S3 transport monkeypatched, since the live walk is an operator-run side
+effect.
 """
 
 from __future__ import annotations
 
+import argparse
+from collections import Counter
+
 import pytest
 
+import refresh_cache_control as rcc
+from _cdn_s3 import filter_safe_keys, is_safe_key
 from refresh_cache_control import (
-    filter_safe_keys,
-    is_safe_key,
+    WalkOutcome,
+    WalkSummary,
+    is_heavy_prefix,
     needs_update,
     normalize_cache_control,
 )
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    """Build a Namespace matching the argparse contract of ``main``.
+
+    Mirrors the dest names collect_targets reads (``all``, ``prefix``,
+    ``dry_run``) so dispatch tests stay independent of argparse wiring. The
+    argparse↔dispatch contract is asserted separately via ``_build_parser``.
+    """
+    base: dict[str, object] = {"dry_run": False, "all": False, "prefix": None}
+    base.update(overrides)
+    return argparse.Namespace(**base)
 
 
 @pytest.mark.parametrize(
@@ -113,3 +134,347 @@ def test_filter_safe_keys_partitions():
         "kanji_animations/一.svg",
     ]
     assert unsafe == ["evil;rm", 'bad"quote']
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "kanji_animations/",
+        "kanji_animations",  # trailing-slash tolerant
+        "kanji_animations/sub/",
+        "phrases/audio/",
+        "phrases/audio",
+        "ndlocr/",
+        "whisper/",
+        "kanji_frames/",
+    ],
+)
+def test_heavy_prefix_detected(prefix: str):
+    assert is_heavy_prefix(prefix)
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "grammar/",
+        "dictionary/",
+        "phrases/data/",
+        "pitch/",
+        "well_known_set/",
+        "manifest.json",
+    ],
+)
+def test_content_prefix_not_heavy(prefix: str):
+    assert not is_heavy_prefix(prefix)
+
+
+# ---------------------------------------------------------------------------
+# Scope dispatch (collect_targets)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_targets_default_uses_manifest_files(monkeypatch):
+    """Default scope must NOT trigger a full bucket walk — the original bug."""
+    called = {"list_keys": False, "manifest": False}
+
+    def fake_manifest() -> tuple[list[str], int]:
+        called["manifest"] = True
+        return ["manifest.json", "grammar/grammar.json"], 0
+
+    def fake_list(prefix: str | None = None) -> tuple[list[str], int]:
+        called["list_keys"] = True
+        return ["should-not-happen"], 0
+
+    monkeypatch.setattr(rcc, "load_manifest_files", fake_manifest)
+    monkeypatch.setattr(rcc, "list_keys", fake_list)
+
+    keys, dropped = rcc.collect_targets(_args())
+
+    assert called["manifest"] is True
+    assert called["list_keys"] is False
+    assert keys == ["manifest.json", "grammar/grammar.json"]
+    assert dropped == 0
+
+
+def test_collect_targets_light_prefix_skips_confirmation(monkeypatch):
+    captured: dict[str, str | None] = {}
+
+    def fake_list(prefix: str | None = None) -> tuple[list[str], int]:
+        captured["prefix"] = prefix
+        return ["grammar/grammar.json"], 0
+
+    monkeypatch.setattr(rcc, "list_keys", fake_list)
+    monkeypatch.setattr(
+        rcc, "_confirm_expensive_walk", lambda desc: pytest.fail("should not prompt")
+    )
+
+    keys, _ = rcc.collect_targets(_args(prefix="grammar/"))
+
+    assert captured["prefix"] == "grammar/"
+    assert keys == ["grammar/grammar.json"]
+
+
+def test_collect_targets_heavy_prefix_prompts(monkeypatch):
+    captured: dict[str, str | None] = {}
+
+    def fake_list(prefix: str | None = None) -> tuple[list[str], int]:
+        captured["prefix"] = prefix
+        return ["kanji_animations/一.svg"], 0
+
+    confirmed = {"value": False}
+
+    def fake_confirm(desc: str) -> bool:
+        confirmed["value"] = True
+        assert "kanji_animations" in desc
+        return True
+
+    monkeypatch.setattr(rcc, "list_keys", fake_list)
+    monkeypatch.setattr(rcc, "_confirm_expensive_walk", fake_confirm)
+
+    keys, _ = rcc.collect_targets(_args(prefix="kanji_animations/"))
+
+    assert confirmed["value"] is True
+    assert captured["prefix"] == "kanji_animations/"
+    assert keys == ["kanji_animations/一.svg"]
+
+
+def test_collect_targets_heavy_prefix_aborts_when_not_confirmed(monkeypatch):
+    monkeypatch.setattr(rcc, "list_keys", lambda prefix=None: ["should-not-run"])
+    monkeypatch.setattr(rcc, "_confirm_expensive_walk", lambda desc: False)
+
+    with pytest.raises(SystemExit) as exc:
+        rcc.collect_targets(_args(prefix="phrases/audio/"))
+
+    assert exc.value.code == 0
+
+
+def test_collect_targets_all_calls_list_keys_without_prefix(monkeypatch):
+    captured: dict[str, str | None] = {}
+
+    def fake_list(prefix: str | None = None) -> tuple[list[str], int]:
+        captured["prefix"] = prefix
+        return ["a", "b"], 1
+
+    monkeypatch.setattr(rcc, "list_keys", fake_list)
+    monkeypatch.setattr(rcc, "_confirm_expensive_walk", lambda desc: True)
+
+    keys, dropped = rcc.collect_targets(_args(all=True))
+
+    assert captured["prefix"] is None
+    assert keys == ["a", "b"]
+    assert dropped == 1
+
+
+def test_collect_targets_all_aborts_when_not_confirmed(monkeypatch):
+    """Refusing the --all prompt exits cleanly without touching S3."""
+    monkeypatch.setattr(rcc, "list_keys", lambda prefix=None: ["should-not-run"])
+    monkeypatch.setattr(rcc, "_confirm_expensive_walk", lambda desc: False)
+
+    with pytest.raises(SystemExit) as exc:
+        rcc.collect_targets(_args(all=True))
+
+    assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# argparse ↔ collect_targets contract
+# ---------------------------------------------------------------------------
+
+
+def test_build_parser_assigns_dests_collect_targets_reads():
+    """Guards against dest-name drift between the parser and dispatch."""
+    all_args = rcc._build_parser().parse_args(["--all"])
+    assert all_args.all is True
+    assert all_args.prefix is None
+    assert all_args.dry_run is False
+
+    prefix_args = rcc._build_parser().parse_args(["--prefix", "grammar/"])
+    assert prefix_args.all is False
+    assert prefix_args.prefix == "grammar/"
+
+    dry_args = rcc._build_parser().parse_args(["--dry-run", "--all"])
+    assert dry_args.all is True
+    assert dry_args.dry_run is True
+
+
+def test_build_parser_rejects_all_and_prefix_together(capsys):
+    with pytest.raises(SystemExit):
+        rcc._build_parser().parse_args(["--all", "--prefix", "grammar/"])
+
+
+def test_validate_prefix_rejects_unsafe_chars(capsys):
+    with pytest.raises(SystemExit) as exc:
+        rcc._validate_prefix("evil;rm")
+    assert exc.value.code == 2
+    assert "unsafe" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# --all confirmation (_confirm_expensive_walk)
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_prompts_and_aborts_on_no(capsys, monkeypatch):
+    captured: dict[str, str] = {}
+
+    def fake_input(prompt: str = "") -> str:
+        captured["prompt"] = prompt
+        return "n"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert rcc._confirm_expensive_walk("--all") is False
+
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "Aborted" in err
+    assert "Continue? [y/N]" in captured["prompt"]
+
+
+def test_confirm_accepts_explicit_yes(capsys, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *a: "y")
+    assert rcc._confirm_expensive_walk("--all") is True
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_confirm_prompts_even_in_dry_run(monkeypatch):
+    """The cost is LIST+HEAD, which --dry-run does NOT avoid (regression guard)."""
+    prompted = {"value": False}
+
+    def fake_input(prompt: str = "") -> str:
+        prompted["value"] = True
+        return "n"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    rcc._confirm_expensive_walk("--all")
+    assert prompted["value"] is True
+
+
+def test_confirm_fails_closed_on_eof(capsys, monkeypatch):
+    """Non-interactive stdin (CI, pipe) must abort, not crash with a traceback."""
+
+    def raise_eof(_prompt: str = "") -> str:
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+
+    assert rcc._confirm_expensive_walk("--all") is False
+    assert "no interactive stdin" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Default scope source (load_manifest_files)
+# ---------------------------------------------------------------------------
+
+
+def test_load_manifest_files_returns_manifest_keys_plus_manifest_itself(monkeypatch):
+    manifest = {
+        "version": 1,
+        "files": {
+            "grammar/grammar.json": "h1",
+            "dictionary/chunk_01.json": "h2",
+        },
+    }
+    monkeypatch.setattr(rcc, "download_remote_manifest", lambda dry_run=False: manifest)
+
+    keys, dropped = rcc.load_manifest_files()
+
+    # manifest.json is tracked nowhere in its own files dict but still needs
+    # its no-cache header refreshed.
+    assert "manifest.json" in keys
+    assert "grammar/grammar.json" in keys
+    assert "dictionary/chunk_01.json" in keys
+    assert dropped == 0
+
+
+def test_load_manifest_files_exits_when_manifest_missing(monkeypatch, capsys):
+    monkeypatch.setattr(rcc, "download_remote_manifest", lambda dry_run=False: None)
+
+    with pytest.raises(SystemExit):
+        rcc.load_manifest_files()
+
+    assert "not found" in capsys.readouterr().err
+
+
+def test_load_manifest_files_exits_when_files_missing(monkeypatch):
+    monkeypatch.setattr(
+        rcc, "download_remote_manifest", lambda dry_run=False: {"version": 1}
+    )
+
+    with pytest.raises(SystemExit):
+        rcc.load_manifest_files()
+
+
+def test_load_manifest_files_drops_unsafe_keys(monkeypatch, capsys):
+    manifest = {"version": 1, "files": {"evil;rm": "h1", "ok.json": "h2"}}
+    monkeypatch.setattr(rcc, "download_remote_manifest", lambda dry_run=False: manifest)
+
+    keys, dropped = rcc.load_manifest_files()
+
+    assert keys == ["ok.json", "manifest.json"]
+    assert dropped == 1
+    assert "evil;rm" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Walk aggregation (_run_walk / _print_summary)
+# ---------------------------------------------------------------------------
+
+
+def test_run_walk_classifies_outcomes(monkeypatch):
+    sequence = iter(
+        [
+            WalkOutcome("updated", failed=False),
+            WalkOutcome("already_ok", failed=False),
+            WalkOutcome("head_failed", failed=True),  # retriable
+            WalkOutcome("copy_failed", failed=True),  # retriable
+            WalkOutcome("oversize", failed=False),  # not retriable, separate bucket
+        ]
+    )
+    monkeypatch.setattr(rcc, "_walk_one", lambda key, dry_run: next(sequence))
+
+    summary = rcc._run_walk(["a", "b", "c", "d", "e"], dry_run=False)
+
+    assert isinstance(summary, WalkSummary)
+    assert summary.scanned == 5
+    assert summary.counts["updated"] == 1
+    assert summary.counts["already_ok"] == 1
+    assert summary.retriable == ["c", "d"]
+    assert summary.oversize == ["e"]
+
+
+def _summary(**counts: int) -> WalkSummary:
+    """Build a WalkSummary pre-populated with the given category counts."""
+    return WalkSummary(
+        scanned=sum(counts.values()),
+        counts=Counter(counts),
+        retriable=[],
+        oversize=[],
+    )
+
+
+def test_print_summary_reports_retriable_and_oversize(capsys):
+    summary = _summary(updated=1, already_ok=0)
+    summary = summary._replace(retriable=["bad.json"], oversize=["huge.bin"])
+
+    rcc._print_summary(summary, dropped=2, dry_run=False)
+
+    out = capsys.readouterr().out
+    assert "scanned:           1" in out
+    assert "updated:           1" in out
+    assert "dropped (unsafe):  2" in out
+    assert "failed (retriable): 1" in out
+    assert "- bad.json" in out
+    assert "oversize (> 5 GiB, manual): 1" in out
+    assert "- huge.bin" in out
+    assert "Re-run to retry" in out
+
+
+def test_print_summary_dry_run_message(capsys):
+    summary = _summary(already_ok=1)
+
+    rcc._print_summary(summary, dropped=0, dry_run=True)
+
+    out = capsys.readouterr().out
+    assert "already OK:        1" in out
+    assert "(dry-run: no metadata rewritten)" in out

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -1,0 +1,152 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "origa-scripts"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", specifier = ">=8.0" }]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## What
Refactor of the CDN cache-refresh tooling that was sitting uncommitted in the working tree (branch `fix/landing-aria-hidden-regression`). Lifted the S3 transport layer into a shared module and added a tiered, cost-guarded scope so the default run no longer walks the bucket's 100k+ truly-static objects.

## Changes
- **`scripts/_cdn_s3.py`** — S3 transport primitives extracted from `refresh_cache_control.py` into a shared module (also consumed by `deploy_cdn.py`): `list_keys` (paginated), `head_object`, `copy_object_cache_control`, `download_remote_manifest`, `is_safe_key`/`filter_safe_keys` (PowerShell-metachar denylist, CJK-safe), `ObjectMetadata`, `COPY_OBJECT_MAX_BYTES`, `_UNSAFE_KEY_CHARS`. Pure stdlib at import time; S3 calls shell out to the `aws` CLI at call time only (no `boto3` dependency).
- **`scripts/refresh_cache_control.py`** — tiered scope (default = manifest-only ~33 keys, `--prefix PREFIX`, `--all` = whole bucket), heavy-prefix cost-guard (`_HEAVY_PREFIXES` with interactive confirmation that fires **even under `--dry-run`**, since the cost is LIST+HEAD, not the copy), fail-closed on non-interactive stdin. Reorganised into `collect_targets` / `load_manifest_files` / `_confirm_expensive_walk` / `_run_walk` / `_print_summary` / `_build_parser` + `WalkSummary`/`WalkOutcome`.
- **`scripts/tests/test_refresh_cache_control.py`** — ~347 lines covering scope selection, heavy-prefix confirmation (prompt/accept/abort/EOF/dry-run-guard), argparse↔dispatch contract, prefix validation, manifest loading, walk aggregation. Regression guards: `test_collect_targets_default_uses_manifest_files`, `test_confirm_prompts_even_in_dry_run`.
- **`scripts/uv.lock`** — committed (the `origa-scripts` `pyproject.toml` project is tracked on master; `.gitignore` has no lockfile rule; uv.lock is the reproducible-install artifact for a uv-managed project).

## Verification
- **Self-contained vs `master`:** proven. `origin/master` already contains the full CDN-scripts stack (`_cdn_cache.py`, `refresh_cache_control.py`, `_cdn_s3.py`); `git diff origin/master fix/cdn-cache-control-policy -- scripts/` is empty, so the unmerged `fix/cdn-cache-control-policy` branch is NOT a dependency. This branch is an incremental refactor on top of master.
- **Tests:** `uv run pytest` (Python 3.13.5 / pytest 9.1.1) → **280 passed in 1.16s** (full `scripts/` suite, including the consumers of the shared `_cdn_s3.py`: `test_cdn_cache.py`, `test_deploy_cdn.py`). The refresh test file alone: **59 passed**.
- **Lint:** `ruff check` on the 3 changed files → "All checks passed!"; `ruff format --check` → "3 files already formatted". (`ruff check .` reports 18 pre-existing violations in unrelated files that predate this change — out of scope.)
- **Code review:** `@code-quality-reviewer` full review → **`recommendation: approve`** (0 High / 4 Common / 5 Low). See "Open review findings" below.

## Notes
- `uv.lock` handling: **committed** — real `scripts/pyproject.toml` project on master, no `.gitignore` lockfile rule.
- No CDN deployment performed — only tooling code. Deployment remains manual per `AGENTS.md`.
- No auto-merge: CDN is critical infra; a separate merge-time GATE will be run before merge.

## Open review findings (from `@code-quality-reviewer`, all non-blocking — `approve`)
The reviewer returned `approve`; these are improvements, not correctness defects. Surfaced here for the merge-time review:
- **Common #1 — DRY drift hazard:** `_HEAVY_PREFIXES` duplicates `_cdn_cache._IMMUTABLE_RULES` (minus `dictionaries/`). Adding a new bulk-immutable dir only to `_cdn_cache` would let `--prefix` into it silently bypass the cost-guard. Worth linking the two sets.
- **Common #2 — `_walk_one` decision logic untested:** it is stubbed in `test_run_walk_classifies_outcomes`; the oversize/`needs_update`/classification branches aren't exercised (mockable via `head_object`/`copy_object_cache_control`).
- **Common #3 — abort tests don't enforce non-invocation:** `test_collect_targets_*_aborts_when_not_confirmed` rely on a `"should-not-run"` literal, not an assertion that `list_keys` was never called. A confirm-before-walk reordering would still pass. Recommend the `called = {...}` pattern used in the default-scope test.
- **Common #4 — `test_confirm_prompts_even_in_dry_run` is a misnomer:** `_confirm_expensive_walk` takes no `dry_run`; the real link (collect_targets ignores `dry_run` when prompting) lives in `collect_targets` and isn't tested via `collect_targets(_args(all=True, dry_run=True))`.
- **Low:** stale one-line docstring in `_cdn_s3.py:1` (mentions only `deploy_cdn.py`); `SYNC_DIRS` reference in `load_manifest_files` is imprecise (`_cdn_cache._IMMUTABLE_RULES` is the real referent); `manifest.json` not deduped against `files.keys()`; `sys.exit(0)` on abort undocumented for CI automation; `s3_uri()` helper not used in `collect_targets` display strings.
