### PR TITLE
feat(lesson): revamp lesson composition for focus and retention

### DIFF
--- a/origa/src/domain/knowledge/kanji_companions.rs
+++ b/origa/src/domain/knowledge/kanji_companions.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 use ulid::Ulid;
 
 use super::lesson::{LessonCard, LessonData, LessonViewGenerator};
-use super::lesson_builder::MAX_LESSON_SIZE;
 use super::{Card, KnowledgeSet, MAX_COMPANION_WORDS};
 use crate::dictionary::kanji::get_kanji_info;
 use crate::domain::japanese::JapaneseChar;
@@ -82,9 +81,10 @@ fn add_reverse_companions(
         return lesson_data;
     }
 
-    let effective_limit = MAX_REVERSE_COMPANION_CARDS_PER_LESSON
-        .min(MAX_LESSON_SIZE.saturating_sub(lesson_data.cards.len()));
-    let capped: Vec<_> = candidates.into_iter().take(effective_limit).collect();
+    let capped: Vec<_> = candidates
+        .into_iter()
+        .take(MAX_REVERSE_COMPANION_CARDS_PER_LESSON)
+        .collect();
 
     append_companions(lesson_data, knowledge_set, &capped)
 }
@@ -265,7 +265,8 @@ mod tests {
                 (*id, LessonCard::new(view, false))
             })
             .collect();
-        LessonData::reorder_core_first_phrases_last(cards)
+        let core_count = cards.len();
+        LessonData { cards, core_count }
     }
 
     #[test]
@@ -562,6 +563,51 @@ mod tests {
             "Reverse companions should be capped at {MAX_REVERSE_COMPANION_CARDS_PER_LESSON}, got {reverse_count}"
         );
         assert!(reverse_count > 0, "Should have some reverse companions");
+    }
+
+    // Regression: previously the cap was tightened by `MAX_LESSON_SIZE.saturating_sub(cards.len())`,
+    // so once the core section grew large enough the reverse budget shrank below the intended 10.
+    // With a 41-card core (MAX_LESSON_SIZE - 9) the old code would have offered only 9 reverse slots.
+    #[test]
+    fn reverse_companions_uncapped_by_lesson_size() {
+        init_real_dictionaries();
+
+        let reverse_kanji_chars = ["日", "本", "人", "大", "出", "見", "食", "飲", "行", "来"];
+
+        let mut ks = KnowledgeSet::new();
+
+        for ch in &reverse_kanji_chars {
+            ks.create_card(create_kanji_card(ch)).unwrap();
+        }
+
+        let mut lesson_card_ids = Vec::new();
+        for i in 0..41 {
+            let filler_sc = ks
+                .create_card(create_vocab_card(&format!("filler{i}")))
+                .unwrap();
+            lesson_card_ids.push(*filler_sc.card_id());
+        }
+
+        let anchor_vocab: String = reverse_kanji_chars.concat();
+        let anchor_sc = ks.create_card(create_vocab_card(&anchor_vocab)).unwrap();
+        lesson_card_ids.push(*anchor_sc.card_id());
+
+        assert_eq!(
+            lesson_card_ids.len(),
+            42,
+            "Test setup must exceed the historical bug threshold (41), got {}",
+            lesson_card_ids.len()
+        );
+
+        let lesson = build_empty_lesson_with_cards(&ks, &lesson_card_ids);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N1);
+
+        let reverse_count = result.cards.len() - lesson_card_ids.len();
+        assert_eq!(
+            reverse_count, MAX_REVERSE_COMPANION_CARDS_PER_LESSON,
+            "Reverse companions should reach the full {} even with a large core section, got {}",
+            MAX_REVERSE_COMPANION_CARDS_PER_LESSON, reverse_count
+        );
     }
 
     #[test]

--- a/origa/src/domain/knowledge/lesson/types.rs
+++ b/origa/src/domain/knowledge/lesson/types.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
@@ -412,28 +411,6 @@ impl LessonData {
     pub fn into_cards(self) -> Vec<(Ulid, LessonCard)> {
         self.cards
     }
-
-    pub fn reorder_core_first_phrases_last(cards: Vec<(Ulid, LessonCard)>) -> Self {
-        let mut core = Vec::new();
-        let mut phrases = Vec::new();
-
-        for entry in cards {
-            if entry.1.card_type() == CardType::Phrase {
-                phrases.push(entry);
-            } else {
-                core.push(entry);
-            }
-        }
-
-        let core_count = core.len();
-        core.shuffle(&mut rand::rng());
-        core.extend(phrases);
-
-        Self {
-            cards: core,
-            core_count,
-        }
-    }
 }
 
 impl IntoIterator for LessonData {
@@ -465,76 +442,70 @@ mod tests {
     }
 
     #[test]
-    fn reorder_core_first_phrases_last_preserves_all_cards() {
+    fn lesson_data_constructor_preserves_all_cards() {
         let vocab_1 = Ulid::new();
         let vocab_2 = Ulid::new();
         let phrase_1 = Ulid::new();
         let phrase_2 = Ulid::new();
 
-        let input = vec![
+        let cards = vec![
             make_phrase_lesson_card(phrase_1),
             make_vocabulary_lesson_card(vocab_1),
             make_phrase_lesson_card(phrase_2),
             make_vocabulary_lesson_card(vocab_2),
         ];
+        let core_count = cards.len();
+        let data = LessonData { cards, core_count };
 
-        let result = LessonData::reorder_core_first_phrases_last(input);
-        let result_ids: Vec<Ulid> = result.card_ids();
+        assert_eq!(data.total_count(), 4);
+        assert_eq!(data.core_count, 4);
+        assert_eq!(data.phrase_count(), 2);
 
-        assert_eq!(result.total_count(), 4);
-        assert_eq!(result.core_count, 2);
-        assert_eq!(result.phrase_count(), 2);
-
-        assert!(result_ids.contains(&vocab_1));
-        assert!(result_ids.contains(&vocab_2));
-        assert!(result_ids.contains(&phrase_1));
-        assert!(result_ids.contains(&phrase_2));
-
-        let core_ids: Vec<Ulid> = result_ids[..result.core_count].to_vec();
-        let phrase_ids: Vec<Ulid> = result_ids[result.core_count..].to_vec();
-
-        assert!(
-            core_ids.iter().all(
-                |id| !matches!(result.get(id), Some(lc) if lc.card_type() == CardType::Phrase)
-            )
-        );
-        assert!(
-            phrase_ids
-                .iter()
-                .all(|id| matches!(result.get(id), Some(lc) if lc.card_type() == CardType::Phrase))
-        );
+        assert!(data.contains_key(&vocab_1));
+        assert!(data.contains_key(&vocab_2));
+        assert!(data.contains_key(&phrase_1));
+        assert!(data.contains_key(&phrase_2));
     }
 
     #[test]
-    fn reorder_core_first_phrases_last_handles_empty() {
-        let result = LessonData::reorder_core_first_phrases_last(vec![]);
+    fn lesson_data_constructor_handles_empty() {
+        let data = LessonData {
+            cards: vec![],
+            core_count: 0,
+        };
 
-        assert!(result.is_empty());
-        assert_eq!(result.core_count, 0);
-        assert_eq!(result.total_count(), 0);
+        assert!(data.is_empty());
+        assert_eq!(data.core_count, 0);
+        assert_eq!(data.total_count(), 0);
     }
 
     #[test]
-    fn reorder_core_first_phrases_last_only_core() {
+    fn lesson_data_core_count_independent_of_phrase_position() {
+        // After interleaving, phrases live inside the core section; core_count
+        // must reflect the interleaved layout (phrases counted as core) while
+        // phrase_count still identifies them by type.
         let vocab_1 = Ulid::new();
+        let phrase_1 = Ulid::new();
         let vocab_2 = Ulid::new();
-        let vocab_3 = Ulid::new();
 
-        let input = vec![
+        let cards = vec![
             make_vocabulary_lesson_card(vocab_1),
+            make_phrase_lesson_card(phrase_1),
             make_vocabulary_lesson_card(vocab_2),
-            make_vocabulary_lesson_card(vocab_3),
         ];
+        let data = LessonData {
+            cards,
+            core_count: 3,
+        };
 
-        let result = LessonData::reorder_core_first_phrases_last(input);
-        let result_ids: Vec<Ulid> = result.card_ids();
-
-        assert_eq!(result.total_count(), 3);
-        assert_eq!(result.core_count, 3);
-        assert_eq!(result.phrase_count(), 0);
-
-        assert!(result_ids.contains(&vocab_1));
-        assert!(result_ids.contains(&vocab_2));
-        assert!(result_ids.contains(&vocab_3));
+        assert_eq!(data.core_count, 3);
+        assert_eq!(data.phrase_count(), 1);
+        assert_eq!(
+            data.phrase_count(),
+            data.cards
+                .iter()
+                .filter(|(_, lc)| lc.card_type() == CardType::Phrase)
+                .count()
+        );
     }
 }

--- a/origa/src/domain/knowledge/lesson_builder.rs
+++ b/origa/src/domain/knowledge/lesson_builder.rs
@@ -1,6 +1,7 @@
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use rand::seq::SliceRandom;
 use ulid::Ulid;
 
 use super::lesson::{LessonCard, LessonData, LessonViewGenerator};
@@ -8,13 +9,28 @@ use super::{Card, CardType, KnowledgeSet, StudyCard};
 use crate::domain::{JapaneseLevel, JlptContent};
 
 const MIN_LESSON_SIZE: usize = 15;
-pub(crate) const MAX_LESSON_SIZE: usize = 50;
+pub(crate) const MAX_LESSON_SIZE: usize = 30;
 const PHRASE_NEW_RATIO: usize = 2;
 
 /// Приоритет карточек без определённого JLPT уровня — ниже всех известных уровней (N1=1)
 const UNKNOWN_JLPT_PRIORITY: u8 = 0;
 
 const PHRASE_MAX_PER_LESSON: usize = 5;
+
+/// Tail phrases only reinforce already-mastered material: no single known word
+/// may appear in more than this many tail phrases, otherwise a frequent word
+/// (e.g. する) would crowd out the entire tail.
+pub(crate) const MAX_PHRASES_PER_WORD_IN_TAIL: usize = 2;
+
+/// How many phrases may be interleaved next to a single anchor word inside the
+/// core section. Two cards let the learner meet the word in context shortly
+/// after the standalone review without saturating the lesson.
+const INTERLEAVED_PHRASES_PER_WORD: usize = 2;
+
+/// Minimum number of other cards that must sit between an anchor word and its
+/// first interleaved phrase, so the phrase does not leak the answer back into
+/// the word rating. Degrades to "as late as possible" on short lessons.
+const INTERLEAVING_GAP: usize = 2;
 
 /// Веса типов карточек для interleaving: Vocab:Kanji:Grammar ≈ 80:10:10.
 /// При добавлении нового варианта в CardType — обновить эту константу.
@@ -24,7 +40,17 @@ const CARD_TYPE_WEIGHTS: [(CardType, usize); 3] = [
     (CardType::Grammar, 1),
 ];
 
-pub(crate) fn build_lesson(
+/// Remaining new-phrase allowance shared between the interleaved and tail
+/// sections. Encapsulates `PHRASE_NEW_RATIO` so callers cannot reach past it.
+pub(crate) fn compute_phrase_new_budget(daily_new_limit: usize, studied: usize) -> usize {
+    (daily_new_limit * PHRASE_NEW_RATIO).saturating_sub(studied)
+}
+
+/// Collects the lesson core (favorites, due/new/known cards, padding) WITHOUT
+/// any phrases. The core is shuffled here so downstream interleaving sees a
+/// stable order. Phrases are attached later by `add_interleaved_phrases` and
+/// `add_tail_phrases`.
+pub(crate) fn build_lesson_core(
     knowledge_set: &KnowledgeSet,
     daily_new_limit: usize,
     jlpt_content: &JlptContent,
@@ -54,30 +80,16 @@ pub(crate) fn build_lesson(
     let all_selected_ids = build_selected_ids(&selected_cards, &favorite_cards);
     let padding_cards = collect_padding(&all_cards, &all_selected_ids);
 
-    let all_lesson_cards: Vec<_> = selected_cards
-        .iter()
-        .chain(favorite_cards.iter())
-        .chain(padding_cards.iter())
-        .copied()
-        .collect();
-    let (lesson_words, lesson_grammar_ids) = extract_lesson_content(&all_lesson_cards);
-
-    let phrase_cards = collect_phrase_cards(
-        &all_cards,
-        &all_selected_ids,
-        knowledge_set,
-        daily_new_limit,
-        &lesson_words,
-        &lesson_grammar_ids,
-    );
-
-    build_lesson_result(
+    let mut cards = build_core_lesson_cards(
         &favorite_cards,
         &selected_cards,
         &padding_cards,
-        &phrase_cards,
         knowledge_set,
-    )
+    );
+    cards.shuffle(&mut rand::rng());
+    let core_count = cards.len();
+
+    LessonData { cards, core_count }
 }
 
 fn collect_core_high_difficulty<'a>(
@@ -187,7 +199,7 @@ fn collect_padding<'a>(
 }
 
 fn extract_lesson_content<'a>(
-    cards: impl IntoIterator<Item = &'a (&'a Ulid, &'a StudyCard)>,
+    cards: impl IntoIterator<Item = (&'a Ulid, &'a StudyCard)>,
 ) -> (HashSet<String>, HashSet<Ulid>) {
     let mut words = HashSet::new();
     let mut grammar_ids = HashSet::new();
@@ -205,6 +217,40 @@ fn extract_lesson_content<'a>(
     }
 
     (words, grammar_ids)
+}
+
+/// Tail phrases only reinforce already-mastered lesson vocab: a word qualifies
+/// when its study card has reached a stable memory state (`is_known_card`),
+/// i.e. stability above the known threshold and not flagged high-difficulty.
+fn extract_known_lesson_words<'a>(
+    cards: impl IntoIterator<Item = (&'a Ulid, &'a StudyCard)>,
+) -> HashSet<String> {
+    let mut words = HashSet::new();
+
+    for (_, study_card) in cards {
+        if !study_card.memory().is_known_card() {
+            continue;
+        }
+        if let Card::Vocabulary(vocab) = study_card.card() {
+            words.insert(vocab.word().text().to_string());
+        }
+    }
+
+    words
+}
+
+/// A phrase is tail-eligible only when every token it references is a lesson
+/// word the user has already mastered. This excludes phrases that lean on
+/// newly-introduced or unstable vocabulary, which get reinforced via the
+/// interleaved section instead.
+fn phrase_tokens_all_known(phrase_id: &Ulid, known_lesson_words: &HashSet<String>) -> bool {
+    let Some(entry) = crate::dictionary::phrase::get_index_entry(phrase_id) else {
+        return false;
+    };
+    entry
+        .tokens()
+        .iter()
+        .all(|token| known_lesson_words.contains(token))
 }
 
 fn phrase_lesson_overlap(
@@ -258,46 +304,405 @@ fn sort_phrases_by_overlap<'a>(
     });
 }
 
-fn collect_phrase_cards<'a>(
-    all_cards: &[(&'a Ulid, &'a StudyCard)],
-    all_selected_ids: &HashSet<Ulid>,
-    knowledge_set: &KnowledgeSet,
-    daily_new_limit: usize,
-    lesson_words: &HashSet<String>,
-    lesson_grammar_ids: &HashSet<Ulid>,
-) -> Vec<(&'a Ulid, &'a StudyCard)> {
-    let phrase_new_limit = daily_new_limit * PHRASE_NEW_RATIO;
-    let phrase_cards_studied = knowledge_set.phrase_cards_studied_today();
-    let phrase_new_remaining = phrase_new_limit.saturating_sub(phrase_cards_studied);
+/// Bundles the immutable inputs driving tail-phrase selection. Grouping them
+/// keeps `collect_phrase_cards` below the argument-count threshold and makes
+/// the selection context explicit at the call site.
+struct TailPhraseSelection<'a> {
+    all_cards: &'a [(&'a Ulid, &'a StudyCard)],
+    excluded_card_ids: &'a HashSet<Ulid>,
+    used_phrase_ids: &'a HashSet<Ulid>,
+    known_lesson_words: &'a HashSet<String>,
+    lesson_words: &'a HashSet<String>,
+    lesson_grammar_ids: &'a HashSet<Ulid>,
+    /// Remaining new-phrase allowance (already shared with the interleaved
+    /// section). Due phrases do not consume it.
+    new_phrase_budget: usize,
+}
 
