### PR TITLE
fix(grammar): label standalone markers unreachable by format_map

### DIFF
--- a/origa/src/domain/tokenizer/translation.rs
+++ b/origa/src/domain/tokenizer/translation.rs
@@ -1153,4 +1153,55 @@ mod integration_tests {
                 .collect::<Vec<_>>()
         );
     }
+
+    // Standalone grammar markers (particle / noun / auxiliary) that previously
+    // carried no grammar_label because their rule had only a format_map and no
+    // keywords. Keyword matching fires on the token surface, so once a keyword
+    // is added the marker token itself is labeled instead of staying bare.
+    fn assert_marker_has_grammar_label(text: &str, marker_surface: &str, expected_label: &str) {
+        ensure_dictionaries();
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let marker = results
+            .iter()
+            .find(|t| t.surface_form == marker_surface)
+            .unwrap_or_else(|| panic!(
+                "「{marker_surface}」 token should exist in '{text}', got surfaces: {surfaces:?}",
+                surfaces = results.iter().map(|t| t.surface_form.as_str()).collect::<Vec<_>>()
+            ));
+        assert_eq!(
+            marker.grammar_label.as_deref(),
+            Some(expected_label),
+            "「{marker_surface}」 in '{text}' grammar_label mismatch, token: {marker:?}",
+        );
+    }
+
+    #[test]
+    fn should_label_te_particle_via_keyword() {
+        assert_marker_has_grammar_label("食べて飲んで", "て", "～て");
+    }
+
+    #[test]
+    fn should_label_tara_conditional_via_keyword() {
+        assert_marker_has_grammar_label("食べたら", "たら", "～たら");
+    }
+
+    #[test]
+    fn should_label_okage_thanks_to_via_keyword() {
+        assert_marker_has_grammar_label("彼のおかげで成功した", "おかげ", "～おかげで");
+    }
+
+    #[test]
+    fn should_label_sei_because_of_via_keyword() {
+        assert_marker_has_grammar_label("失敗は彼のせいだ", "せい", "～せいで");
+    }
+
+    #[test]
+    fn should_label_totan_the_moment_via_keyword() {
+        assert_marker_has_grammar_label(
+            "ドアを開けたとたん猫が逃げた",
+            "とたん",
+            "～たとたん（に）",
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Systematic audit of the 503 grammar rules identified rules that had a `format_map` but **no `keywords`**, leaving the standalone particle/noun/auxiliary token that carries the grammar meaning without a `grammar_label` in `resolve_grammar_label`. Restored labels on **5** verified, unambiguous markers.

> **Stacked on #193** (`fix/grammar-conjugation-chain`). Base is intentionally that branch, not `master`, so this PR shows only the keywords-audit commit. It will retarget to `master` automatically once #193 merges.

## Root cause

`match_grammar_keyword` (`translation.rs`) matches a rule when the **token surface** exactly equals a keyword AND every keyword group is present in the text. A rule with only a `format_map` (no keywords) is matched solely via the conjugated **verb stem**. When the marker is a separate token (e.g. the `て` particle, the `つもり`/`おかげ` noun), it stays bare (`grammar_label = None`) even though it is the token that carries the grammar meaning.

## Empirical method (corrects the brief's premise)

The brief estimated ~80+ rules need keywords, assuming compound tokens like `てください` exist. A diagnostic pass dumping real Lindera tokenization for ~80 phrases showed this assumption is **false**: Lindera splits `てください` → `て`[Particle] + `ください`[Verb]. So:

- a keyword like `["てください"]` would **never match** any token surface (dead data);
- most `format_map`-only rules are **already reachable** via the verb stem (format_map labels the conjugated verb), so the marker being unlabeled is not a reachability bug for them;
- many markers are **already covered** by keyword rules at another level (`ながら`→N2, `はず`→N4, `だけ`/`ばかり`/`まで`/`ほど`→existing keywords).

So the genuinely-qualifying set (marker unlabeled + unambiguous + no conflict + real token) is **5 rules**, not 80.

## Changes — 5 keyword additions

| Level | Rule | Keyword | Marker token (verified) |
|-------|------|---------|-------------------------|
| N5 | ～て | `[[\"て\"]]` | `て`[Particle] — headline bug; verb stem got the wrong `～てる` label |
| N5 | ～たら | `[[\"たら\"]]` | `たら`[AuxiliaryVerb\|た] |
| N3 | ～おかげで | `[[\"おかげ\"]]` | `おかげ`[Noun\|御陰] (archaic kanji) |
| N3 | ～せいで | `[[\"せい\"]]` | `せい`[Noun\|所為] (archaic kanji) |
| N2 | ～たとたん（に） | `[[\"とたん\"]]` | `とたん`[Noun\|途端] (archaic kanji) |

The archaic-kanji nouns are matchable via the `is_vocab && surface != base` branch (the same mechanism that powers `すぎる` detection).

## Deliberately SKIPPED (with reasoning)

- **`ます`/`た`/`ない`** standalone auxiliaries — ubiquitous, reachable via verb stem, would add redundant labels to every sentence.
- **Pure conjugation categories** (可能形/受身形/使役形/命令形/意向形) — verb conjugates as one token, no standalone marker.
- **`ば`** — bare `\"ば\"` already contested by `～さえ～ば` and `～ば～だけ` (3-way conflict); particle already gets *a* label.
- **`そうだ`** (3 rules) — `そう` token already grabbed by the `こう・そう・ああ・どう` manner rule; verb stem carries 様態/伝聞 via format_map.
- **`よう` family / `こと` / `つもり`** — bare keyword is **non-discriminating across competing rules with different meanings**. ⚠️ `つもり` was initially added then **reverted**: `たつもり` (pretend) would have been mislabeled as `～つもりです` (intention) — actively harmful in a learning app. Needs context-aware (multi-group) matching, out of scope here.
- **Common content words** (`ため`/`上`/`以上`/`次第`/`わけ`/`はじめて`) — high false-positive risk or already verb-stem-labeled.
- **`て`-compounds** (`てください`/`ている`/`てみる`/...) — no compound token exists (Lindera splits), verb stem already labeled.

## Files

**Tracked (this PR):**
- `origa/src/domain/tokenizer/translation.rs` — `assert_marker_has_grammar_label` helper + 5 regression tests.

**Gitignored `cdn/` (grammar source-of-truth, deployed to CDN — not committed):**
- NEW: `rules/n5_legacy_fixes/rule_te_particle.json`, `rule_tara_conditional.json`
- MODIFIED (added `keywords`, `format_map` preserved): `rules/n3_lessons_09-12/rule_38_okage_de.json`, `rule_40_sei_de.json`, `rules/n2_lessons_17-20/rule_39_ta_totan.json`
- REGENERATED: `grammar.json` (503 rules, **259** with keywords vs 254 baseline; 0 format_map loss)

## Verification

| Check | Result |
|-------|--------|
| `validate_grammar.py --file grammar.json` | 0 errors |
| `merge_grammar_chunks.py --dry-run` | 0 errors, 0 warnings |
| format_map guard (all 5 rules) | preserved (identical before/after) |
| `cargo test -p origa --lib translation` | 84 passed |
| `cargo test -p origa --lib grammar` | 326 passed |
| `cargo fmt --check` / `cargo clippy -p origa --all-targets -- -D warnings` | clean |
| Code review (@code-quality-reviewer) | **approve** (2 rounds; つもり reverted on round 1) |

## CDN deploy

⚠️ `deploy_cdn.py --dry-run` confirms `grammar/grammar.json` is staged (cache `max-age=300, must-revalidate`, the correct release-updated policy). The actual upload is blocked on the `origa` AWS profile (not configured in the dev env) — to be run by a maintainer with credentials or in CI after merge.