### PR TITLE
fix(lesson): 50% lenient pass + reactive PhraseListen result rendering

### DIFF
--- a/origa/src/domain/knowledge/lesson/types.rs
+++ b/origa/src/domain/knowledge/lesson/types.rs
@@ -149,7 +149,7 @@ impl MultiQuizResult {
     pub fn is_lenient_pass(&self) -> bool {
         self.wrong_selections.is_empty()
             && self.correct_selections.len() * 2
-                > (self.correct_selections.len() + self.missed.len())
+                >= (self.correct_selections.len() + self.missed.len())
     }
 
     pub fn rating_lenient(&self) -> Rating {

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/kanji_reading_quiz.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/kanji_reading_quiz.rs
@@ -419,12 +419,26 @@ fn rating_lenient_returns_again_for_minority() {
 
     let result = MultiQuizResult {
         correct_selections: vec![0],
-        missed: vec![1],
+        missed: vec![1, 2],
         wrong_selections: vec![],
         is_perfect: false,
     };
 
     assert_eq!(result.rating_lenient(), Rating::Again);
+}
+
+#[test]
+fn rating_lenient_returns_good_for_half() {
+    use crate::domain::knowledge::lesson::types::MultiQuizResult;
+
+    let result = MultiQuizResult {
+        correct_selections: vec![0],
+        missed: vec![1],
+        wrong_selections: vec![],
+        is_perfect: false,
+    };
+
+    assert_eq!(result.rating_lenient(), Rating::Good);
 }
 
 #[test]

--- a/origa_ui/src/pages/lesson/lesson_card_container.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_container.rs
@@ -229,7 +229,6 @@ pub fn LessonCardContainer() -> impl IntoView {
                             if let LessonCardView::PhraseListen { card, audio_file, options } = lesson_card.into_view() {
                                 let state = lesson_state.get();
                                 let selected_option = state.selected_quiz_option;
-                                let show_result = state.showing_answer;
                                 let card_type = CardType::from(&card);
                                 let phrase_text = card.question(&native_language.get()).ok().map(|q| q.text().to_string());
                                 let phrase_translation = {
@@ -254,7 +253,7 @@ pub fn LessonCardContainer() -> impl IntoView {
                                         card_type=card_type
                                         audio_file=audio_file
                                         options=options
-                                        show_result=show_result
+                                        show_result=Signal::derive(move || lesson_state.get().showing_answer)
                                         selected_option=selected_option
                                         on_select_option=on_quiz_select
                                         on_dont_know=on_quiz_dont_know
@@ -262,7 +261,7 @@ pub fn LessonCardContainer() -> impl IntoView {
                                         phrase_text=phrase_text
                                         phrase_translation=phrase_translation
                                         known_kanji=Signal::from(known_kanji)
-                                        waiting_for_next=state.waiting_for_next
+                                        waiting_for_next=Signal::derive(move || lesson_state.get().waiting_for_next)
                                         on_next_card=on_next_card
                                     />
                                 })

--- a/origa_ui/src/pages/lesson/phrase_card.rs
+++ b/origa_ui/src/pages/lesson/phrase_card.rs
@@ -16,7 +16,7 @@ pub fn PhraseCardView(
     card_type: CardType,
     audio_file: String,
     options: Vec<QuizOption>,
-    show_result: bool,
+    show_result: Signal<bool>,
     selected_option: Option<usize>,
     on_select_option: Callback<usize>,
     on_dont_know: Callback<()>,
@@ -24,7 +24,7 @@ pub fn PhraseCardView(
     phrase_text: Option<String>,
     phrase_translation: Option<String>,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
-    waiting_for_next: bool,
+    waiting_for_next: Signal<bool>,
     on_next_card: Callback<()>,
 ) -> impl IntoView {
     let i18n = use_i18n();
@@ -36,7 +36,7 @@ pub fn PhraseCardView(
     let phrase_translation_stored = StoredValue::new(phrase_translation);
 
     let quiz_result = move || {
-        if dont_know_selected && show_result {
+        if dont_know_selected && show_result.get() {
             return QuizResult::DontKnow;
         }
         if let Some(selected) = selected_option {
@@ -87,9 +87,9 @@ pub fn PhraseCardView(
                                 let is_correct = option.is_correct();
                                 let is_selected = selected_option == Some(index);
                                 let base_class = "p-2 sm:p-4 border text-left transition-all cursor-pointer relative flex flex-col justify-center min-h-[4rem]";
-                                let disabled_class = if show_result { "pointer-events-none" } else { "" };
+                                let disabled_class = if show_result.get() { "pointer-events-none" } else { "" };
                                 let result_class = quiz_result().option_class(is_correct, is_selected);
-                                let selected_ring = if is_selected && !show_result {
+                                let selected_ring = if is_selected && !show_result.get() {
                                     "ring-2 ring-[var(--accent-olive)]"
                                 } else {
                                     ""
@@ -109,7 +109,7 @@ pub fn PhraseCardView(
                                         class=class
                                         data-testid=format!("quiz-option-{}", index)
                                         on:click=move |_| {
-                                            if !show_result {
+                                            if !show_result.get() {
                                                 on_select_option.run(index);
                                             }
                                         }
@@ -122,7 +122,7 @@ pub fn PhraseCardView(
                                                     known_kanji=known_kanji.get()
                                                 />
                                             </Text>
-                                            <Show when=move || !show_result>
+                                            <Show when=move || !show_result.get()>
                                                 <span class="text-[var(--fg-muted)] text-xs font-mono shrink-0">
                                                     {key_hint.clone()}
                                                 </span>
@@ -134,7 +134,7 @@ pub fn PhraseCardView(
                             .collect::<Vec<_>>()
                     }}
                 </div>
-                <Show when=move || !show_result>
+                <Show when=move || !show_result.get()>
                     <button
                         data-testid="quiz-dont-know-btn"
                         class=move || {
@@ -146,7 +146,7 @@ pub fn PhraseCardView(
                             }
                         }
                         on:click=move |_| {
-                            if !show_result {
+                            if !show_result.get() {
                                 on_dont_know.run(());
                             }
                         }
@@ -158,11 +158,11 @@ pub fn PhraseCardView(
                     </button>
                 </Show>
 
-                <Show when=move || show_result>
+                <Show when=move || show_result.get()>
                     <QuizResultDisplay quiz_result=quiz_result() />
                 </Show>
 
-                <Show when=move || show_result>
+                <Show when=move || show_result.get()>
                     {move || match phrase_text_stored.get_value() {
                         Some(text) => {
                             let sentences = crate::utils::text_format::split_japanese_sentences(&text);
@@ -178,7 +178,7 @@ pub fn PhraseCardView(
                     }}
                 </Show>
 
-                <Show when=move || show_result>
+                <Show when=move || show_result.get()>
                     {move || match phrase_translation_stored.get_value() {
                         Some(translation) => view! {
                             <div class="mt-2 p-3 bg-[var(--bg-secondary)] text-center">
@@ -194,7 +194,7 @@ pub fn PhraseCardView(
                     }}
                 </Show>
 
-                <Show when=move || waiting_for_next && show_result>
+                <Show when=move || waiting_for_next.get() && show_result.get()>
                     <div class="mt-4 flex justify-center">
                         <Button
                             variant=Signal::derive(|| ButtonVariant::Filled)


### PR DESCRIPTION
## Summary

Two surgical bug fixes in the lesson flow:

1. **50% lenient pass threshold** — `is_lenient_pass` required strictly more than 50% correct (`>`), so selecting 1 of 2 kanji readings (=50%) was incorrectly marked wrong. Changed to `>=50%`. Updated the existing minority regression test to a real minority (1 of 3) and added a test pinning that exactly 50% now passes.

2. **PhraseListen reactive result rendering** — `PhraseCardView` received `show_result` and `waiting_for_next` as plain `bool` props. The inner `<Show when=move || show_result>` created an ArcMemo with no reactive dependency, so when Leptos patched (rather than recreated) the component, the phrase_text/translation blocks did not re-evaluate — causing the source sentence to intermittently fail to render after a correct answer. Both props are now `Signal<bool>`, every internal read uses `.get()`, and the call site passes `Signal::derive` from lesson_state so the `<Show>` blocks track reactively.

## Test counts
- origa: 1457 passed, 0 failed
- origa_ui: 234 passed, 0 failed

## Note
Sibling quiz components (quiz_card, yesno, quiz_options*) may carry the same latent plain-bool-prop defect — flagged for a follow-up sweep.