### PR TITLE
fix(tokenizer+lesson): grammar descriptions, くらい split, yes/no two-line layout

### DIFF
--- a/origa/src/domain/knowledge/lesson/types.rs
+++ b/origa/src/domain/knowledge/lesson/types.rs
@@ -161,18 +161,20 @@ impl MultiQuizResult {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct YesNoCard {
     card: Card,
-    statement_text: String,
+    word: String,
+    statement: String,
     is_correct: bool,
 }
 
 impl YesNoCard {
-    pub fn new(card: Card, statement_text: String, is_correct: bool) -> Self {
+    pub fn new(card: Card, word: String, statement: String, is_correct: bool) -> Self {
         Self {
             card,
-            statement_text,
+            word,
+            statement,
             is_correct,
         }
     }
@@ -181,8 +183,12 @@ impl YesNoCard {
         &self.card
     }
 
-    pub fn statement_text(&self) -> &str {
-        &self.statement_text
+    pub fn word(&self) -> &str {
+        &self.word
+    }
+
+    pub fn statement(&self) -> &str {
+        &self.statement
     }
 
     pub fn is_correct(&self) -> bool {
@@ -191,6 +197,58 @@ impl YesNoCard {
 
     pub fn check_answer(&self, user_said_yes: bool) -> bool {
         (self.is_correct && user_said_yes) || (!self.is_correct && !user_said_yes)
+    }
+}
+
+impl<'de> Deserialize<'de> for YesNoCard {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Manual impl (rather than derive) to backfill the legacy
+        // single-field `statement_text` shape; see `split_legacy_statement_text`.
+        #[derive(Deserialize)]
+        struct Wire {
+            card: Card,
+            is_correct: bool,
+            #[serde(default)]
+            word: Option<String>,
+            #[serde(default)]
+            statement: Option<String>,
+            #[serde(default)]
+            statement_text: Option<String>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+
+        let (word, statement) = match (wire.word, wire.statement) {
+            (Some(word), Some(statement)) => (word, statement),
+            (Some(word), None) => (word, String::new()),
+            (None, Some(statement)) => (String::new(), statement),
+            (None, None) => wire
+                .statement_text
+                .as_deref()
+                .map(split_legacy_statement_text)
+                .unwrap_or_default(),
+        };
+
+        Ok(YesNoCard {
+            card: wire.card,
+            word,
+            statement,
+            is_correct: wire.is_correct,
+        })
+    }
+}
+
+/// Recovers `word` and `statement` from a legacy `statement_text` joined
+/// by `" \n "` (the format emitted by `generate_yesno`). When the
+/// separator is absent the whole string becomes `statement`.
+fn split_legacy_statement_text(joined: &str) -> (String, String) {
+    const SEP: &str = " \n ";
+    match joined.split_once(SEP) {
+        Some((word, statement)) => (word.trim().to_string(), statement.trim().to_string()),
+        None => (String::new(), joined.to_string()),
     }
 }
 
@@ -640,5 +698,185 @@ mod tests {
             slot_id,
             "nil card_id must be backfilled from the slot id"
         );
+    }
+
+    mod yesno_card_deserialize_tests {
+        use super::*;
+
+        fn sample_card() -> Card {
+            Card::Vocabulary(VocabularyCard::new(
+                Question::new("温度".to_string()).expect("valid question"),
+            ))
+        }
+
+        fn sample_card_json() -> String {
+            serde_json::to_string(&sample_card()).expect("serialize card")
+        }
+
+        #[test]
+        fn yesno_card_roundtrip_preserves_fields() {
+            let original = YesNoCard::new(
+                sample_card(),
+                "温度".to_string(),
+                "спортивное состязание, матч, игра".to_string(),
+                true,
+            );
+
+            let json = serde_json::to_string(&original).expect("serialize YesNoCard");
+            let restored: YesNoCard = serde_json::from_str(&json).expect("deserialize YesNoCard");
+
+            assert_eq!(restored.card(), original.card());
+            assert_eq!(restored.word(), "温度");
+            assert_eq!(restored.statement(), "спортивное состязание, матч, игра");
+            assert!(restored.is_correct());
+        }
+
+        #[test]
+        fn yesno_card_serialized_new_shape_omits_statement_text() {
+            let card = YesNoCard::new(
+                sample_card(),
+                "温度".to_string(),
+                "перевод".to_string(),
+                false,
+            );
+
+            let json = serde_json::to_string(&card).expect("serialize YesNoCard");
+            assert!(
+                !json.contains("statement_text"),
+                "new shape must not emit legacy `statement_text`: {json}"
+            );
+            assert!(json.contains("\"word\""));
+            assert!(json.contains("\"statement\""));
+        }
+
+        #[test]
+        fn yesno_card_deserialize_backfills_from_legacy_statement_text() {
+            let json = format!(
+                r#"{{"card":{},"statement_text":"温度 \n спортивное состязание","is_correct":true}}"#,
+                sample_card_json()
+            );
+
+            let restored: YesNoCard =
+                serde_json::from_str(&json).expect("deserialize legacy shape");
+
+            assert_eq!(restored.word(), "温度");
+            assert_eq!(restored.statement(), "спортивное состязание");
+            assert!(restored.is_correct());
+        }
+
+        #[test]
+        fn yesno_card_deserialize_legacy_without_separator() {
+            let json = format!(
+                r#"{{"card":{},"statement_text":"no separator here","is_correct":false}}"#,
+                sample_card_json()
+            );
+
+            let restored: YesNoCard =
+                serde_json::from_str(&json).expect("deserialize legacy shape");
+
+            assert_eq!(restored.word(), "");
+            assert_eq!(restored.statement(), "no separator here");
+            assert!(!restored.is_correct());
+        }
+
+        #[test]
+        fn yesno_card_deserialize_partial_new_shape_word_only() {
+            let json = format!(
+                r#"{{"card":{},"word":"温度","is_correct":true}}"#,
+                sample_card_json()
+            );
+
+            let restored: YesNoCard =
+                serde_json::from_str(&json).expect("deserialize partial new shape");
+
+            assert_eq!(restored.word(), "温度");
+            assert_eq!(restored.statement(), "");
+            assert!(restored.is_correct());
+        }
+
+        #[test]
+        fn yesno_card_deserialize_partial_new_shape_statement_only() {
+            let json = format!(
+                r#"{{"card":{},"statement":"only statement","is_correct":true}}"#,
+                sample_card_json()
+            );
+
+            let restored: YesNoCard =
+                serde_json::from_str(&json).expect("deserialize partial new shape");
+
+            assert_eq!(restored.word(), "");
+            assert_eq!(restored.statement(), "only statement");
+            assert!(restored.is_correct());
+        }
+
+        #[test]
+        fn yesno_card_deserialize_missing_card_errors() {
+            let json = r#"{"word":"温度","statement":"x","is_correct":true}"#;
+
+            let result: Result<YesNoCard, _> = serde_json::from_str(json);
+            assert!(
+                result.is_err(),
+                "missing `card` must be a hard error, not a silent default"
+            );
+        }
+
+        #[test]
+        fn yesno_card_deserialize_missing_is_correct_errors() {
+            let json = format!(
+                r#"{{"card":{},"word":"温度","statement":"x"}}"#,
+                sample_card_json()
+            );
+
+            let result: Result<YesNoCard, _> = serde_json::from_str(&json);
+            assert!(
+                result.is_err(),
+                "missing `is_correct` must be a hard error: the answer-key must not silently default"
+            );
+        }
+
+        #[test]
+        fn yesno_card_deserialize_prefers_new_fields_over_legacy_statement_text() {
+            let json = format!(
+                r#"{{"card":{},"word":"新","statement":"new-stmt","statement_text":"legacy \n old","is_correct":true}}"#,
+                sample_card_json()
+            );
+
+            let restored: YesNoCard = serde_json::from_str(&json).expect("deserialize mixed shape");
+
+            assert_eq!(restored.word(), "新");
+            assert_eq!(restored.statement(), "new-stmt");
+        }
+
+        /// Legacy statement_text without the `" \n "` separator (na-adjective
+        /// edge): the whole string lands in `statement`, `word` stays empty.
+        /// Pins the data-shape contract for the degraded legacy case.
+        #[test]
+        fn yesno_card_deserialize_legacy_na_adjective_edge() {
+            let json = format!(
+                r#"{{"card":{},"statement_text":"静か","is_correct":true}}"#,
+                sample_card_json()
+            );
+
+            let restored: YesNoCard =
+                serde_json::from_str(&json).expect("deserialize legacy shape");
+
+            assert_eq!(restored.word(), "");
+            assert_eq!(restored.statement(), "静か");
+        }
+
+        /// Minimal shape with only `card` + `is_correct` (no word/statement/
+        /// statement_text): both text fields default to empty rather than
+        /// erroring, since they are recoverable display-only data.
+        #[test]
+        fn yesno_card_deserialize_only_card_and_is_correct_yields_empty_strings() {
+            let json = format!(r#"{{"card":{},"is_correct":true}}"#, sample_card_json());
+
+            let restored: YesNoCard =
+                serde_json::from_str(&json).expect("deserialize minimal shape");
+
+            assert_eq!(restored.word(), "");
+            assert_eq!(restored.statement(), "");
+            assert!(restored.is_correct());
+        }
     }
 }

--- a/origa/src/domain/knowledge/lesson/view_generator/generation.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/generation.rs
@@ -141,11 +141,12 @@ pub(crate) fn generate_yesno(
         statement_answer
     };
 
-    let statement_text = format!("{} \n {}", question.text(), statement_answer);
+    let word = question.text().to_string();
 
     Ok(LessonCardView::YesNo(YesNoCard::new(
         original_card,
-        statement_text,
+        word,
+        statement_answer,
         is_correct,
     )))
 }

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/quiz.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/quiz.rs
@@ -422,9 +422,7 @@ mod generate_quiz_pos_filter_tests {
 
             if let Ok(LessonCardView::YesNo(yn)) = result {
                 if !yn.is_correct() {
-                    let uses_noun = noun_answers
-                        .iter()
-                        .any(|na| yn.statement_text().contains(na));
+                    let uses_noun = noun_answers.iter().any(|na| yn.statement().contains(na));
                     if uses_noun {
                         noun_used_count += 1;
                     }
@@ -455,7 +453,7 @@ mod generate_quiz_pos_filter_tests {
 
         match result.expect("should succeed") {
             LessonCardView::YesNo(yn) => {
-                assert!(!yn.statement_text().is_empty());
+                assert!(!yn.statement().is_empty());
             },
             other => panic!("Expected YesNo with fallback, got {:?}", other),
         }

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/types.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/types.rs
@@ -130,7 +130,7 @@ mod lesson_card_view_accessors {
     #[test]
     fn card_accessor_for_yesno_variant() {
         let vocab = create_vocab_card("猫");
-        let yesno = YesNoCard::new(vocab.clone(), "stmt".to_string(), true);
+        let yesno = YesNoCard::new(vocab.clone(), "word".to_string(), "stmt".to_string(), true);
         assert_eq!(LessonCardView::YesNo(yesno).card(), &vocab);
     }
 
@@ -183,7 +183,7 @@ mod lesson_card_view_accessors {
                 .grammar_info()
                 .is_none()
         );
-        let yesno = YesNoCard::new(vocab, "s".into(), true);
+        let yesno = YesNoCard::new(vocab, "w".into(), "s".into(), true);
         assert!(LessonCardView::YesNo(yesno).grammar_info().is_none());
     }
 }

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/yesno.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/yesno.rs
@@ -13,7 +13,7 @@ fn create_vocab_card_with_word(word: &str) -> Card {
 
 fn create_yesno_card(is_correct: bool) -> YesNoCard {
     let card = create_vocab_card_with_word("テスト");
-    YesNoCard::new(card, "テスト – тест".to_string(), is_correct)
+    YesNoCard::new(card, "テスト".to_string(), "тест".to_string(), is_correct)
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn test_generate_yesno_correct_statement() {
     assert!(result.is_ok());
     match result.unwrap() {
         LessonCardView::YesNo(yesno) => {
-            assert!(!yesno.statement_text().is_empty());
+            assert!(!yesno.statement().is_empty());
         },
         _ => panic!("Expected YesNo view"),
     }
@@ -88,7 +88,7 @@ fn test_generate_yesno_false_statement() {
     assert!(result.is_ok());
     match result.unwrap() {
         LessonCardView::YesNo(yesno) => {
-            assert!(!yesno.statement_text().is_empty());
+            assert!(!yesno.statement().is_empty());
         },
         _ => panic!("Expected YesNo view"),
     }
@@ -212,7 +212,7 @@ fn generate_yesno_kanji_with_distractors() {
 
     match result.expect("should succeed") {
         LessonCardView::YesNo(yn) => {
-            assert!(!yn.statement_text().is_empty());
+            assert!(!yn.statement().is_empty());
         },
         other => panic!("Expected YesNo for kanji, got {:?}", other),
     }
@@ -228,4 +228,44 @@ fn generate_yesno_kanji_fallback_no_distractors() {
         LessonCardView::Normal(c) => assert_eq!(c, card),
         other => panic!("Expected Normal fallback, got {:?}", other),
     }
+}
+
+#[test]
+fn generate_yesno_stores_word_and_statement_separately() {
+    init_real_dictionaries();
+
+    let vocab_words = ["猫", "犬", "鳥", "魚"];
+    let cards: Vec<Card> = vocab_words
+        .iter()
+        .map(|w| create_vocab_card_with_word(w))
+        .collect();
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let result = generation::generate_yesno(
+        cards[0].clone(),
+        &cards[1..],
+        &NativeLanguage::Russian,
+        &mut rng,
+    );
+
+    let yesno = match result.expect("should succeed") {
+        LessonCardView::YesNo(yn) => yn,
+        other => panic!("Expected YesNo, got {other:?}"),
+    };
+
+    let expected_word = cards[0]
+        .question(&NativeLanguage::Russian)
+        .expect("question")
+        .text()
+        .to_string();
+    assert_eq!(yesno.word(), expected_word);
+    assert!(
+        !yesno.word().contains(" \n "),
+        "word must not embed the legacy separator: {}",
+        yesno.word()
+    );
+    assert!(
+        !yesno.statement().is_empty(),
+        "statement must carry the answer/distractor"
+    );
 }

--- a/origa/src/domain/tokenizer/mod.rs
+++ b/origa/src/domain/tokenizer/mod.rs
@@ -356,8 +356,28 @@ fn non_japanese_token(segment: &str, is_whitespace: bool) -> TokenInfo {
 
 /// Suffixes that Lindera sometimes over-merges with preceding nouns into a
 /// single ProperNoun token. When found at the end of a ProperNoun, the token
-/// is split so the suffix gets its own token (with correct POS + translation).
-const SPLITTABLE_SUFFIXES: &[&str] = &["なし"];
+/// is split so the suffix gets its own token. Each entry pairs the suffix
+/// surface with the POS the split suffix token should carry: なし is a noun
+/// suffix (absence), while くらい/ぐらい are particles (degree/extent).
+struct SplittableSuffix {
+    surface: &'static str,
+    pos: PartOfSpeech,
+}
+
+const SPLITTABLE_SUFFIXES: &[SplittableSuffix] = &[
+    SplittableSuffix {
+        surface: "なし",
+        pos: PartOfSpeech::Noun,
+    },
+    SplittableSuffix {
+        surface: "くらい",
+        pos: PartOfSpeech::Particle,
+    },
+    SplittableSuffix {
+        surface: "ぐらい",
+        pos: PartOfSpeech::Particle,
+    },
+];
 
 /// Post-processing step: split ProperNoun tokens ending in known productive
 /// suffixes (e.g. 水なし → 水 + なし). Lindera sometimes merges noun + suffix
@@ -376,8 +396,8 @@ fn split_compound_proper_nouns(tokens: &mut Vec<TokenInfo>) {
 
         let surface = tokens[i].orthographic_surface_form();
         match find_splittable_suffix(surface) {
-            Some((prefix, suffix)) => {
-                let split = split_at_suffix(&tokens[i], &prefix, &suffix);
+            Some((prefix, suffix, suffix_pos)) => {
+                let split = split_at_suffix(&tokens[i], &prefix, suffix, suffix_pos);
                 tokens.splice(i..=i, split);
                 i += 2;
             },
@@ -394,7 +414,12 @@ fn split_compound_proper_nouns(tokens: &mut Vec<TokenInfo>) {
 /// surface/reading lengths automatically. If the merged reading does not end
 /// in the suffix's katakana form (unexpected), falls back to using surface
 /// forms as readings.
-fn split_at_suffix(token: &TokenInfo, prefix: &str, suffix: &str) -> [TokenInfo; 2] {
+fn split_at_suffix(
+    token: &TokenInfo,
+    prefix: &str,
+    suffix: &str,
+    suffix_pos: PartOfSpeech,
+) -> [TokenInfo; 2] {
     let merged_reading = token.phonological_surface_form();
     let (prefix_reading, suffix_reading) = split_reading(merged_reading, suffix);
 
@@ -411,7 +436,7 @@ fn split_at_suffix(token: &TokenInfo, prefix: &str, suffix: &str) -> [TokenInfo;
             phonological_base_form: suffix_reading.clone(),
             orthographic_surface_form: suffix.to_string(),
             phonological_surface_form: suffix_reading,
-            part_of_speech: PartOfSpeech::Noun,
+            part_of_speech: suffix_pos,
         },
     ]
 }
@@ -427,13 +452,13 @@ fn split_reading(merged_reading: &str, suffix: &str) -> (String, String) {
     (merged_reading.to_string(), suffix.to_string())
 }
 
-fn find_splittable_suffix(surface: &str) -> Option<(String, String)> {
+fn find_splittable_suffix(surface: &str) -> Option<(String, &'static str, PartOfSpeech)> {
     for suffix in SPLITTABLE_SUFFIXES {
-        if let Some(prefix_str) = surface.strip_suffix(*suffix) {
+        if let Some(prefix_str) = surface.strip_suffix(suffix.surface) {
             // Prefix must be non-empty AND contain at least one kanji,
             // otherwise we'd split katakana names or hiragana fragments.
             if !prefix_str.is_empty() && prefix_str.chars().any(|c| c.is_kanji()) {
-                return Some((prefix_str.to_string(), suffix.to_string()));
+                return Some((prefix_str.to_string(), suffix.surface, suffix.pos.clone()));
             }
         }
     }
@@ -774,6 +799,34 @@ mod tests {
         assert_eq!(tokens[1].part_of_speech(), &PartOfSpeech::Noun);
         // Trailing token must survive the splice unchanged.
         assert_eq!(tokens[2].orthographic_surface_form(), "で");
+        assert_eq!(tokens[2].part_of_speech(), &PartOfSpeech::Particle);
+    }
+
+    // 努力くらい is over-merged by Lindera into a single ProperNoun (ドリョクライ),
+    // swallowing the くらい particle. The splitter must split it into 努力
+    // (Noun) + くらい (Particle) so the particle carries its own token. Unlike
+    // なし, the くらい suffix is a particle, so its split token's POS is derived
+    // from the SplittableSuffix mapping rather than hardcoded Noun.
+    #[test]
+    fn should_split_doryokukurai_proper_noun() {
+        let mut tokens = vec![
+            TokenInfo::new_test_with_reading(
+                "努力くらい",
+                "ドリョククライ",
+                PartOfSpeech::ProperNoun,
+            ),
+            TokenInfo::new_test("は", PartOfSpeech::Particle),
+        ];
+        split_compound_proper_nouns(&mut tokens);
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(tokens[0].orthographic_surface_form(), "努力");
+        assert_eq!(tokens[0].phonological_surface_form(), "ドリョク");
+        assert_eq!(tokens[0].part_of_speech(), &PartOfSpeech::Noun);
+        assert_eq!(tokens[1].orthographic_surface_form(), "くらい");
+        assert_eq!(tokens[1].phonological_surface_form(), "クライ");
+        assert_eq!(tokens[1].part_of_speech(), &PartOfSpeech::Particle);
+        // Trailing token must survive the splice unchanged.
+        assert_eq!(tokens[2].orthographic_surface_form(), "は");
         assert_eq!(tokens[2].part_of_speech(), &PartOfSpeech::Particle);
     }
 

--- a/origa/src/domain/tokenizer/translation.rs
+++ b/origa/src/domain/tokenizer/translation.rs
@@ -16,6 +16,44 @@ pub struct TokenTranslation {
     pub pos: PartOfSpeech,
     pub translation: Option<String>,
     pub grammar_label: Option<String>,
+    pub grammar_description: Option<String>,
+}
+
+/// A grammar rule match carried through the resolution pipeline: the rule
+/// title (surfaced as `grammar_label`) plus the rule's `short_description`
+/// (surfaced as `grammar_description`). Keeping both together avoids a second
+/// rule lookup and ensures the description always corresponds to the matched
+/// rule rather than a re-resolved one.
+struct GrammarMatch {
+    title: String,
+    short_description: String,
+}
+
+impl GrammarMatch {
+    fn from_rule(rule: &GrammarRule, native_language: &NativeLanguage) -> Self {
+        let content = rule.content(native_language);
+        Self {
+            title: content.title().to_string(),
+            short_description: content.short_description().to_string(),
+        }
+    }
+}
+
+/// Splits a `GrammarMatch` into the two `TokenTranslation` fields. The
+/// description is `None` when the matched rule has an empty `short_description`
+/// so the popup does not render an empty line.
+fn split_grammar_fields(grammar: Option<GrammarMatch>) -> (Option<String>, Option<String>) {
+    match grammar {
+        Some(m) => {
+            let description = if m.short_description.is_empty() {
+                None
+            } else {
+                Some(m.short_description)
+            };
+            (Some(m.title), description)
+        },
+        None => (None, None),
+    }
 }
 
 // Particle homonyms whose surface form (て/し) collides with a dictionary lemma
@@ -35,6 +73,12 @@ pub fn lookup_tokens_translations(
     native_language: &NativeLanguage,
     original_text: &str,
 ) -> Vec<TokenTranslation> {
+    // Computed once for the whole phrase: the katakana→hiragana equivalent of
+    // the input lets `match_grammar_keyword` match katakana-written tokens
+    // (e.g. ベキ) against hiragana grammar keywords (e.g. べき) without
+    // re-normalizing the same text for every token and rule.
+    let original_hiragana = katakana_to_hiragana(original_text);
+
     tokens
         .iter()
         .enumerate()
@@ -46,8 +90,11 @@ pub fn lookup_tokens_translations(
                 get_translation(&base_form, native_language)
             };
 
-            let grammar_label = resolve_sou_da_label(token, index, tokens, native_language)
-                .or_else(|| resolve_grammar_label(token, native_language, original_text));
+            let grammar =
+                resolve_sou_da_match(token, index, tokens, native_language).or_else(|| {
+                    resolve_grammar_match(token, native_language, original_text, &original_hiragana)
+                });
+            let (grammar_label, grammar_description) = split_grammar_fields(grammar);
 
             TokenTranslation {
                 surface_form: token.orthographic_surface_form().to_string(),
@@ -56,26 +103,35 @@ pub fn lookup_tokens_translations(
                 pos: token.part_of_speech().clone(),
                 translation,
                 grammar_label,
+                grammar_description,
             }
         })
         .collect()
 }
 
 fn match_grammar_keyword(
-    rules: &[GrammarRule],
+    rules: &'static [GrammarRule],
     surface: &str,
+    surface_hiragana: &str,
     original_text: &str,
-    native_language: &NativeLanguage,
-) -> Option<String> {
+    original_hiragana: &str,
+) -> Option<&'static GrammarRule> {
     for rule in rules.iter() {
         let keyword_groups = rule.keywords();
         if keyword_groups.is_empty() {
             continue;
         }
 
-        let token_matches_some_group = keyword_groups
-            .iter()
-            .any(|group| group.iter().any(|kw| surface == kw));
+        // Match the token surface against a keyword, accepting either the
+        // raw surface (hiragana input) or its katakana→hiragana equivalent
+        // (katakana input like ベキ → べき). This is a monotonic OR extension:
+        // it can only add matches for katakana forms that normalize to an
+        // existing keyword, never drop a hiragana match.
+        let token_matches_some_group = keyword_groups.iter().any(|group| {
+            group
+                .iter()
+                .any(|kw| surface == kw || surface_hiragana == kw)
+        });
         if !token_matches_some_group {
             continue;
         }
@@ -83,24 +139,31 @@ fn match_grammar_keyword(
         // Every group must contribute at least one keyword present in the original
         // text. This converges with detect_keyword_rules AND-semantics and prevents
         // bare-single-keyword false positives (e.g. topic は falsely matching the
-        // ～は～ほど～ない rule when ほど is absent from the sentence).
-        let text_covers_all_groups = keyword_groups
-            .iter()
-            .all(|group| !group.is_empty() && group.iter().any(|kw| original_text.contains(kw)));
+        // ～は～ほど～ない rule when ほど is absent from the sentence). The katakana
+        // equivalent of the text is also accepted so a katakana-written phrase
+        // (ベキ) still covers its hiragana keyword (べき).
+        let text_covers_all_groups = keyword_groups.iter().all(|group| {
+            !group.is_empty()
+                && group
+                    .iter()
+                    .any(|kw| original_text.contains(kw) || original_hiragana.contains(kw))
+        });
         if text_covers_all_groups {
-            return Some(rule.content(native_language).title().to_string());
+            return Some(rule);
         }
     }
     None
 }
 
-fn resolve_grammar_label(
+fn resolve_grammar_match(
     token: &TokenInfo,
     native_language: &NativeLanguage,
     original_text: &str,
-) -> Option<String> {
+    original_hiragana: &str,
+) -> Option<GrammarMatch> {
     let rules = GRAMMAR_RULES.get()?;
     let surface = token.orthographic_surface_form();
+    let surface_hiragana = katakana_to_hiragana(surface);
     let base = token.orthographic_base_form();
     let pos = token.part_of_speech();
     let is_vocab = pos.is_vocabulary_word();
@@ -114,8 +177,14 @@ fn resolve_grammar_label(
     // See issue #178 P-6 for context.
     let eligible_for_keyword_match = !is_vocab || surface == base;
     if eligible_for_keyword_match {
-        if let Some(label) = match_grammar_keyword(rules, surface, original_text, native_language) {
-            return Some(label);
+        if let Some(rule) = match_grammar_keyword(
+            rules,
+            surface,
+            &surface_hiragana,
+            original_text,
+            original_hiragana,
+        ) {
+            return Some(GrammarMatch::from_rule(rule, native_language));
         }
     }
 
@@ -124,8 +193,14 @@ fn resolve_grammar_label(
         // base すぎる, classified by Lindera as Verb) must still resolve to their
         // grammar keyword before format_map matching — otherwise a more generic
         // rule (～て) wins on the te-form surface.
-        if let Some(label) = match_grammar_keyword(rules, surface, original_text, native_language) {
-            return Some(label);
+        if let Some(rule) = match_grammar_keyword(
+            rules,
+            surface,
+            &surface_hiragana,
+            original_text,
+            original_hiragana,
+        ) {
+            return Some(GrammarMatch::from_rule(rule, native_language));
         }
 
         let mut matches = find_format_map_matches(base, pos, original_text, rules);
@@ -160,7 +235,7 @@ fn resolve_grammar_label(
                 .unwrap_or(0);
             kanji_len.max(hira_len)
         }) {
-            return Some(best.content(native_language).title().to_string());
+            return Some(GrammarMatch::from_rule(best, native_language));
         }
     }
 
@@ -183,17 +258,17 @@ enum SouDaVariant {
 ///   past/copula auxiliary (降った→降ったそうだ, 元気だ→元気だそうだ).
 ///
 /// A standalone そう that is NOT part of a そうだ construction (the demonstrative
-/// manner adverb そう in そう思う, そうですね) must be left to `resolve_grammar_label`
+/// manner adverb そう in そう思う, そうですね) must be left to `resolve_grammar_match`
 /// so the manner rule `こう・そう・ああ・どう` can match — this function returns
 /// `None` whenever the preceding token is not a predicate the pattern could
 /// attach to (particle, adverb, pronoun, ...) or when a sentence boundary
 /// separates そう from any predecessor.
-fn resolve_sou_da_label(
+fn resolve_sou_da_match(
     token: &TokenInfo,
     index: usize,
     tokens: &[TokenInfo],
     native_language: &NativeLanguage,
-) -> Option<String> {
+) -> Option<GrammarMatch> {
     let surface = token.orthographic_surface_form();
 
     // Lindera splits the grammar pattern into a standalone そう token followed
@@ -244,7 +319,7 @@ fn resolve_sou_da_label(
 
     let rules = GRAMMAR_RULES.get()?;
 
-    if is_stem_form {
+    let rule = if is_stem_form {
         find_sou_rule(rules, native_language, SouDaVariant::Appearance)
     } else if is_plain_form || is_ta_or_da_aux {
         find_sou_rule(rules, native_language, SouDaVariant::Hearsay)
@@ -252,7 +327,9 @@ fn resolve_sou_da_label(
         find_sou_rule(rules, native_language, SouDaVariant::Combined)
     } else {
         None
-    }
+    };
+
+    rule.map(|r| GrammarMatch::from_rule(r, native_language))
 }
 
 /// Locates the nearest content token preceding `index`, stopping at a sentence
@@ -291,10 +368,10 @@ fn is_sentence_boundary(token: &TokenInfo) -> bool {
 /// ～とか（伝聞）). Falls back to any `そうだ` rule when the dictionary lacks a
 /// variant-specific entry.
 fn find_sou_rule(
-    rules: &[GrammarRule],
+    rules: &'static [GrammarRule],
     native_language: &NativeLanguage,
     variant: SouDaVariant,
-) -> Option<String> {
+) -> Option<&'static GrammarRule> {
     let term_groups: &[&[&str]] = match variant {
         SouDaVariant::Appearance => &[&["そうだ（様態）"], &["そうだ"]],
         SouDaVariant::Hearsay => &[&["そうだ（伝聞）"], &["そうだ"]],
@@ -305,7 +382,7 @@ fn find_sou_rule(
         for rule in rules.iter() {
             let title = rule.content(native_language).title();
             if terms.iter().any(|term| title.contains(term)) {
-                return Some(title.to_string());
+                return Some(rule);
             }
         }
     }
@@ -441,6 +518,38 @@ mod tests {
             "テ",
             PartOfSpeech::Particle
         )));
+    }
+
+    #[test]
+    fn split_grammar_fields_returns_both_when_description_present() {
+        let m = GrammarMatch {
+            title: "～test".to_string(),
+            short_description: "desc".to_string(),
+        };
+        let (label, description) = split_grammar_fields(Some(m));
+        assert_eq!(label.as_deref(), Some("～test"));
+        assert_eq!(description.as_deref(), Some("desc"));
+    }
+
+    #[test]
+    fn split_grammar_fields_drops_description_when_empty() {
+        let m = GrammarMatch {
+            title: "～test".to_string(),
+            short_description: String::new(),
+        };
+        let (label, description) = split_grammar_fields(Some(m));
+        assert_eq!(label.as_deref(), Some("～test"));
+        assert!(
+            description.is_none(),
+            "empty short_description must surface as None so the popup renders no line"
+        );
+    }
+
+    #[test]
+    fn split_grammar_fields_returns_none_none_when_no_match() {
+        let (label, description) = split_grammar_fields(None);
+        assert!(label.is_none());
+        assert!(description.is_none());
     }
 }
 
@@ -760,6 +869,84 @@ mod integration_tests {
         );
     }
 
+    // べき carries the べきだ grammar rule, whose short_description is non-empty
+    // (RU «Следует…; должен…», EN «Should…»). The popup must surface that
+    // description as grammar_description so べき is no longer shown title-only.
+    // Asserting the description content (not just non-empty) guards against a
+    // wiring error that attached the wrong field.
+    #[test]
+    fn tokenize_standalone_beki_returns_grammar_description() {
+        ensure_dictionaries();
+        let text = "べき";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
+
+        let beki = results
+            .iter()
+            .find(|t| t.surface_form == "べき")
+            .expect("「べき」standalone token should exist");
+        assert!(
+            beki.grammar_label
+                .as_ref()
+                .is_some_and(|label| label.contains("べき")),
+            "standalone「べき」should carry the べきだ grammar_label, got: {:?}",
+            beki
+        );
+        assert!(
+            beki.grammar_description
+                .as_ref()
+                .is_some_and(|d| d.contains("Should")),
+            "standalone「べき」should carry the べきだ grammar_description, got: {:?}",
+            beki.grammar_description
+        );
+    }
+
+    // Katakana ベキ (e.g. emphasis or stylised writing) must still match the
+    // べきだ rule: match_grammar_keyword normalises the katakana surface to
+    // hiragana (ベキ → べき) and the katakana input text to cover the keyword.
+    // Robust to whether Lindera keeps ベキ as katakana or normalises to べき.
+    #[test]
+    fn should_match_katakana_beki_via_normalization() {
+        ensure_dictionaries();
+        let text = "ベキ";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
+
+        let beki = results
+            .iter()
+            .find(|t| t.surface_form == "ベキ" || t.surface_form == "べき")
+            .expect("「ベキ/べき」token should exist");
+        assert!(
+            beki.grammar_label
+                .as_ref()
+                .is_some_and(|label| label.contains("べき")),
+            "katakana「ベキ」should match the べき grammar rule via hiragana normalization, got: {:?}",
+            beki
+        );
+    }
+
+    // The katakana→hiragana normalization is a monotonic OR extension: it can
+    // only add matches for katakana forms that normalise to an existing keyword.
+    // A katakana content word (テスト, "test") whose hiragana equivalent (てすと)
+    // is not a grammar keyword must NOT receive a spurious grammar_label.
+    #[test]
+    fn should_not_overmatch_katakana_content_word() {
+        ensure_dictionaries();
+        let text = "テスト";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::English, text);
+
+        let tesuto = results
+            .iter()
+            .find(|t| t.surface_form == "テスト")
+            .expect("「テスト」token should exist");
+        assert!(
+            tesuto.grammar_label.is_none(),
+            "katakana content word「テスト」must not receive a spurious grammar_label via normalization, got: {:?}",
+            tesuto.grammar_label
+        );
+    }
+
     // Negative test for the relaxed grammar_label gate: a common content
     // noun in dictionary form (猫, "cat") must NOT pick up a spurious
     // grammar_label just because surface == base. Guards against the
@@ -925,6 +1112,42 @@ mod integration_tests {
         assert_ne!(
             nashi.reading, "なし",
             "「なし」reading must be katakana ナシ derived from merged token"
+        );
+    }
+
+    // --- 努力くらいはしてみるよ ---
+    // Lindera over-merges 努力くらい into a single ProperNoun (ドリョクライ),
+    // leaving くらい with no token at all. The splitter must split it into
+    // 努力 (Noun) + くらい (Particle). The くらい grammar rule has AND-semantics
+    // keyword groups ([["くらい"],["ぐらい"]]) that require BOTH forms in the
+    // text, so くらい does NOT receive a grammar_label here — the split itself
+    // is the fix; the grammar_label data gap is a separate cdn/ concern.
+    #[test]
+    fn should_split_doryokukurai_compound() {
+        ensure_dictionaries();
+        let text = "努力くらいはしてみるよ";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+
+        let merged = results.iter().find(|t| t.surface_form == "努力くらい");
+        assert!(
+            merged.is_none(),
+            "「努力くらい」should be split into separate tokens, got merged token: {:?}",
+            merged
+        );
+
+        let _doryoku = results
+            .iter()
+            .find(|t| t.surface_form == "努力" && t.pos == PartOfSpeech::Noun)
+            .expect("「努力」noun should exist after split");
+
+        let kurai = results
+            .iter()
+            .find(|t| t.surface_form == "くらい" && t.pos == PartOfSpeech::Particle)
+            .expect("「くらい」particle token should exist after split");
+        assert_ne!(
+            kurai.reading, "くらい",
+            "「くらい」reading must be a katakana reading derived from the merged token, not the hiragana surface"
         );
     }
 

--- a/origa/src/use_cases/tests/journeys/yesno_journey.rs
+++ b/origa/src/use_cases/tests/journeys/yesno_journey.rs
@@ -33,8 +33,13 @@ fn create_user_with_real_vocab_cards(words: &[&str]) -> User {
     user
 }
 
-fn create_yesno_card_with_words(card: Card, statement_text: String, is_correct: bool) -> YesNoCard {
-    YesNoCard::new(card, statement_text, is_correct)
+fn create_yesno_card_with_words(
+    card: Card,
+    word: String,
+    statement: String,
+    is_correct: bool,
+) -> YesNoCard {
+    YesNoCard::new(card, word, statement, is_correct)
 }
 
 #[tokio::test]
@@ -57,8 +62,9 @@ async fn yesno_journey_correct_answer_results_in_good_rating() {
     // Создаём YesNo с верным утверждением (is_correct = true)
     let question = card.question(&NativeLanguage::Russian).unwrap();
     let answer = card.answer(&NativeLanguage::Russian).unwrap();
-    let statement_text = format!("{} – {}", question.text(), answer_display_text(&answer));
-    let yesno = create_yesno_card_with_words(card.clone(), statement_text, true);
+    let word = question.text().to_string();
+    let statement = answer_display_text(&answer);
+    let yesno = create_yesno_card_with_words(card.clone(), word, statement, true);
 
     // Act: пользователь отвечает "Да" на верное утверждение
     let user_said_yes = true;
@@ -108,8 +114,9 @@ async fn yesno_journey_wrong_answer_results_in_again_rating() {
     // Создаём YesNo с верным утверждением (is_correct = true)
     let question = card.question(&NativeLanguage::Russian).unwrap();
     let answer = card.answer(&NativeLanguage::Russian).unwrap();
-    let statement_text = format!("{} – {}", question.text(), answer_display_text(&answer));
-    let yesno = create_yesno_card_with_words(card.clone(), statement_text, true);
+    let word = question.text().to_string();
+    let statement = answer_display_text(&answer);
+    let yesno = create_yesno_card_with_words(card.clone(), word, statement, true);
 
     // Act: пользователь отвечает "Нет" на верное утверждение (неправильно)
     let user_said_yes = false;
@@ -153,10 +160,11 @@ async fn yesno_journey_false_statement_correct_no_answer() {
         .question(&NativeLanguage::Russian)
         .unwrap();
     let distractor_answer = "собака"; // Неверный ответ (дистрактор)
-    let statement_text = format!("{} – {}", question.text(), distractor_answer);
+    let word = question.text().to_string();
     let yesno = create_yesno_card_with_words(
         Card::Vocabulary(card),
-        statement_text,
+        word,
+        distractor_answer.to_string(),
         false, // is_correct = false
     );
 
@@ -181,10 +189,11 @@ async fn yesno_journey_false_statement_wrong_yes_answer() {
         .question(&NativeLanguage::Russian)
         .unwrap();
     let distractor_answer = "собака"; // Неверный ответ
-    let statement_text = format!("{} – {}", question.text(), distractor_answer);
+    let word = question.text().to_string();
     let yesno = create_yesno_card_with_words(
         Card::Vocabulary(card),
-        statement_text,
+        word,
+        distractor_answer.to_string(),
         false, // is_correct = false
     );
 
@@ -258,8 +267,9 @@ async fn yesno_journey_all_rating_cases(
     // Создаём YesNo карточку с нужным значением is_correct
     let question = card.question(&NativeLanguage::Russian).unwrap();
     let answer = card.answer(&NativeLanguage::Russian).unwrap();
-    let statement_text = format!("{} – {}", question.text(), answer_display_text(&answer));
-    let yesno = create_yesno_card_with_words(card, statement_text, statement_is_correct);
+    let word = question.text().to_string();
+    let statement = answer_display_text(&answer);
+    let yesno = create_yesno_card_with_words(card, word, statement, statement_is_correct);
 
     // Act: Проверяем ответ и определяем рейтинг
     let is_answer_correct = yesno.check_answer(user_said_yes);

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1751,6 +1751,13 @@ rt {
     margin-top: var(--space-xs);
 }
 
+.token-popup-grammar-description {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-muted);
+    margin-top: var(--space-xs);
+}
+
 .kanji-animation-container {
     display: flex;
     flex-direction: column;

--- a/origa_ui/src/pages/lesson/yesno_card_view.rs
+++ b/origa_ui/src/pages/lesson/yesno_card_view.rs
@@ -54,12 +54,13 @@ pub fn YesNoCardView(
     let is_na_adj = super::na_adjective_helper::is_na_adjective_card(&card);
     let part_of_speech = card.vocabulary_part_of_speech();
 
-    let statement_text_raw = yesno_card.statement_text().to_string();
-    let statement = StoredValue::new(if is_na_adj {
-        super::na_adjective_helper::append_na_suffix(&statement_text_raw)
+    let word_raw = yesno_card.word().to_string();
+    let display_word = StoredValue::new(if is_na_adj {
+        super::na_adjective_helper::append_na_suffix(&word_raw)
     } else {
-        statement_text_raw.clone()
+        word_raw
     });
+    let statement_value = StoredValue::new(yesno_card.statement().to_string());
     let is_statement_correct = yesno_card.is_correct();
 
     let question_text_raw = match card.question(&lang) {
@@ -189,9 +190,9 @@ pub fn YesNoCardView(
             <div class="flex-1 flex flex-col justify-center">
                 <div class="text-center mb-3 sm:mb-6">
                     <Show when=move || kanji_for_animation.get_value().is_none()>
-                        <div class="mb-4">
+                        <div class="mb-2 sm:mb-3">
                             <MarkdownText
-                                content=Signal::derive(move || statement.get_value())
+                                content=Signal::derive(move || display_word.get_value())
                                 known_kanji=known_kanji.get()
                                 variant=Signal::derive(|| MarkdownVariant::Large)
                             />
@@ -200,21 +201,21 @@ pub fn YesNoCardView(
 
                     <Show when=move || kanji_for_animation.get_value().is_some()>
                         {move || {
-                            let stmt = statement.get_value();
                             kanji_for_animation.get_value().map(|kanji: String| {
                                 view! {
-                                    <div class="mb-3 sm:mb-6">
+                                    <div class="mb-2 sm:mb-3">
                                         <DisplayText>
                                             {kanji}
                                         </DisplayText>
                                     </div>
-                                    <Text size=TextSize::Default variant=TypographyVariant::Muted>
-                                        {stmt}
-                                    </Text>
                                 }
                             })
                         }}
                     </Show>
+
+                    <Text size=TextSize::Default variant=TypographyVariant::Muted>
+                        {move || statement_value.get_value()}
+                    </Text>
 
                     <Text size=TextSize::Default variant=TypographyVariant::Muted class="mt-4">
                         {t!(i18n, lesson.is_this_correct)}

--- a/origa_ui/src/ui_components/translator.rs
+++ b/origa_ui/src/ui_components/translator.rs
@@ -105,6 +105,7 @@ pub fn TranslatorText(
                         let base_form = token.base_form.clone();
                         let translation_text = token.translation.clone();
                         let grammar_label = token.grammar_label.clone();
+                        let grammar_description = token.grammar_description.clone();
                         let clickable = token.pos.is_vocabulary_word() || grammar_label.is_some();
                         let has_kanji = has_kanji(&surface);
                         let show_base = base_form != surface;
@@ -167,6 +168,15 @@ pub fn TranslatorText(
                                                     {if let Some(label) = &grammar_label {
                                                         view! {
                                                             <div class="token-popup-grammar">{label.clone()}</div>
+                                                        }.into_any()
+                                                    } else {
+                                                        ().into_any()
+                                                    }}
+                                                    {if let Some(description) = &grammar_description {
+                                                        view! {
+                                                            <div class="token-popup-grammar-description">
+                                                                {description.clone()}
+                                                            </div>
                                                         }.into_any()
                                                     } else {
                                                         ().into_any()


### PR DESCRIPTION
## Summary

Three bug fixes across tokenizer and lesson modules:

1. **Grammar description in token popup** — Grammar-auxiliary tokens (べき, はず, ところ, etc.) previously showed only the rule title in the translator popup, with no description. Now surfaces short_description from the grammar rule data via a GrammarMatch value-object refactor. Also normalizes katakana surfaces (ベキ→べき) for keyword matching.

2. **くらい/ぐらい particle split** — The tokenizer merged くらい/ぐらい into the preceding ProperNoun token (e.g. 努力くらい → single token). Adds a data-driven SplittableSuffix table to split them into separate tokens with correct POS (Particle). Code-only approach — user_dictionary.csv was deliberately avoided (broke furigana rendering, per PR #197).

3. **Yes/No card two-line layout** — The single statement_text field joined the Japanese word and its translation with a soft newline that Markdown collapsed to one line (e.g. '温度 спортивное состязание, матч, игра'). Replaced with two explicit word + statement fields rendered as separate DOM elements. Includes legacy statement_text backfill via custom Deserialize.

## Notes

- cdn/grammar/grammar.json くらい keyword AND→OR data fix is NOT in this PR (cdn/ is gitignored) and ships separately via deploy_cdn.py.

## Test results

- origa: 1456 tests pass
- origa_ui: 230 tests pass
- clippy/fmt: clean