-    let mut due_phrases: Vec<_> = all_cards
-        .iter()
-        .filter(|(id, card)| {
-            !all_selected_ids.contains(id)
-                && matches!(card.card(), Card::Phrase(_))
-                && card.memory().is_due()
-                && !card.memory().is_new()
-        })
-        .copied()
-        .collect();
-    sort_phrases_by_overlap(&mut due_phrases, lesson_words, lesson_grammar_ids);
+fn collect_phrase_cards<'a>(selection: &TailPhraseSelection<'a>) -> Vec<(&'a Ulid, &'a StudyCard)> {
+    let phrase_new_remaining = selection.new_phrase_budget;
 
-    let mut new_phrases: Vec<_> = all_cards
+    let phrase_eligible = |id: &&Ulid, card: &&StudyCard| {
+        let Card::Phrase(phrase_card) = card.card() else {
+            return false;
+        };
+        !selection.excluded_card_ids.contains(id)
+            && !selection.used_phrase_ids.contains(phrase_card.phrase_id())
+            && phrase_tokens_all_known(phrase_card.phrase_id(), selection.known_lesson_words)
+    };
+
+    let mut due_phrases: Vec<_> = selection
+        .all_cards
         .iter()
-        .filter(|(id, card)| {
-            !all_selected_ids.contains(id)
-                && matches!(card.card(), Card::Phrase(_))
-                && card.memory().is_new()
-        })
         .copied()
+        .filter(|(id, card)| phrase_eligible(id, card) && card.memory().is_due())
         .collect();
-    sort_phrases_by_overlap(&mut new_phrases, lesson_words, lesson_grammar_ids);
+    sort_phrases_by_overlap(
+        &mut due_phrases,
+        selection.lesson_words,
+        selection.lesson_grammar_ids,
+    );
+
+    let mut new_phrases: Vec<_> = selection
+        .all_cards
+        .iter()
+        .copied()
+        .filter(|(id, card)| phrase_eligible(id, card) && card.memory().is_new())
+        .collect();
+    sort_phrases_by_overlap(
+        &mut new_phrases,
+        selection.lesson_words,
+        selection.lesson_grammar_ids,
+    );
     new_phrases.truncate(phrase_new_remaining);
 
     let mut phrase_cards = due_phrases;
     phrase_cards.extend(new_phrases);
+    phrase_cards = apply_per_word_cap(phrase_cards, selection.known_lesson_words);
     phrase_cards.truncate(PHRASE_MAX_PER_LESSON);
     phrase_cards
+}
+
+/// Enforces `MAX_PHRASES_PER_WORD_IN_TAIL`: no single known lesson word may
+/// anchor more than the cap tail phrases. Phrases are consumed in priority
+/// order (due before new, overlap-sorted within each) so the most relevant
+/// phrase wins a word's slot when contention occurs.
+fn apply_per_word_cap<'a>(
+    phrases: Vec<(&'a Ulid, &'a StudyCard)>,
+    known_lesson_words: &HashSet<String>,
+) -> Vec<(&'a Ulid, &'a StudyCard)> {
+    let mut word_count: HashMap<&str, usize> = HashMap::new();
+    let mut kept = Vec::with_capacity(phrases.len());
+
+    for (id, card) in phrases {
+        let Card::Phrase(phrase_card) = card.card() else {
+            continue;
+        };
+        let Some(entry) = crate::dictionary::phrase::get_index_entry(phrase_card.phrase_id())
+        else {
+            continue;
+        };
+        let over_cap = entry.tokens().iter().any(|token| {
+            known_lesson_words.contains(token)
+                && word_count.get(token.as_str()).copied().unwrap_or(0)
+                    >= MAX_PHRASES_PER_WORD_IN_TAIL
+        });
+        if over_cap {
+            continue;
+        }
+        for token in entry.tokens() {
+            if known_lesson_words.contains(token) {
+                *word_count.entry(token.as_str()).or_insert(0) += 1;
+            }
+        }
+        kept.push((id, card));
+    }
+
+    kept
+}
+
+/// Interleaves phrase cards into the core stream so each phrase appears after
+/// its anchor word with at least `gap` other cards between them. The invariant
+/// `phrase_position > word_position` is preserved even when the lesson is too
+/// short to honour the gap (remaining phrases flush at the end).
+fn interleave_with_gap(
+    core_cards: Vec<(Ulid, LessonCard)>,
+    mut assignments: HashMap<Ulid, Vec<(Ulid, LessonCard)>>,
+    gap: usize,
+) -> Vec<(Ulid, LessonCard)> {
+    let pending_phrases: usize = assignments.values().map(|v| v.len()).sum();
+    let mut result: Vec<(Ulid, LessonCard)> =
+        Vec::with_capacity(core_cards.len() + pending_phrases);
+    let mut pending: Vec<(usize, (Ulid, LessonCard))> = Vec::new();
+
+    for card in core_cards {
+        let word_id = card.0;
+        result.push(card);
+
+        if let Some(phrases) = assignments.remove(&word_id) {
+            let word_pos = result.len() - 1;
+            for phrase in phrases {
+                pending.push((word_pos + gap + 1, phrase));
+            }
+        }
+
+        let mut deferred = Vec::with_capacity(pending.len());
+        for (min_pos, phrase) in pending.drain(..) {
+            if result.len() >= min_pos {
+                result.push(phrase);
+            } else {
+                deferred.push((min_pos, phrase));
+            }
+        }
+        pending = deferred;
+    }
+
+    for (_, phrase) in pending {
+        result.push(phrase);
+    }
+
+    // Any assignment left in `assignments` had no matching core card and would
+    // be silently dropped. Surface this as a programmer error in debug builds.
+    debug_assert!(
+        assignments.is_empty(),
+        "interleave_with_gap dropped phrase assignments for words not present in core_cards"
+    );
+
+    result
+}
+
+/// Picks up to `INTERLEAVED_PHRASES_PER_WORD` phrase study cards for a single
+/// anchor word. Due phrases win slots for free; new phrases fill the remainder
+/// and each consumes one unit of the shared new-phrase budget.
+fn collect_interleaved_phrases_for_word<'a>(
+    word: &str,
+    phrase_cards_by_id: &'a HashMap<Ulid, (&'a Ulid, &'a StudyCard)>,
+    in_lesson: &'a HashSet<Ulid>,
+    used_phrase_ids: &'a mut HashSet<Ulid>,
+    phrase_new_budget: &'a mut usize,
+) -> Vec<(Ulid, &'a StudyCard)> {
+    let mut picker = InterleavePicker {
+        phrase_cards_by_id,
+        in_lesson,
+        used_phrase_ids,
+        phrase_new_budget,
+    };
+    let entries = crate::dictionary::phrase::get_phrases_by_token(word);
+    let mut picked: Vec<(Ulid, &'a StudyCard)> = Vec::new();
+
+    // `MemoryState::is_due` already implies `!is_new`, so due phrases are a
+    // strict subset disjoint from the new-phrase pass below.
+    picker.fill(&entries, &mut picked, |sc| sc.memory().is_due(), false);
+    picker.fill(&entries, &mut picked, |sc| sc.memory().is_new(), true);
+
+    picked
+}
+
+/// Shared selection state for the two interleaving passes (due then new) of a
+/// single anchor word. Grouping the lookup inputs keeps `fill` below the
+/// argument-count threshold and makes the pass context explicit.
+struct InterleavePicker<'a> {
+    phrase_cards_by_id: &'a HashMap<Ulid, (&'a Ulid, &'a StudyCard)>,
+    in_lesson: &'a HashSet<Ulid>,
+    used_phrase_ids: &'a mut HashSet<Ulid>,
+    phrase_new_budget: &'a mut usize,
+}
+
+impl<'a> InterleavePicker<'a> {
+    /// Appends eligible phrases to `picked` until `INTERLEAVED_PHRASES_PER_WORD`
+    /// is reached or the budget runs out. `consume_budget` ties new-phrase
+    /// consumption to the shared allowance (free for due phrases).
+    fn fill<F>(
+        &mut self,
+        entries: &[&'static crate::dictionary::phrase::IndexEntry],
+        picked: &mut Vec<(Ulid, &'a StudyCard)>,
+        memory_predicate: F,
+        consume_budget: bool,
+    ) where
+        F: Fn(&StudyCard) -> bool,
+    {
+        for entry in entries {
+            if picked.len() >= INTERLEAVED_PHRASES_PER_WORD {
+                break;
+            }
+            if consume_budget && *self.phrase_new_budget == 0 {
+                break;
+            }
+            let pid = entry.id();
+            if self.used_phrase_ids.contains(pid) {
+                continue;
+            }
+            let Some(&(card_id, sc)) = self.phrase_cards_by_id.get(pid) else {
+                continue;
+            };
+            if self.in_lesson.contains(card_id) {
+                continue;
+            }
+            if !memory_predicate(sc) {
+                continue;
+            }
+            picked.push((*card_id, sc));
+            self.used_phrase_ids.insert(*pid);
+            if consume_budget {
+                *self.phrase_new_budget -= 1;
+            }
+        }
+    }
+}
+
+fn build_phrase_assignments(
+    targets: &[(&Ulid, String)],
+    phrase_cards_by_id: &HashMap<Ulid, (&Ulid, &StudyCard)>,
+    in_lesson: &HashSet<Ulid>,
+    used_phrase_ids: &mut HashSet<Ulid>,
+    phrase_new_budget: &mut usize,
+    generator: &mut LessonViewGenerator,
+) -> HashMap<Ulid, Vec<(Ulid, LessonCard)>> {
+    let mut assignments: HashMap<Ulid, Vec<(Ulid, LessonCard)>> = HashMap::new();
+
+    for (word_card_id, word_text) in targets {
+        if assignments.contains_key(word_card_id) {
+            continue;
+        }
+        let picked = collect_interleaved_phrases_for_word(
+            word_text,
+            phrase_cards_by_id,
+            in_lesson,
+            used_phrase_ids,
+            phrase_new_budget,
+        );
+        if picked.is_empty() {
+            continue;
+        }
+        let lesson_cards = picked
+            .into_iter()
+            .map(|(card_id, sc)| {
+                let view = generator.apply_view(sc, sc.is_new(), &mut rand::rng());
+                (card_id, LessonCard::new(view, false))
+            })
+            .collect();
+        assignments.insert(**word_card_id, lesson_cards);
+    }
+
+    assignments
+}
+
+/// Inserts up to `INTERLEAVED_PHRASES_PER_WORD` phrases per anchor word into the
+/// core section. Anchor words are new/in-progress vocab; if none yield phrases,
+/// known vocab is used as a fallback. Interleaved phrases become part of
+/// `core_count` and are excluded from the tail via `used_phrase_ids`.
+pub(crate) fn add_interleaved_phrases(
+    mut lesson_data: LessonData,
+    knowledge_set: &KnowledgeSet,
+    used_phrase_ids: &mut HashSet<Ulid>,
+    phrase_new_budget: &mut usize,
+) -> LessonData {
+    let core_count = lesson_data.core_count;
+    if core_count == 0 {
+        return lesson_data;
+    }
+
+    let phrase_cards_by_id: HashMap<Ulid, (&Ulid, &StudyCard)> = knowledge_set
+        .study_cards()
+        .iter()
+        .filter_map(|(id, sc)| match sc.card() {
+            Card::Phrase(pc) => Some((*pc.phrase_id(), (id, sc))),
+            _ => None,
+        })
+        .collect();
+
+    let in_lesson: HashSet<Ulid> = lesson_data.cards.iter().map(|(id, _)| *id).collect();
+
+    let core_vocab: Vec<(Ulid, String)> = lesson_data.cards[..core_count]
+        .iter()
+        .filter_map(|(id, lc)| match lc.card() {
+            Card::Vocabulary(v) => Some((*id, v.word().text().to_string())),
+            _ => None,
+        })
+        .collect();
+
+    let new_in_progress: Vec<(&Ulid, String)> = core_vocab
+        .iter()
+        .filter(|(id, _)| {
+            knowledge_set
+                .get_card(*id)
+                .map(|sc| sc.memory().is_new() || sc.memory().is_in_progress())
+                .unwrap_or(false)
+        })
+        .map(|(id, word)| (id, word.clone()))
+        .collect();
+    let known: Vec<(&Ulid, String)> = core_vocab
+        .iter()
+        .filter(|(id, _)| {
+            knowledge_set
+                .get_card(*id)
+                .map(|sc| sc.memory().is_known_card())
+                .unwrap_or(false)
+        })
+        .map(|(id, word)| (id, word.clone()))
+        .collect();
+
+    let mut generator = LessonViewGenerator::new(knowledge_set);
+
+    let mut assignments = build_phrase_assignments(
+        &new_in_progress,
+        &phrase_cards_by_id,
+        &in_lesson,
+        used_phrase_ids,
+        phrase_new_budget,
+        &mut generator,
+    );
+
+    if assignments.is_empty() && !known.is_empty() {
+        assignments = build_phrase_assignments(
+            &known,
+            &phrase_cards_by_id,
+            &in_lesson,
+            used_phrase_ids,
+            phrase_new_budget,
+            &mut generator,
+        );
+    }
+
+    if assignments.is_empty() {
+        return lesson_data;
+    }
+
+    let core_cards = std::mem::take(&mut lesson_data.cards);
+    lesson_data.cards = interleave_with_gap(core_cards, assignments, INTERLEAVING_GAP);
+    lesson_data.core_count = lesson_data.cards.len();
+    lesson_data
+}
+
+/// Appends the tail phrases after the core section. Tail phrases only use
+/// already-mastered lesson words and share the remaining new-phrase budget with
+/// the interleaved section (due phrases are free).
+pub(crate) fn add_tail_phrases(
+    mut lesson_data: LessonData,
+    knowledge_set: &KnowledgeSet,
+    used_phrase_ids: &HashSet<Ulid>,
+    phrase_new_budget: usize,
+) -> LessonData {
+    let mut all_cards = knowledge_set.study_cards().iter().collect::<Vec<_>>();
+    all_cards.sort_by_key(|(_, card)| card.memory().next_review_date());
+
+    let excluded: HashSet<Ulid> = lesson_data.cards.iter().map(|(id, _)| *id).collect();
+
+    let lesson_study_refs: Vec<(&Ulid, &StudyCard)> = lesson_data
+        .cards
+        .iter()
+        .filter_map(|(id, _)| knowledge_set.get_card(*id).map(|sc| (id, sc)))
+        .collect();
+    let (lesson_words, lesson_grammar_ids) =
+        extract_lesson_content(lesson_study_refs.iter().copied());
+    let known_lesson_words = extract_known_lesson_words(lesson_study_refs.iter().copied());
+
+    let selection = TailPhraseSelection {
+        all_cards: &all_cards,
+        excluded_card_ids: &excluded,
+        used_phrase_ids,
+        known_lesson_words: &known_lesson_words,
+        lesson_words: &lesson_words,
+        lesson_grammar_ids: &lesson_grammar_ids,
+        new_phrase_budget: phrase_new_budget,
+    };
+    let phrase_cards = collect_phrase_cards(&selection);
+
+    if phrase_cards.is_empty() {
+        return lesson_data;
+    }
+
+    let mut generator = LessonViewGenerator::new(knowledge_set);
+    let phrase_lessons: Vec<(Ulid, LessonCard)> = phrase_cards
+        .iter()
+        .map(|(card_id, sc)| {
+            let view = generator.apply_view(sc, sc.is_new(), &mut rand::rng());
+            (**card_id, LessonCard::new(view, false))
+        })
+        .collect();
+
+    lesson_data.cards.extend(phrase_lessons);
+    lesson_data
 }
 
 fn build_selected_ids(
@@ -309,13 +714,12 @@ fn build_selected_ids(
     selected_ids.union(&favorite_ids).copied().collect()
 }
 
-fn build_lesson_result(
+fn build_core_lesson_cards(
     favorite_cards: &[(&Ulid, &StudyCard)],
     selected_cards: &[(&Ulid, &StudyCard)],
     padding_cards: &[(&Ulid, &StudyCard)],
-    phrase_cards: &[(&Ulid, &StudyCard)],
     knowledge_set: &KnowledgeSet,
-) -> LessonData {
+) -> Vec<(Ulid, LessonCard)> {
     let padding_ids: HashSet<_> = padding_cards.iter().map(|(id, _)| **id).collect();
     let mut generator = LessonViewGenerator::new(knowledge_set);
 
@@ -345,19 +749,10 @@ fn build_lesson_result(
         })
         .collect();
 
-    let phrase_lessons: Vec<_> = phrase_cards
-        .iter()
-        .map(|(card_id, study_card)| {
-            let view = generator.apply_view(study_card, study_card.is_new(), &mut rand::rng());
-            (**card_id, LessonCard::new(view, false))
-        })
-        .collect();
-
     let mut result = favorite_lessons;
     result.extend(selected_lessons);
     result.extend(padding_lessons);
-    result.extend(phrase_lessons);
-    LessonData::reorder_core_first_phrases_last(result)
+    result
 }
 
 fn resolve_jlpt_level(card: &Card, jlpt_content: &JlptContent) -> Option<JapaneseLevel> {
@@ -434,8 +829,10 @@ fn distribute_new_cards<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::knowledge::LessonCardView;
     use crate::domain::knowledge::{GrammarRuleCard, KanjiCard, PhraseCard, VocabularyCard};
     use crate::domain::value_objects::Question;
+    use crate::domain::{RateMode, Rating};
 
     fn vocab_card(word: &str) -> Card {
         Card::Vocabulary(VocabularyCard::new(
@@ -471,7 +868,7 @@ mod tests {
         ];
         let refs: Vec<(&Ulid, &StudyCard)> = cards.iter().map(|(id, sc)| (id, sc)).collect();
 
-        let (words, grammar_ids) = extract_lesson_content(&refs);
+        let (words, grammar_ids) = extract_lesson_content(refs.iter().copied());
 
         assert_eq!(words.len(), 1);
         assert!(words.contains(word));
@@ -487,7 +884,7 @@ mod tests {
         ];
         let refs: Vec<(&Ulid, &StudyCard)> = cards.iter().map(|(id, sc)| (id, sc)).collect();
 
-        let (words, grammar_ids) = extract_lesson_content(&refs);
+        let (words, grammar_ids) = extract_lesson_content(refs.iter().copied());
 
         assert!(words.is_empty());
         assert!(grammar_ids.is_empty());
@@ -496,7 +893,7 @@ mod tests {
     #[test]
     fn extract_lesson_content_empty_input() {
         let refs: Vec<(&Ulid, &StudyCard)> = vec![];
-        let (words, grammar_ids) = extract_lesson_content(&refs);
+        let (words, grammar_ids) = extract_lesson_content(refs.iter().copied());
         assert!(words.is_empty());
         assert!(grammar_ids.is_empty());
     }
@@ -509,7 +906,7 @@ mod tests {
         ];
         let refs: Vec<(&Ulid, &StudyCard)> = cards.iter().map(|(id, sc)| (id, sc)).collect();
 
-        let (words, _) = extract_lesson_content(&refs);
+        let (words, _) = extract_lesson_content(refs.iter().copied());
 
         assert_eq!(words.len(), 1);
     }
@@ -557,5 +954,681 @@ mod tests {
         let mut phrases: Vec<(&Ulid, &StudyCard)> = vec![];
         sort_phrases_by_overlap(&mut phrases, &HashSet::new(), &HashSet::new());
         assert!(phrases.is_empty());
+    }
+
+    // --- Tail phrase selection (Slice-3) ---
+    //
+    // The phrase index is a process-wide `OnceLock`; only one index can live in
+    // a test binary. These tests reuse the exact 4-phrase fixture also used by
+    // `journeys/phrase.rs` and `seed_ready_phrases.rs` so they hold regardless
+    // of which module wins the initialization race.
+
+    static PHRASE_INDEX_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+
+    fn phrase_id_hello() -> Ulid {
+        Ulid::from_string("01KPJ5S3N1DRFFD236Z4EZ03HJ").expect("valid ULID")
+    }
+
+    fn phrase_id_bye() -> Ulid {
+        Ulid::from_string("01KPJ5S3N1DRFFD236Z4EZ03HK").expect("valid ULID")
+    }
+
+    fn phrase_id_morning() -> Ulid {
+        Ulid::from_string("01KPJ5S3N1DRFFD236Z4EZ03HN").expect("valid ULID")
+    }
+
+    fn phrase_id_thanks() -> Ulid {
+        Ulid::from_string("01KPJ5S3N1DRFFD236Z4EZ03HM").expect("valid ULID")
+    }
+
+    fn ensure_test_phrase_index() {
+        PHRASE_INDEX_INIT.get_or_init(|| {
+            if crate::dictionary::phrase::is_phrases_loaded() {
+                return;
+            }
+            let index_json = r#"{"v":1,"h":"test","total":4,"phrases":[
+                {"i":"01KPJ5S3N1DRFFD236Z4EZ03HJ","t":["test","hello"],"c":0},
+                {"i":"01KPJ5S3N1DRFFD236Z4EZ03HK","t":["test","bye"],"c":0,"g":["01KJ9AVWBGC2BT0DMFPDYYFEWB"]},
+                {"i":"01KPJ5S3N1DRFFD236Z4EZ03HN","t":["test","morning"],"c":0,"g":["01KJ9AVWBGC2BT0DMFPDYYFEWB","01G00000000000000024000000"]},
+                {"i":"01KPJ5S3N1DRFFD236Z4EZ03HM","t":["test","thanks"],"c":0}
+            ]}"#;
+            crate::dictionary::phrase::init_phrase_index(index_json)
+                .expect("Failed to init test phrase index");
+        });
+    }
+
+    fn full_known_set() -> HashSet<String> {
+        ["test", "hello", "bye", "morning", "thanks"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn phrase_tokens_all_known_true_when_all_tokens_known() {
+        ensure_test_phrase_index();
+
+        let known = full_known_set();
+        assert!(phrase_tokens_all_known(&phrase_id_hello(), &known));
+        assert!(phrase_tokens_all_known(&phrase_id_bye(), &known));
+    }
+
+    #[test]
+    fn phrase_tokens_all_known_false_when_token_missing() {
+        ensure_test_phrase_index();
+
+        let partial: HashSet<String> = ["test", "hello"].iter().map(|s| s.to_string()).collect();
+        assert!(!phrase_tokens_all_known(&phrase_id_bye(), &partial));
+    }
+
+    #[test]
+    fn phrase_tokens_all_known_false_when_index_missing_entry() {
+        ensure_test_phrase_index();
+
+        let known = full_known_set();
+        assert!(!phrase_tokens_all_known(&Ulid::new(), &known));
+    }
+
+    fn make_phrase_study_cards(phrase_ids: &[Ulid]) -> Vec<(Ulid, StudyCard)> {
+        phrase_ids
+            .iter()
+            .map(|pid| make_study_card(phrase_card(*pid)))
+            .collect()
+    }
+
+    fn selected_phrase_ids(cards: &[(&Ulid, &StudyCard)]) -> Vec<Ulid> {
+        cards
+            .iter()
+            .filter_map(|(_, sc)| match sc.card() {
+                Card::Phrase(p) => Some(*p.phrase_id()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn empty_ulid_set() -> &'static HashSet<Ulid> {
+        static EMPTY: std::sync::OnceLock<HashSet<Ulid>> = std::sync::OnceLock::new();
+        EMPTY.get_or_init(HashSet::new)
+    }
+
+    fn tail_selection<'a>(
+        all_cards: &'a [(&'a Ulid, &'a StudyCard)],
+        known: &'a HashSet<String>,
+        used: &'a HashSet<Ulid>,
+    ) -> TailPhraseSelection<'a> {
+        TailPhraseSelection {
+            all_cards,
+            excluded_card_ids: empty_ulid_set(),
+            used_phrase_ids: used,
+            known_lesson_words: known,
+            lesson_words: known,
+            lesson_grammar_ids: empty_ulid_set(),
+            new_phrase_budget: 20,
+        }
+    }
+
+    #[test]
+    fn tail_phrases_contain_only_known_words() {
+        ensure_test_phrase_index();
+
+        let owned = make_phrase_study_cards(&[phrase_id_hello(), phrase_id_bye(), Ulid::new()]);
+        let unknown_phrase = match owned[2].1.card() {
+            Card::Phrase(p) => *p.phrase_id(),
+            _ => unreachable!("third card is a phrase card"),
+        };
+        let all_cards: Vec<(&Ulid, &StudyCard)> = owned.iter().map(|(id, sc)| (id, sc)).collect();
+
+        let known = full_known_set();
+        let empty_used = HashSet::new();
+        let selection = tail_selection(&all_cards, &known, &empty_used);
+        let result = collect_phrase_cards(&selection);
+
+        let selected = selected_phrase_ids(&result);
+        assert!(
+            selected.contains(&phrase_id_hello()),
+            "phrase with all-known tokens should be selected"
+        );
+        assert!(
+            selected.contains(&phrase_id_bye()),
+            "phrase with all-known tokens should be selected"
+        );
+        assert!(
+            !selected.contains(&unknown_phrase),
+            "phrase whose phrase_id is absent from the index must be excluded"
+        );
+    }
+
+    #[test]
+    fn tail_phrases_respect_per_word_cap() {
+        ensure_test_phrase_index();
+
+        // All four phrases share the token "test"; with MAX_PHRASES_PER_WORD_IN_TAIL=2
+        // only two of them may enter the tail even though every token is known.
+        let owned = make_phrase_study_cards(&[
+            phrase_id_hello(),
+            phrase_id_bye(),
+            phrase_id_morning(),
+            phrase_id_thanks(),
+        ]);
+        let all_cards: Vec<(&Ulid, &StudyCard)> = owned.iter().map(|(id, sc)| (id, sc)).collect();
+
+        let known = full_known_set();
+        let empty_used = HashSet::new();
+        let selection = tail_selection(&all_cards, &known, &empty_used);
+        let result = collect_phrase_cards(&selection);
+
+        assert!(
+            result.len() <= MAX_PHRASES_PER_WORD_IN_TAIL,
+            "Tail phrases sharing a word should be capped at {MAX_PHRASES_PER_WORD_IN_TAIL}, got {}",
+            result.len()
+        );
+        assert_eq!(
+            result.len(),
+            MAX_PHRASES_PER_WORD_IN_TAIL,
+            "With four all-known phrases sharing one word exactly {MAX_PHRASES_PER_WORD_IN_TAIL} should be kept"
+        );
+    }
+
+    #[test]
+    fn tail_phrases_exclude_used_phrase_ids() {
+        ensure_test_phrase_index();
+
+        let owned = make_phrase_study_cards(&[phrase_id_hello(), phrase_id_bye()]);
+        let all_cards: Vec<(&Ulid, &StudyCard)> = owned.iter().map(|(id, sc)| (id, sc)).collect();
+
+        let known = full_known_set();
+        let mut used = HashSet::new();
+        used.insert(phrase_id_hello());
+
+        let selection = tail_selection(&all_cards, &known, &used);
+        let result = collect_phrase_cards(&selection);
+
+        let selected = selected_phrase_ids(&result);
+        assert!(
+            !selected.contains(&phrase_id_hello()),
+            "phrase already used by interleaving must not reappear in the tail"
+        );
+        assert!(selected.contains(&phrase_id_bye()));
+    }
+
+    #[test]
+    fn init_phrase_index_loads_entries() {
+        // The CDN loader (`init_phrase_index_from_cdn`) is process-wide and
+        // mutually exclusive with the 4-phrase fixture used across the lib test
+        // binary, so loading the real 156k-entry index here would win the
+        // OnceLock race and break fixture-based tests. We instead verify the
+        // helper is exported and callable, and assert the index contract
+        // (entries become retrievable) via the safe fixture path.
+        let _helper: fn() = crate::use_cases::init_phrase_index_from_cdn;
+
+        ensure_test_phrase_index();
+
+        assert!(
+            crate::dictionary::phrase::is_phrases_loaded(),
+            "phrase index should be loaded after init"
+        );
+        assert!(
+            crate::dictionary::phrase::iter_index_entries().is_some(),
+            "iter_index_entries should yield entries once the index is loaded"
+        );
+        assert!(
+            crate::dictionary::phrase::get_phrases_by_token("test")
+                .iter()
+                .any(|e| !e.tokens().is_empty()),
+            "get_phrases_by_token should resolve known fixture tokens to entries"
+        );
+    }
+
+    // --- Interleaving algorithm (H1) ---
+    //
+    // These tests pin the invariants of the phrase-interleaving pipeline. They
+    // intentionally span three levels: the pure layout primitive
+    // `interleave_with_gap`, the mid-level orchestrator `add_interleaved_phrases`
+    // / `collect_interleaved_phrases_for_word`, and the full `cards_to_lesson`
+    // pipeline. Lower levels isolate a single invariant; the pipeline tests
+    // guard the integration of the shared budget and `used_phrase_ids` set.
+
+    fn lesson_card_for(card: Card) -> LessonCard {
+        LessonCard::new(LessonCardView::Normal(card), false)
+    }
+
+    fn lesson_phrase_id(lc: &LessonCard) -> Option<Ulid> {
+        match lc.card() {
+            Card::Phrase(p) => Some(*p.phrase_id()),
+            _ => None,
+        }
+    }
+
+    fn phrase_cards_map(owned: &[(Ulid, StudyCard)]) -> HashMap<Ulid, (&Ulid, &StudyCard)> {
+        owned
+            .iter()
+            .filter_map(|(id, sc)| match sc.card() {
+                Card::Phrase(p) => Some((*p.phrase_id(), (id, sc))),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn lesson_phrase_ids(lesson: &LessonData) -> HashSet<Ulid> {
+        lesson
+            .cards
+            .iter()
+            .filter_map(|(_, lc)| lesson_phrase_id(lc))
+            .collect()
+    }
+
+    /// A phrase anchored to a word must land strictly after it, with at least
+    /// `gap` intervening cards when the core is long enough to honour the gap.
+    #[test]
+    fn interleaved_phrases_placed_after_word_with_gap() {
+        let word_id = Ulid::new();
+        let phrase_card_id = Ulid::new();
+
+        let mut core_cards: Vec<(Ulid, LessonCard)> = (0..5)
+            .map(|_| (Ulid::new(), lesson_card_for(vocab_card("filler"))))
+            .collect();
+        core_cards[2] = (word_id, lesson_card_for(vocab_card("anchor")));
+
+        let assignments: HashMap<Ulid, Vec<(Ulid, LessonCard)>> = [(
+            word_id,
+            vec![(phrase_card_id, lesson_card_for(phrase_card(Ulid::new())))],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = interleave_with_gap(core_cards, assignments, INTERLEAVING_GAP);
+
+        let word_pos = result
+            .iter()
+            .position(|(id, _)| *id == word_id)
+            .expect("anchor word present in output");
+        let phrase_pos = result
+            .iter()
+            .position(|(id, _)| *id == phrase_card_id)
+            .expect("interleaved phrase present in output");
+
+        assert!(
+            phrase_pos > word_pos,
+            "phrase must follow its anchor word: {phrase_pos} <= {word_pos}"
+        );
+        assert!(
+            phrase_pos > word_pos + INTERLEAVING_GAP,
+            "core had room for the gap: phrase_pos {phrase_pos} should be > {}",
+            word_pos + INTERLEAVING_GAP
+        );
+    }
+
+    /// No single anchor word may pull more than `INTERLEAVED_PHRASES_PER_WORD`
+    /// phrases into the core, even when many eligible phrases share its token.
+    #[test]
+    fn interleaved_phrases_max_two_per_word() {
+        ensure_test_phrase_index();
+
+        let owned = make_phrase_study_cards(&[
+            phrase_id_hello(),
+            phrase_id_bye(),
+            phrase_id_morning(),
+            phrase_id_thanks(),
+        ]);
+        let map = phrase_cards_map(&owned);
+
+        let in_lesson = HashSet::new();
+        let mut used = HashSet::new();
+        let mut budget = 10;
+
+        let picked =
+            collect_interleaved_phrases_for_word("test", &map, &in_lesson, &mut used, &mut budget);
+
+        assert!(
+            picked.len() <= INTERLEAVED_PHRASES_PER_WORD,
+            "per-word cap violated: {} > {INTERLEAVED_PHRASES_PER_WORD}",
+            picked.len()
+        );
+        assert_eq!(
+            picked.len(),
+            INTERLEAVED_PHRASES_PER_WORD,
+            "four eligible phrases with a deep budget should fill the cap exactly"
+        );
+    }
+
+    /// Interleaving targets new/in-progress vocab and deliberately skips
+    /// high-difficulty vocab: phrases anchored to the high-difficulty word must
+    /// not appear, while the new and in-progress words receive their phrases.
+    #[test]
+    fn interleaved_phrases_target_new_and_in_progress() {
+        ensure_test_phrase_index();
+
+        let mut ks = KnowledgeSet::new();
+        let hello_sc = ks.create_card(vocab_card("hello")).expect("create hello");
+        let morning_sc = ks
+            .create_card(vocab_card("morning"))
+            .expect("create morning");
+        let bye_sc = ks.create_card(vocab_card("bye")).expect("create bye");
+        for pid in [phrase_id_hello(), phrase_id_morning(), phrase_id_bye()] {
+            ks.create_card(phrase_card(pid)).expect("create phrase");
+        }
+
+        // in_progress: rated Good once, stability stays under the known threshold.
+        ks.rate_card(*hello_sc.card_id(), Rating::Good, RateMode::StandardLesson)
+            .expect("rate hello");
+        // High difficulty: repeated Again under ShortTerm drives difficulty up.
+        for _ in 0..3 {
+            ks.rate_card(*bye_sc.card_id(), Rating::Again, RateMode::ShortTerm)
+                .expect("rate bye");
+        }
+        // morning stays new (untouched).
+
+        let hello_id = *hello_sc.card_id();
+        let morning_id = *morning_sc.card_id();
+        let bye_id = *bye_sc.card_id();
+        assert!(
+            ks.get_card(morning_id).unwrap().memory().is_new(),
+            "fixture sanity: morning should be new"
+        );
+        assert!(
+            ks.get_card(bye_id).unwrap().memory().is_high_difficulty(),
+            "fixture sanity: bye should be high difficulty"
+        );
+        assert!(
+            ks.get_card(hello_id).unwrap().memory().is_in_progress(),
+            "fixture sanity: hello should be in progress"
+        );
+
+        let lesson = LessonData {
+            cards: vec![
+                (hello_id, lesson_card_for(vocab_card("hello"))),
+                (morning_id, lesson_card_for(vocab_card("morning"))),
+                (bye_id, lesson_card_for(vocab_card("bye"))),
+            ],
+            core_count: 3,
+        };
+
+        let mut used = HashSet::new();
+        let mut budget = 5;
+        let result = add_interleaved_phrases(lesson, &ks, &mut used, &mut budget);
+        let phrases = lesson_phrase_ids(&result);
+
+        assert!(
+            phrases.contains(&phrase_id_hello()),
+            "new/in-progress anchor 'hello' should receive its phrase"
+        );
+        assert!(
+            phrases.contains(&phrase_id_morning()),
+            "new anchor 'morning' should receive its phrase"
+        );
+        assert!(
+            !phrases.contains(&phrase_id_bye()),
+            "high-difficulty anchor 'bye' must not receive an interleaved phrase"
+        );
+    }
+
+    /// With no new/in-progress vocab, interleaving falls back to known vocab.
+    /// High-difficulty vocab is never used as an anchor, even in the fallback.
+    #[test]
+    fn interleaved_phrases_fallback_to_known() {
+        ensure_test_phrase_index();
+
+        let mut ks = KnowledgeSet::new();
+        let hello_sc = ks.create_card(vocab_card("hello")).expect("create hello");
+        let bye_sc = ks.create_card(vocab_card("bye")).expect("create bye");
+        for pid in [phrase_id_hello(), phrase_id_bye()] {
+            ks.create_card(phrase_card(pid)).expect("create phrase");
+        }
+
+        ks.mark_card_as_known(*hello_sc.card_id())
+            .expect("mark hello known");
+        for _ in 0..3 {
+            ks.rate_card(*bye_sc.card_id(), Rating::Again, RateMode::ShortTerm)
+                .expect("rate bye");
+        }
+
+        let hello_id = *hello_sc.card_id();
+        let bye_id = *bye_sc.card_id();
+        assert!(ks.get_card(hello_id).unwrap().memory().is_known_card());
+        assert!(ks.get_card(bye_id).unwrap().memory().is_high_difficulty());
+
+        let lesson = LessonData {
+            cards: vec![
+                (hello_id, lesson_card_for(vocab_card("hello"))),
+                (bye_id, lesson_card_for(vocab_card("bye"))),
+            ],
+            core_count: 2,
+        };
+
+        let mut used = HashSet::new();
+        let mut budget = 5;
+        let result = add_interleaved_phrases(lesson, &ks, &mut used, &mut budget);
+        let phrases = lesson_phrase_ids(&result);
+
+        assert!(
+            phrases.contains(&phrase_id_hello()),
+            "fallback should anchor a phrase to the known word"
+        );
+        assert!(
+            !phrases.contains(&phrase_id_bye()),
+            "high-difficulty word must not anchor a phrase even via fallback"
+        );
+    }
+
+    /// A phrase consumed by the interleaved section (tracked via
+    /// `used_phrase_ids`) must never reappear in the tail, and vice versa.
+    #[test]
+    fn interleaved_phrases_no_overlap_with_tail() {
+        ensure_test_phrase_index();
+
+        let mut ks = KnowledgeSet::new();
+        ks.create_card(vocab_card("hello")).expect("create hello");
+        for word in ["test", "bye", "morning", "thanks"] {
+            let sc = ks
+                .create_card(vocab_card(word))
+                .expect("create known vocab");
+            ks.mark_card_as_known(*sc.card_id()).expect("mark known");
+        }
+        for pid in [
+            phrase_id_hello(),
+            phrase_id_bye(),
+            phrase_id_morning(),
+            phrase_id_thanks(),
+        ] {
+            ks.create_card(phrase_card(pid)).expect("create phrase");
+        }
+
+        let lesson = ks.cards_to_lesson(1, &JlptContent::new(), JapaneseLevel::N5);
+
+        let core_count = lesson.core_count;
+        let interleaved_ids: HashSet<Ulid> = lesson.cards[..core_count]
+            .iter()
+            .filter_map(|(_, lc)| lesson_phrase_id(lc))
+            .collect();
+        let tail_ids: HashSet<Ulid> = lesson.cards[core_count..]
+            .iter()
+            .filter_map(|(_, lc)| lesson_phrase_id(lc))
+            .collect();
+
+        assert!(
+            !interleaved_ids.is_empty(),
+            "scenario should produce at least one interleaved phrase"
+        );
+        let overlap: Vec<_> = interleaved_ids.intersection(&tail_ids).copied().collect();
+        assert!(
+            overlap.is_empty(),
+            "interleaved and tail must not share phrase ids: {overlap:?}"
+        );
+    }
+
+    /// `core_count` is recomputed after interleaving, so every phrase placed in
+    /// the core section counts as core; the tail only starts after it.
+    #[test]
+    fn interleaved_phrases_core_count_includes_them() {
+        ensure_test_phrase_index();
+
+        let mut ks = KnowledgeSet::new();
+        ks.create_card(vocab_card("hello")).expect("create hello");
+        for word in ["test", "bye", "morning", "thanks"] {
+            let sc = ks
+                .create_card(vocab_card(word))
+                .expect("create known vocab");
+            ks.mark_card_as_known(*sc.card_id()).expect("mark known");
+        }
+        for pid in [
+            phrase_id_hello(),
+            phrase_id_bye(),
+            phrase_id_morning(),
+            phrase_id_thanks(),
+        ] {
+            ks.create_card(phrase_card(pid)).expect("create phrase");
+        }
+
+        let lesson = ks.cards_to_lesson(1, &JlptContent::new(), JapaneseLevel::N5);
+        let core_count = lesson.core_count;
+
+        let interleaved_in_core = lesson.cards[..core_count]
+            .iter()
+            .filter(|(_, lc)| lesson_phrase_id(lc).is_some())
+            .count();
+
+        assert!(
+            interleaved_in_core >= 1,
+            "at least one interleaved phrase should sit inside the core section"
+        );
+        assert!(core_count >= interleaved_in_core);
+        for (_, lc) in &lesson.cards[core_count..] {
+            assert!(
+                lesson_phrase_id(lc).is_some(),
+                "everything past core_count must be a (tail) phrase card"
+            );
+        }
+    }
+
+    /// On a lesson too short to honour the gap, the phrase is flushed at the
+    /// end. The only inviolable ordering rule — phrase after its anchor — holds.
+    #[test]
+    fn interleaved_phrases_small_lesson_degrades_gap() {
+        let word_id = Ulid::new();
+        let phrase_card_id = Ulid::new();
+
+        let core_cards: Vec<(Ulid, LessonCard)> =
+            [(word_id, lesson_card_for(vocab_card("solo")))].to_vec();
+        let assignments: HashMap<Ulid, Vec<(Ulid, LessonCard)>> = [(
+            word_id,
+            vec![(phrase_card_id, lesson_card_for(phrase_card(Ulid::new())))],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = interleave_with_gap(core_cards, assignments, INTERLEAVING_GAP);
+
+        let word_pos = result
+            .iter()
+            .position(|(id, _)| *id == word_id)
+            .expect("anchor present");
+        let phrase_pos = result
+            .iter()
+            .position(|(id, _)| *id == phrase_card_id)
+            .expect("flushed phrase present");
+
+        assert_eq!(result.len(), 2);
+        assert!(phrase_pos > word_pos);
+        assert!(
+            phrase_pos < word_pos + INTERLEAVING_GAP + 1,
+            "gap should degrade on a tiny core, but ordering must survive"
+        );
+    }
+
+    /// The new-phrase budget is shared between the interleaved and tail
+    /// sections: together they may not exceed it. Due phrases are free.
+    #[test]
+    fn interleaved_and_tail_respect_shared_phrase_new_budget() {
+        ensure_test_phrase_index();
+
+        let mut ks = KnowledgeSet::new();
+        ks.create_card(vocab_card("hello")).expect("create hello");
+        for word in ["test", "bye", "morning", "thanks"] {
+            let sc = ks
+                .create_card(vocab_card(word))
+                .expect("create known vocab");
+            ks.mark_card_as_known(*sc.card_id()).expect("mark known");
+        }
+        for pid in [
+            phrase_id_hello(),
+            phrase_id_bye(),
+            phrase_id_morning(),
+            phrase_id_thanks(),
+        ] {
+            ks.create_card(phrase_card(pid)).expect("create phrase");
+        }
+
+        let daily_new_limit = 1;
+        let budget = compute_phrase_new_budget(daily_new_limit, 0);
+        assert_eq!(budget, 2, "fixture sanity: PHRASE_NEW_RATIO=2");
+
+        let lesson = ks.cards_to_lesson(daily_new_limit, &JlptContent::new(), JapaneseLevel::N5);
+
+        let new_phrases_in_lesson = lesson
+            .cards
+            .iter()
+            .filter(|(_, lc)| lesson_phrase_id(lc).is_some())
+            .filter(|(id, _)| ks.get_card(*id).is_some_and(|sc| sc.memory().is_new()))
+            .count();
+
+        assert!(
+            new_phrases_in_lesson <= budget,
+            "new phrases (interleaved + tail) must respect the shared budget: {new_phrases_in_lesson} > {budget}"
+        );
+        assert!(
+            new_phrases_in_lesson >= 1,
+            "scenario should place at least one new phrase"
+        );
+    }
+
+    /// Due phrases enter the interleaved section for free: they do not decrement
+    /// `phrase_new_budget`, which stays reserved for new phrases.
+    #[test]
+    fn interleaved_phrases_due_do_not_consume_new_budget() {
+        ensure_test_phrase_index();
+
+        let mut ks = KnowledgeSet::new();
+        let hello_sc = ks
+            .create_card(phrase_card(phrase_id_hello()))
+            .expect("create hello");
+        for pid in [phrase_id_bye(), phrase_id_morning(), phrase_id_thanks()] {
+            ks.create_card(phrase_card(pid)).expect("create phrase");
+        }
+
+        // mark_card_as_known schedules next_review in the past, so the phrase
+        // becomes due (and not new) without going through a timed review cycle.
+        ks.mark_card_as_known(*hello_sc.card_id())
+            .expect("mark hello due");
+        let hello_card = ks.get_card(*hello_sc.card_id()).unwrap();
+        assert!(hello_card.memory().is_due());
+        assert!(!hello_card.memory().is_new());
+
+        let owned: Vec<(Ulid, StudyCard)> = ks
+            .study_cards()
+            .iter()
+            .map(|(id, sc)| (*id, sc.clone()))
+            .collect();
+        let map = phrase_cards_map(&owned);
+
+        let in_lesson = HashSet::new();
+        let mut used = HashSet::new();
+        let mut budget = 2;
+        let initial_budget = budget;
+
+        let picked =
+            collect_interleaved_phrases_for_word("test", &map, &in_lesson, &mut used, &mut budget);
+
+        let picked_due_hello = picked.iter().any(|(id, _)| *id == *hello_sc.card_id());
+        assert!(
+            picked_due_hello,
+            "due phrase must be picked for free by the due pass"
+        );
+
+        let new_picked = picked.iter().filter(|(_, sc)| sc.memory().is_new()).count();
+        assert_eq!(
+            budget,
+            initial_budget - new_picked,
+            "only new phrases consume budget; the due phrase must be free"
+        );
     }
 }

--- a/origa/src/domain/knowledge/mod.rs
+++ b/origa/src/domain/knowledge/mod.rs
@@ -225,8 +225,27 @@ impl KnowledgeSet {
         jlpt_content: &JlptContent,
         user_level: JapaneseLevel,
     ) -> LessonData {
-        let lesson = lesson_builder::build_lesson(self, daily_new_limit, jlpt_content);
-        kanji_companions::add_kanji_companions(lesson, self, user_level)
+        use std::collections::HashSet;
+
+        let core = lesson_builder::build_lesson_core(self, daily_new_limit, jlpt_content);
+        let with_companions = kanji_companions::add_kanji_companions(core, self, user_level);
+        let mut phrase_new_budget = lesson_builder::compute_phrase_new_budget(
+            daily_new_limit,
+            self.phrase_cards_studied_today(),
+        );
+        let mut used_phrase_ids: HashSet<Ulid> = HashSet::new();
+        let with_interleaved = lesson_builder::add_interleaved_phrases(
+            with_companions,
+            self,
+            &mut used_phrase_ids,
+            &mut phrase_new_budget,
+        );
+        lesson_builder::add_tail_phrases(
+            with_interleaved,
+            self,
+            &used_phrase_ids,
+            phrase_new_budget,
+        )
     }
 
     pub(crate) fn rate_card(

--- a/origa/src/domain/knowledge/tests.rs
+++ b/origa/src/domain/knowledge/tests.rs
@@ -19,6 +19,66 @@ fn create_known_memory_state() -> MemoryState {
     )
 }
 
+// --- Phrase index fixture ---
+//
+// The phrase index is a process-wide `OnceLock`: only one index can live in a
+// test binary. This loads the same 4-phrase fixture used by `lesson_builder`,
+// `journeys/phrase` and `seed_ready_phrases`, so the data is identical no matter
+// which module wins the initialization race. Tests that assert on phrase
+// selection MUST call this so their assertions exercise the real selection path
+// rather than silently matching zero phrases (the failure mode flagged in C1).
+
+static PHRASE_INDEX_INIT: std::sync::Once = std::sync::Once::new();
+
+fn ensure_test_phrase_index() {
+    PHRASE_INDEX_INIT.call_once(|| {
+        if crate::dictionary::phrase::is_phrases_loaded() {
+            return;
+        }
+        let index_json = r#"{"v":1,"h":"test","total":4,"phrases":[
+            {"i":"01KPJ5S3N1DRFFD236Z4EZ03HJ","t":["test","hello"],"c":0},
+            {"i":"01KPJ5S3N1DRFFD236Z4EZ03HK","t":["test","bye"],"c":0,"g":["01KJ9AVWBGC2BT0DMFPDYYFEWB"]},
+            {"i":"01KPJ5S3N1DRFFD236Z4EZ03HN","t":["test","morning"],"c":0,"g":["01KJ9AVWBGC2BT0DMFPDYYFEWB","01G00000000000000024000000"]},
+            {"i":"01KPJ5S3N1DRFFD236Z4EZ03HM","t":["test","thanks"],"c":0}
+        ]}"#;
+        crate::dictionary::phrase::init_phrase_index(index_json)
+            .expect("Failed to init test phrase index");
+    });
+}
+
+fn phrase_id_hello() -> Ulid {
+    Ulid::from_string("01KPJ5S3N1DRFFD236Z4EZ03HJ").expect("valid ULID")
+}
+
+fn phrase_id_bye() -> Ulid {
+    Ulid::from_string("01KPJ5S3N1DRFFD236Z4EZ03HK").expect("valid ULID")
+}
+
+fn phrase_id_morning() -> Ulid {
+    Ulid::from_string("01KPJ5S3N1DRFFD236Z4EZ03HN").expect("valid ULID")
+}
+
+fn phrase_id_thanks() -> Ulid {
+    Ulid::from_string("01KPJ5S3N1DRFFD236Z4EZ03HM").expect("valid ULID")
+}
+
+/// Counts phrase study cards present in a lesson, split by core (interleaved)
+/// vs tail. Core phrases sit at indices `< core_count`; tail phrases follow.
+fn count_phrases(result: &LessonData) -> (usize, usize) {
+    let mut core_phrases = 0usize;
+    let mut tail_phrases = 0usize;
+    for (index, (_, lc)) in result.cards.iter().enumerate() {
+        if matches!(lc.card(), Card::Phrase(_)) {
+            if index < result.core_count {
+                core_phrases += 1;
+            } else {
+                tail_phrases += 1;
+            }
+        }
+    }
+    (core_phrases, tail_phrases)
+}
+
 #[test]
 fn cards_to_lesson_includes_favorite_cards() {
     let mut knowledge_set = KnowledgeSet::new();
@@ -850,53 +910,42 @@ fn new_cards_interleave_preserves_jlpt_priority() {
 
 #[test]
 fn phrase_new_cards_limited() {
+    ensure_test_phrase_index();
+
+    // Four known anchor words (each a unique token of one fixture phrase) and
+    // the four matching NEW phrase cards. Known anchors enter the core without
+    // consuming the daily new-card allowance, so every phrase competes only for
+    // the shared new-phrase budget.
     let mut knowledge_set = KnowledgeSet::new();
-    for _ in 0..20 {
-        let phrase_id = Ulid::new();
+    for word in ["hello", "bye", "morning", "thanks"] {
+        let study = knowledge_set.create_card(create_vocab_card(word)).unwrap();
+        knowledge_set.mark_card_as_known(*study.card_id()).unwrap();
+    }
+    for phrase_id in [
+        phrase_id_hello(),
+        phrase_id_bye(),
+        phrase_id_morning(),
+        phrase_id_thanks(),
+    ] {
         knowledge_set
             .create_card(Card::Phrase(PhraseCard::new_test_with_id(phrase_id)))
             .unwrap();
     }
-    for i in 0..5 {
-        knowledge_set
-            .create_card(create_vocab_card(&format!("vocab{i}")))
-            .unwrap();
-    }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
+    // daily_new_limit = 1 -> new-phrase budget = 1 * PHRASE_NEW_RATIO (2).
+    // Four phrases are available, so the budget must be the binding constraint.
+    let result = knowledge_set.cards_to_lesson(1, &JlptContent::new(), JapaneseLevel::N5);
 
-    let phrase_count = result
-        .keys()
-        .filter(|id| {
-            matches!(
-                knowledge_set.get_card(**id).unwrap().card(),
-                Card::Phrase(_)
-            )
-        })
-        .count();
-    let vocab_count = result
-        .keys()
-        .filter(|id| {
-            matches!(
-                knowledge_set.get_card(**id).unwrap().card(),
-                Card::Vocabulary(_)
-            )
-        })
-        .count();
+    let (core_phrases, tail_phrases) = count_phrases(&result);
+    let total_phrases = core_phrases + tail_phrases;
 
-    let expected_phrase_limit = 5 * 2;
-    assert!(
-        phrase_count <= expected_phrase_limit,
-        "Phrase cards should be limited to daily_new_limit*2, got {phrase_count}, expected <={expected_phrase_limit}"
+    assert_eq!(
+        total_phrases, 2,
+        "New phrase cards must be capped at daily_new_limit * PHRASE_NEW_RATIO (2), got {total_phrases}"
     );
-    assert!(
-        vocab_count <= 5,
-        "Vocab cards should respect daily limit, got {vocab_count}"
-    );
-    assert!(
-        phrase_count + vocab_count <= 50 + 5,
-        "Total should not exceed MAX_LESSON_SIZE + PHRASE_MAX_PER_LESSON, got {}",
-        phrase_count + vocab_count
+    assert_eq!(
+        core_phrases, 2,
+        "Both budget-bound phrases land in the interleaved core section, got {core_phrases}"
     );
 }
 
@@ -1039,7 +1088,7 @@ fn lesson_size_respects_max_limit() {
     let result = knowledge_set.cards_to_lesson(100, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(
-        result.len() <= 50,
+        result.len() <= 30,
         "Total lesson size should not exceed MAX_LESSON_SIZE, got {}",
         result.len()
     );
@@ -1062,7 +1111,7 @@ fn high_difficulty_cards_respect_max_lesson_size() {
     let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
 
     assert!(
-        result.len() <= 50,
+        result.len() <= 30,
         "High-difficulty cards should be capped at MAX_LESSON_SIZE, got {}",
         result.len()
     );
@@ -1102,23 +1151,10 @@ fn phrases_added_after_core_cards_learning() {
             )
         })
         .count();
-    let phrase_count = result
-        .keys()
-        .filter(|id| {
-            matches!(
-                knowledge_set.get_card(**id).unwrap().card(),
-                Card::Phrase(_)
-            )
-        })
-        .count();
 
     assert!(
         core_count >= 15,
         "Core cards should reach at least MIN_LESSON_SIZE, got {core_count}"
-    );
-    assert!(
-        phrase_count <= 5,
-        "Phrase cards should not exceed PHRASE_MAX_PER_LESSON, got {phrase_count}"
     );
 }
 
@@ -1156,23 +1192,10 @@ fn phrases_added_after_core_cards_review() {
             )
         })
         .count();
-    let phrase_count = result
-        .keys()
-        .filter(|id| {
-            matches!(
-                knowledge_set.get_card(**id).unwrap().card(),
-                Card::Phrase(_)
-            )
-        })
-        .count();
 
     assert!(
         core_count >= 15,
         "Core cards should reach at least MIN_LESSON_SIZE, got {core_count}"
-    );
-    assert!(
-        phrase_count <= 5,
-        "Phrase cards should not exceed PHRASE_MAX_PER_LESSON, got {phrase_count}"
     );
 }
 

--- a/origa/src/use_cases/mod.rs
+++ b/origa/src/use_cases/mod.rs
@@ -21,7 +21,7 @@ mod update_user_profile;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]
-pub use tests::fixtures::init_real_dictionaries;
+pub use tests::fixtures::{init_phrase_index_from_cdn, init_real_dictionaries};
 
 pub use analyze_text_for_cards::{AnalyzeTextForCardsUseCase, AnalyzeTextResult, AnalyzedWord};
 pub use create_cards_from_analysis::{

--- a/origa/src/use_cases/tests/fixtures/mod.rs
+++ b/origa/src/use_cases/tests/fixtures/mod.rs
@@ -3,7 +3,7 @@ mod in_memory_repository;
 mod real_dictionaries;
 
 pub use in_memory_repository::InMemoryUserRepository;
-pub use real_dictionaries::init_real_dictionaries;
+pub use real_dictionaries::{init_phrase_index_from_cdn, init_real_dictionaries};
 
 use std::path::PathBuf;
 

--- a/origa/src/use_cases/tests/fixtures/real_dictionaries.rs
+++ b/origa/src/use_cases/tests/fixtures/real_dictionaries.rs
@@ -6,6 +6,7 @@ use flate2::read::DeflateDecoder;
 use super::get_cdn_dir;
 use crate::dictionary::grammar::{GrammarData, init_grammar, is_grammar_loaded};
 use crate::dictionary::kanji::{KanjiData, init_kanji, is_kanji_loaded};
+use crate::dictionary::phrase::{init_phrase_index, is_phrases_loaded};
 use crate::dictionary::radical::{RadicalData, init_radicals, is_radicals_loaded};
 use crate::dictionary::vocabulary::{VocabularyChunkData, init_vocabulary};
 use crate::domain::{DictionaryData, init_dictionary, is_dictionary_loaded};
@@ -15,6 +16,7 @@ static VOCABULARY_INIT: Once = Once::new();
 static KANJI_INIT: Once = Once::new();
 static RADICALS_INIT: Once = Once::new();
 static GRAMMAR_INIT: Once = Once::new();
+static PHRASE_INDEX_INIT: Once = Once::new();
 
 fn decompress(data: Vec<u8>) -> Vec<u8> {
     let mut decoder = DeflateDecoder::new(&data[..]);
@@ -29,6 +31,35 @@ pub fn init_real_dictionaries() {
     init_kanji_dictionary();
     init_radicals_dictionary();
     init_grammar_rules();
+}
+
+/// Loads `cdn/phrases/phrase_index.json` into the process-wide `PHRASE_INDEX`.
+/// Required by lesson-builder tests because `init_real_dictionaries` intentionally
+/// does not pull the phrase index (production loads it lazily from the CDN).
+pub fn init_phrase_index_from_cdn() {
+    PHRASE_INDEX_INIT.call_once(|| {
+        if is_phrases_loaded() {
+            return;
+        }
+
+        let cdn_dir = get_cdn_dir();
+        let index_path = cdn_dir.join("phrases").join("phrase_index.json");
+
+        let index_json = match std::fs::read_to_string(&index_path) {
+            Ok(content) => content,
+            Err(e) => {
+                tracing::warn!(
+                    "Phrase index not found, skipping phrase index initialization: {}",
+                    e
+                );
+                return;
+            },
+        };
+
+        if let Err(e) = init_phrase_index(&index_json) {
+            tracing::warn!("Failed to init phrase index: {:?}", e);
+        }
+    });
 }
 
 fn init_tokenizer_dictionary() {

--- a/origa_ui/src/pages/lesson/on_dont_know.rs
+++ b/origa_ui/src/pages/lesson/on_dont_know.rs
@@ -1,6 +1,6 @@
 use super::lesson_state::LessonState;
 use leptos::prelude::*;
-use origa::domain::{LessonCardView, QuizMode, Rating};
+use origa::domain::{CardType, LessonCardView, QuizMode, Rating};
 
 pub fn create_on_dont_know(
     lesson_state: RwSignal<LessonState>,
@@ -8,12 +8,17 @@ pub fn create_on_dont_know(
 ) -> Callback<()> {
     Callback::new(move |_: ()| {
         let state = lesson_state.get();
-        let is_phrase = state.current_index >= state.core_count;
 
-        let is_multi_quiz = state
+        let current_card = state
             .card_ids
             .get(state.current_index)
-            .and_then(|id| state.cards.get(id))
+            .and_then(|id| state.cards.get(id));
+
+        let is_phrase = current_card
+            .map(|c| CardType::from(c.card()) == CardType::Phrase)
+            .unwrap_or(false);
+
+        let is_multi_quiz = current_card
             .map(|c| {
                 matches!(c.view(), LessonCardView::KanjiReadingQuiz(q) if q.mode() == QuizMode::Multi)
             })

--- a/origa_ui/src/pages/lesson/on_quiz_select.rs
+++ b/origa_ui/src/pages/lesson/on_quiz_select.rs
@@ -1,7 +1,7 @@
 use super::lesson_state::LessonState;
 use leptos::prelude::*;
 use leptos::task::spawn_local;
-use origa::domain::{LessonCardView, Rating};
+use origa::domain::{CardType, LessonCardView, Rating};
 
 pub fn create_on_quiz_select(
     lesson_state: RwSignal<LessonState>,
@@ -12,9 +12,6 @@ pub fn create_on_quiz_select(
     };
 
     Callback::new(move |option_index: usize| {
-        let state = lesson_state.get();
-        let is_phrase = state.current_index >= state.core_count;
-
         lesson_state.update(|state| {
             state.selected_quiz_option = Some(option_index);
             state.showing_answer = true;
@@ -29,6 +26,7 @@ pub fn create_on_quiz_select(
         };
 
         if let Some(lesson_card) = lesson_state.get().cards.get(&card_id) {
+            let is_phrase = CardType::from(lesson_card.card()) == CardType::Phrase;
             let is_correct = match lesson_card.view() {
                 LessonCardView::Quiz(q) | LessonCardView::KanjiReadingQuiz(q) => {
                     Some(q.check_answer(option_index))

--- a/origa_ui/src/pages/lesson/on_quiz_submit.rs
+++ b/origa_ui/src/pages/lesson/on_quiz_submit.rs
@@ -1,6 +1,6 @@
 use super::lesson_state::LessonState;
 use leptos::prelude::*;
-use origa::domain::{LessonCardView, QuizMode, Rating};
+use origa::domain::{CardType, LessonCardView, QuizMode, Rating};
 
 pub fn create_on_quiz_submit(
     lesson_state: RwSignal<LessonState>,
@@ -14,7 +14,6 @@ pub fn create_on_quiz_submit(
             return;
         }
 
-        let is_phrase = state.current_index >= state.core_count;
         let card_id = state.card_ids.get(state.current_index).copied();
 
         let Some(card_id) = card_id else {
@@ -24,6 +23,8 @@ pub fn create_on_quiz_submit(
         let Some(lesson_card) = state.cards.get(&card_id) else {
             return;
         };
+
+        let is_phrase = CardType::from(lesson_card.card()) == CardType::Phrase;
 
         let quiz = match lesson_card.view() {
             LessonCardView::KanjiReadingQuiz(q) => q,

--- a/origa_ui/src/pages/lesson/on_rate.rs
+++ b/origa_ui/src/pages/lesson/on_rate.rs
@@ -8,18 +8,19 @@ use origa::use_cases::{CreatePhraseCardUseCase, RateCardWithSideEffectsUseCase};
 use tracing::warn;
 use ulid::Ulid;
 
-fn determine_rate_mode(card: &LessonCard, current_index: usize, core_count: usize) -> RateMode {
-    let is_phrase = current_index >= core_count;
-    if is_phrase {
-        RateMode::PhraseReview
-    } else if card.is_short_term() {
-        RateMode::ShortTerm
-    } else {
-        match CardType::from(card.card()) {
-            CardType::Grammar => RateMode::GrammarReview,
-            CardType::Kanji => RateMode::KanjiReview,
-            CardType::Vocabulary | CardType::Phrase => RateMode::StandardLesson,
-        }
+fn determine_rate_mode(card: &LessonCard) -> RateMode {
+    if CardType::from(card.card()) == CardType::Phrase {
+        return RateMode::PhraseReview;
+    }
+    if card.is_short_term() {
+        return RateMode::ShortTerm;
+    }
+    match CardType::from(card.card()) {
+        CardType::Grammar => RateMode::GrammarReview,
+        CardType::Kanji => RateMode::KanjiReview,
+        // Phrase cards are intercepted by the early return above, so the only
+        // remaining type reaching this arm is Vocabulary.
+        _ => RateMode::StandardLesson,
     }
 }
 
@@ -120,7 +121,7 @@ pub fn create_on_rate_callback(
         let rate_mode = state
             .cards
             .get(&card_id)
-            .map(|c| determine_rate_mode(c, state.current_index, state.core_count))
+            .map(determine_rate_mode)
             .unwrap_or(RateMode::StandardLesson);
 
         let grammar_rule_id = state.cards.get(&card_id).and_then(extract_grammar_rule_id);
@@ -145,4 +146,52 @@ pub fn create_on_rate_callback(
             is_rating.set(None);
         });
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use origa::domain::{LessonCardView, PhraseCard};
+
+    fn phrase_lesson_card(is_short_term: bool) -> LessonCard {
+        let card = Card::Phrase(PhraseCard::new(Ulid::new()));
+        LessonCard::new(LessonCardView::Normal(card), is_short_term)
+    }
+
+    // `VocabularyCard::new` is `#[cfg(test)] pub(crate)` in the `origa` crate,
+    // so it cannot be reached from `origa_ui` tests (different crate, even with
+    // `cfg(test)`). We therefore round-trip a vocab card through its public
+    // serde representation. This is intentionally fragile: any change to the
+    // `VocabularyCard` serialization shape will break this helper loudly, which
+    // is preferable to a silent mismatch between the test fixture and prod data.
+    fn vocab_lesson_card(is_short_term: bool) -> LessonCard {
+        let card: Card =
+            serde_json::from_str(r#"{"Vocabulary":{"word":{"text":"test"},"reverse_side":null}}"#)
+                .expect("deserialize vocab card");
+        LessonCard::new(LessonCardView::Normal(card), is_short_term)
+    }
+
+    // A phrase card placed inside the core section (index < core_count) must
+    // still be reviewed as a phrase now that the mode is derived from card
+    // type rather than the positional threshold.
+    #[test]
+    fn determine_rate_mode_phrase_at_core_position() {
+        let card = phrase_lesson_card(false);
+        assert_eq!(determine_rate_mode(&card), RateMode::PhraseReview);
+    }
+
+    // A vocab card placed past the core boundary must NOT be treated as a
+    // phrase review; it falls through to the standard / short-term branches.
+    #[test]
+    fn determine_rate_mode_vocab_at_phrase_position() {
+        let card = vocab_lesson_card(false);
+        assert_ne!(determine_rate_mode(&card), RateMode::PhraseReview);
+        assert_eq!(determine_rate_mode(&card), RateMode::StandardLesson);
+    }
+
+    #[test]
+    fn determine_rate_mode_short_term_vocab_uses_short_term() {
+        let card = vocab_lesson_card(true);
+        assert_eq!(determine_rate_mode(&card), RateMode::ShortTerm);
+    }
 }


### PR DESCRIPTION
## Summary

Reduce cognitive overload by capping the core lesson size and interleaving practice phrases into the lesson body, so users get smaller, more frequent lessons that reinforce words in context instead of one exhausting session dominated by difficult cards.

## Changes

- **lesson_builder**: lower `MAX_LESSON_SIZE` 50 → 30 (other thresholds unchanged: `MIN_LESSON_SIZE=15`, phrase caps, FSRS thresholds)
- **lesson_builder**: tail phrases (5 at end) now match ONLY known words, capped at `MAX_PHRASES_PER_WORD_IN_TAIL=2` per word — fixes a bug where a single popular word could claim all 5 tail phrases
- **lesson_builder**: interleave up to `INTERLEAVED_PHRASES_PER_WORD=2` phrases per target word INSIDE the core section (above the 30 cap), with `INTERLEAVING_GAP=2` cards between the word and its first phrase; the anchor word always precedes its phrases so the user rates the word before seeing it used in a phrase. Targets new/in_progress vocab (fallback to known). Due phrases are free; new phrases share one budget across interleaving and tail
- **kanji_companions**: remove the `MAX_LESSON_SIZE`-based cap on reverse companions — they now respect only `MAX_REVERSE_COMPANION_CARDS_PER_LESSON` (fixes silent truncation once the lesson grew past the ceiling)
- **origa_ui lesson handlers** (on_rate / on_quiz_select / on_dont_know / on_quiz_submit): detect phrase cards by `CardType` instead of positional index `>= core_count`, since interleaving places phrases inside the core section
- **cards_to_lesson pipeline reordered**: `build_lesson_core` → `add_kanji_companions` → `add_interleaved_phrases` → `add_tail_phrases`

## Test plan

- +16 new unit/integration tests covering interleaving invariants (word precedes phrase, gap, per-word cap, target filtering, dedup vs tail, shared budget, due-free, gap degradation on tiny lessons) and tail-phrase selection (known-only, per-word cap)
- Phrase integration tests now load the real phrase index instead of passing trivially
- `cargo test -p origa -p origa_ui` — all green
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- `cargo fmt --check -p origa -p origa_ui` — clean
