### PR TITLE
fix(lesson): reactive show_answer/show_result props across all card components

### DIFF
--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -25,7 +25,7 @@ use crate::repository::cdn_provider::prefetch_blob_url;
 #[component]
 pub fn LessonCard(
     card: DomainCard,
-    show_answer: bool,
+    show_answer: Signal<bool>,
     is_reversed: bool,
     on_show_answer: Callback<()>,
     grammar_info: Option<GrammarInfo>,
@@ -167,7 +167,7 @@ pub fn LessonCard(
             .as_ref()
             .map(|ctx| ctx.is_muted.get_untracked())
             .unwrap_or(false);
-        if !show_answer
+        if !show_answer.get()
             && !is_reversed
             && card_type != CardType::Kanji
             && card_type != CardType::Phrase
@@ -186,7 +186,7 @@ pub fn LessonCard(
             .as_ref()
             .map(|ctx| ctx.is_muted.get_untracked())
             .unwrap_or(false);
-        if !show_answer && is_phrase && !is_muted {
+        if !show_answer.get() && is_phrase && !is_muted {
             if let Some(path) = phrase_audio_path.as_ref() {
                 stop_current_audio();
                 let path_owned = path.clone();
@@ -196,7 +196,7 @@ pub fn LessonCard(
                     play_phrase_in_lesson(&path_owned, &question_val).await;
                 });
             }
-        } else if is_phrase || show_answer {
+        } else if is_phrase || show_answer.get() {
             stop_current_audio();
         }
     });
@@ -207,7 +207,7 @@ pub fn LessonCard(
             .as_ref()
             .map(|ctx| ctx.is_muted.get_untracked())
             .unwrap_or(false);
-        if show_answer
+        if show_answer.get()
             && is_reversed
             && card_type != CardType::Kanji
             && is_speech_supported()
@@ -218,7 +218,9 @@ pub fn LessonCard(
     });
 
     Effect::new(move |_| {
-        if show_answer && let Some(el) = content_ref.get() {
+        if show_answer.get()
+            && let Some(el) = content_ref.get()
+        {
             let is_overflow = el.scroll_height() > el.client_height();
             needs_collapse.set(is_overflow);
         }
@@ -244,7 +246,7 @@ pub fn LessonCard(
             />
 
             <div class="flex-1 flex flex-col justify-center">
-                <Show when=move || !show_answer>
+                <Show when=move || !show_answer.get()>
                     <LessonCardQuestion
                         question_text=display_question.get_value()
                         kanji=kanji_stored.get_value()
@@ -255,7 +257,7 @@ pub fn LessonCard(
                     />
                 </Show>
 
-                <Show when=move || show_answer>
+                <Show when=move || show_answer.get()>
                     <LessonCardAnswer
                         question_text=display_question.get_value()
                         answer_text=answer.get_value()

--- a/origa_ui/src/pages/lesson/lesson_card_container.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_container.rs
@@ -137,7 +137,7 @@ pub fn LessonCardContainer() -> impl IntoView {
                         current_lesson_card.get().map(|lesson_card| {
                             render_lesson_card(
                                 lesson_card,
-                                lesson_state.get().showing_answer,
+                                Signal::derive(move || lesson_state.get().showing_answer),
                                 Callback::new(move |_| show_answer()),
                                 on_rate_callback,
                                 is_rating,
@@ -154,16 +154,15 @@ pub fn LessonCardContainer() -> impl IntoView {
                             if let LessonCardView::Quiz(quiz) = lesson_card.into_view() {
                                 let state = lesson_state.get();
                                 let selected_option = state.selected_quiz_option;
-                                let show_result = state.showing_answer;
 
                                 Some(view! {
                                     <QuizCardView
                                         quiz_card=quiz
-                                        show_result=show_result
+                                        show_result=Signal::derive(move || lesson_state.get().showing_answer)
                                         selected_option=selected_option
                                         on_select_option=on_quiz_select
                                         on_dont_know=on_quiz_dont_know
-                                        dont_know_selected=state.dont_know_selected
+                                        dont_know_selected=Signal::derive(move || lesson_state.get().dont_know_selected)
                                         native_language=native_language.get()
                                         known_kanji=Signal::from(known_kanji)
                                     />
@@ -202,16 +201,15 @@ pub fn LessonCardContainer() -> impl IntoView {
                             if let LessonCardView::YesNo(yesno) = lesson_card.into_view() {
                                 let state = lesson_state.get();
                                 let selected_answer = state.selected_yesno_answer;
-                                let show_result = state.showing_answer;
 
                                 Some(view! {
                                     <YesNoCardView
                                         yesno_card=yesno
-                                        show_result=show_result
+                                        show_result=Signal::derive(move || lesson_state.get().showing_answer)
                                         selected_answer=selected_answer
                                         on_answer=on_yesno_select
                                         on_dont_know=on_yesno_dont_know
-                                        dont_know_selected=state.dont_know_selected
+                                        dont_know_selected=Signal::derive(move || lesson_state.get().dont_know_selected)
                                         native_language=native_language.get()
                                         known_kanji=Signal::from(known_kanji)
                                     />
@@ -278,28 +276,26 @@ pub fn LessonCardContainer() -> impl IntoView {
                             if let LessonCardView::KanjiReadingQuiz(quiz) = lesson_card.into_view() {
                                 let state = lesson_state.get();
                                 let selected_option = state.selected_quiz_option;
-                                let show_result = state.showing_answer;
                                 let selected_options = state.selected_quiz_options.clone();
-                                let multi_submitted = state.multi_quiz_submitted;
                                 let multi_result = state.multi_result;
 
                                 Some(view! {
                                     <QuizCardView
                                         quiz_card=quiz
-                                        show_result=show_result
+                                        show_result=Signal::derive(move || lesson_state.get().showing_answer)
                                         selected_option=selected_option
                                         on_select_option=on_quiz_select
                                         on_dont_know=on_quiz_dont_know
-                                        dont_know_selected=state.dont_know_selected
+                                        dont_know_selected=Signal::derive(move || lesson_state.get().dont_know_selected)
                                         native_language=native_language.get()
                                         known_kanji=Signal::from(known_kanji)
                                         quiz_variant=QuizVariant::Reading
                                         selected_options=Signal::derive(move || selected_options.clone())
-                                        multi_submitted=multi_submitted
+                                        multi_submitted=Signal::derive(move || lesson_state.get().multi_quiz_submitted)
                                         multi_result=multi_result
                                         on_toggle=on_quiz_toggle
                                         on_submit=on_quiz_submit
-                                        waiting_for_next=state.waiting_for_next
+                                        waiting_for_next=Signal::derive(move || lesson_state.get().waiting_for_next)
                                         on_next_card=on_next_card
                                         lenient_grading=true
                                     />
@@ -317,16 +313,15 @@ pub fn LessonCardContainer() -> impl IntoView {
                             if let LessonCardView::GrammarQuiz(gq) = lesson_card.into_view() {
                                 let state = lesson_state.get();
                                 let selected_option = state.selected_quiz_option;
-                                let show_result = state.showing_answer;
 
                                 Some(view! {
                                     <QuizCardView
                                         quiz_card=gq.quiz().clone()
-                                        show_result=show_result
+                                        show_result=Signal::derive(move || lesson_state.get().showing_answer)
                                         selected_option=selected_option
                                         on_select_option=on_quiz_select
                                         on_dont_know=on_quiz_dont_know
-                                        dont_know_selected=state.dont_know_selected
+                                        dont_know_selected=Signal::derive(move || lesson_state.get().dont_know_selected)
                                         native_language=native_language.get()
                                         known_kanji=Signal::from(known_kanji)
                                         quiz_variant=QuizVariant::Grammar

--- a/origa_ui/src/pages/lesson/lesson_card_header.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_header.rs
@@ -12,7 +12,7 @@ pub fn LessonCardHeader(
     card_type: CardType,
     question_text: String,
     grammar_info: Option<GrammarInfo>,
-    show_answer: bool,
+    show_answer: Signal<bool>,
     card: Card,
     #[prop(into)] audio_path: Option<String>,
 ) -> impl IntoView {
@@ -46,7 +46,7 @@ pub fn LessonCardHeader(
                             })
                     }}
                 </Show>
-                <Show when=move || show_answer && grammar_info.get_value().is_some()>
+                <Show when=move || show_answer.get() && grammar_info.get_value().is_some()>
                     {move || {
                         grammar_info
                             .get_value()

--- a/origa_ui/src/pages/lesson/lesson_card_renderer.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_renderer.rs
@@ -14,7 +14,7 @@ struct LessonCardParams {
 
 pub(in crate::pages::lesson) fn render_lesson_card(
     lesson_card: LessonCard,
-    show_answer: bool,
+    show_answer: Signal<bool>,
     on_show_answer: Callback<()>,
     on_rate_callback: Callback<Rating>,
     is_rating: RwSignal<Option<Ulid>>,
@@ -81,7 +81,7 @@ pub(in crate::pages::lesson) fn render_lesson_card(
                 audio_path=phrase_audio_path
             />
 
-            <Show when=move || show_answer>
+            <Show when=move || show_answer.get()>
                 <PhraseRatingButtons
                     on_rate=on_rate_callback
                     disabled=Signal::derive(move || is_rating.get().is_some())
@@ -103,7 +103,7 @@ pub(in crate::pages::lesson) fn render_lesson_card(
                 audio_path=None
             />
 
-            <Show when=move || show_answer>
+            <Show when=move || show_answer.get()>
                 <RatingButtonsView
                     on_rate=on_rate_callback
                     disabled=Signal::derive(move || is_rating.get().is_some())

--- a/origa_ui/src/pages/lesson/quiz_card.rs
+++ b/origa_ui/src/pages/lesson/quiz_card.rs
@@ -94,22 +94,22 @@ pub enum QuizVariant {
 #[component]
 pub fn QuizCardView(
     quiz_card: QuizCard,
-    show_result: bool,
+    show_result: Signal<bool>,
     selected_option: Option<usize>,
     on_select_option: Callback<usize>,
     on_dont_know: Callback<()>,
-    dont_know_selected: bool,
+    dont_know_selected: Signal<bool>,
     native_language: NativeLanguage,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
     #[prop(optional)] quiz_variant: QuizVariant,
     #[prop(into, default = Signal::derive(|| HashSet::new()))] selected_options: Signal<
         HashSet<usize>,
     >,
-    #[prop(default = false)] multi_submitted: bool,
+    #[prop(default = Signal::derive(|| false))] multi_submitted: Signal<bool>,
     #[prop(default = None)] multi_result: Option<MultiQuizResult>,
     #[prop(default = Callback::new(|_: usize| {}))] on_toggle: Callback<usize>,
     #[prop(default = Callback::new(|_: ()| {}))] on_submit: Callback<()>,
-    #[prop(default = false)] waiting_for_next: bool,
+    #[prop(default = Signal::derive(|| false))] waiting_for_next: Signal<bool>,
     #[prop(default = Callback::new(|_: ()| {}))] on_next_card: Callback<()>,
     #[prop(default = false)] lenient_grading: bool,
 ) -> impl IntoView {
@@ -143,7 +143,7 @@ pub fn QuizCardView(
     let multi_result_stored = StoredValue::new(multi_result);
 
     let quiz_result = move || {
-        if dont_know_selected && show_result {
+        if dont_know_selected.get() && show_result.get() {
             return QuizResult::DontKnow;
         }
         if let Some(selected) = selected_option {
@@ -186,7 +186,8 @@ pub fn QuizCardView(
             .as_ref()
             .map(|ctx| ctx.is_muted.get_untracked())
             .unwrap_or(false);
-        if !show_result && card_type != CardType::Kanji && is_speech_supported() && !is_muted {
+        if !show_result.get() && card_type != CardType::Kanji && is_speech_supported() && !is_muted
+        {
             speak_word(&question_text, 1.0);
         }
     });
@@ -260,7 +261,7 @@ pub fn QuizCardView(
                         waiting_for_next=waiting_for_next
                         on_next_card=on_next_card
                     />
-                    <Show when=move || multi_submitted>
+                    <Show when=move || multi_submitted.get()>
                         {move || {
                             multi_result_stored
                                 .get_value()
@@ -294,7 +295,7 @@ pub fn QuizCardView(
                         known_kanji=known_kanji
                     />
 
-                    <Show when=move || show_result && quiz_result() != QuizResult::DontKnow>
+                    <Show when=move || show_result.get() && quiz_result() != QuizResult::DontKnow>
                         <QuizResultDisplay quiz_result=quiz_result() />
                     </Show>
                 </Show>

--- a/origa_ui/src/pages/lesson/quiz_options.rs
+++ b/origa_ui/src/pages/lesson/quiz_options.rs
@@ -10,11 +10,11 @@ use super::quiz_result::QuizResult;
 pub fn QuizOptions(
     options: Vec<QuizOption>,
     selected_option: Option<usize>,
-    show_result: bool,
+    show_result: Signal<bool>,
     quiz_result: QuizResult,
     on_select_option: Callback<usize>,
     on_dont_know: Callback<()>,
-    dont_know_selected: bool,
+    dont_know_selected: Signal<bool>,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
 ) -> impl IntoView {
     let i18n = use_i18n();
@@ -29,15 +29,15 @@ pub fn QuizOptions(
                         let is_correct = option.is_correct();
                         let is_selected = selected_option == Some(index);
                         let base_class = "p-2 sm:p-4 border text-left transition-all cursor-pointer relative flex flex-col justify-center min-h-[4rem]";
-                        let disabled_class = if show_result { "pointer-events-none" } else { "" };
+                        let disabled_class = if show_result.get() { "pointer-events-none" } else { "" };
                         let result_class = quiz_result.option_class(is_correct, is_selected);
-                        let selected_ring = if is_selected && !show_result {
+                        let selected_ring = if is_selected && !show_result.get() {
                             "ring-2 ring-[var(--accent-olive)]"
                         } else {
                             ""
                         };
 
-                        let shake_class = if show_result && is_selected && matches!(quiz_result, QuizResult::Incorrect) {
+                        let shake_class = if show_result.get() && is_selected && matches!(quiz_result, QuizResult::Incorrect) {
                             "anima-shake"
                         } else {
                             ""
@@ -52,7 +52,7 @@ pub fn QuizOptions(
                                 class=class
                                 data-testid=format!("quiz-option-{}", index)
                                 on:click=move |_| {
-                                    if !show_result {
+                                    if !show_result.get() {
                                         on_select_option.run(index);
                                     }
                                 }
@@ -64,7 +64,7 @@ pub fn QuizOptions(
                                         known_kanji=known_kanji.get()
                                     />
                                 </Text>
-                                <Show when=move || !show_result>
+                                <Show when=move || !show_result.get()>
                                     <span class="absolute top-1 right-2 text-[var(--fg-muted)] text-xs font-mono opacity-50 pointer-events-none">
                                         {key_hint.clone()}
                                     </span>
@@ -79,22 +79,22 @@ pub fn QuizOptions(
             data-testid="quiz-dont-know-btn"
             class=move || {
                 let base = "w-full mt-2 p-2 sm:p-4 border text-center transition-all cursor-pointer flex items-center justify-center gap-2";
-                if dont_know_selected {
+                if dont_know_selected.get() {
                     format!("{} quiz-option-neutral ring-2 ring-[var(--accent-olive)]", base)
-                } else if show_result {
+                } else if show_result.get() {
                     format!("{} quiz-option-dimmed pointer-events-none", base)
                 } else {
                     format!("{} quiz-option-neutral", base)
                 }
             }
             on:click=move |_| {
-                if !show_result {
+                if !show_result.get() {
                     on_dont_know.run(());
                 }
             }
         >
             <Text size=TextSize::Default>{t!(i18n, lesson.dont_know)}</Text>
-            <Show when=move || !show_result>
+            <Show when=move || !show_result.get()>
                 <span class="text-[var(--fg-muted)] text-xs font-mono">{t!(i18n, lesson.space_key)}</span>
             </Show>
         </button>

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -10,15 +10,15 @@ use super::quiz_result::OptionDisplay;
 pub fn QuizOptionsMulti(
     options: Vec<QuizOption>,
     selected_options: HashSet<usize>,
-    show_result: bool,
-    multi_submitted: bool,
+    show_result: Signal<bool>,
+    multi_submitted: Signal<bool>,
     multi_result: Option<MultiQuizResult>,
     on_toggle: Callback<usize>,
     on_submit: Callback<()>,
     on_dont_know: Callback<()>,
-    dont_know_selected: bool,
+    dont_know_selected: Signal<bool>,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
-    #[prop(default = false)] waiting_for_next: bool,
+    #[prop(default = Signal::derive(|| false))] waiting_for_next: Signal<bool>,
     #[prop(default = Callback::new(|_: ()| {}))] on_next_card: Callback<()>,
 ) -> impl IntoView {
     let i18n = use_i18n();
@@ -60,7 +60,7 @@ pub fn QuizOptionsMulti(
             }
         </div>
 
-        <Show when=move || !multi_submitted && !dont_know_selected>
+        <Show when=move || !multi_submitted.get() && !dont_know_selected.get()>
             <button
                 data-testid="quiz-submit-btn"
                 class=move || {
@@ -86,7 +86,7 @@ pub fn QuizOptionsMulti(
             </button>
         </Show>
 
-        <Show when=move || waiting_for_next && multi_submitted>
+        <Show when=move || waiting_for_next.get() && multi_submitted.get()>
             <div class="mt-4 flex justify-center">
                 <Button
                     variant=Signal::derive(|| ButtonVariant::Filled)
@@ -109,10 +109,10 @@ fn MultiOptionButton(
     is_correct: bool,
     tag: Option<String>,
     selected_options: StoredValue<HashSet<usize>>,
-    multi_submitted: bool,
+    multi_submitted: Signal<bool>,
     multi_result_stored: StoredValue<Option<MultiQuizResult>>,
     on_toggle: Callback<usize>,
-    show_result: bool,
+    show_result: Signal<bool>,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
 ) -> impl IntoView {
     let tag_stored = StoredValue::new(tag);
@@ -120,7 +120,7 @@ fn MultiOptionButton(
     view! {
         <button
             class=move || {
-                if multi_submitted {
+                if multi_submitted.get() {
                     if let Some(result) = multi_result_stored.get_value() {
                         let is_selected = selected_options.get_value().contains(&index);
                         let display = super::quiz_result::QuizResult::multi_option_display(
@@ -142,7 +142,7 @@ fn MultiOptionButton(
             }
             data-testid=format!("quiz-option-{}", index)
             on:click=move |_| {
-                if !show_result {
+                if !show_result.get() {
                     on_toggle.run(index);
                 }
             }
@@ -156,7 +156,7 @@ fn MultiOptionButton(
                         known_kanji=known_kanji.get()
                     />
                 </Text>
-                <Show when=move || multi_submitted && tag_stored.get_value().is_some()>
+                <Show when=move || multi_submitted.get() && tag_stored.get_value().is_some()>
                     {move || {
                         tag_stored.get_value().map(|t| {
                     let tag_class = tag_class(t.as_str());
@@ -167,12 +167,12 @@ fn MultiOptionButton(
                     }}
                 </Show>
             </div>
-            <Show when=move || !multi_submitted>
+            <Show when=move || !multi_submitted.get()>
                 <span class="absolute top-1 right-2 text-[var(--fg-muted)] text-xs font-mono opacity-50 pointer-events-none">
                     {key_hint.clone()}
                 </span>
             </Show>
-            <Show when=move || selected_options.get_value().contains(&index) && !multi_submitted>
+            <Show when=move || selected_options.get_value().contains(&index) && !multi_submitted.get()>
                 <span class="absolute top-1 left-1 w-3 h-3 bg-[var(--accent-olive)]"></span>
             </Show>
         </button>

--- a/origa_ui/src/pages/lesson/yesno_card_view.rs
+++ b/origa_ui/src/pages/lesson/yesno_card_view.rs
@@ -39,11 +39,11 @@ impl YesNoResult {
 #[component]
 pub fn YesNoCardView(
     yesno_card: YesNoCard,
-    show_result: bool,
+    show_result: Signal<bool>,
     selected_answer: Option<bool>,
     on_answer: Callback<bool>,
     on_dont_know: Callback<()>,
-    dont_know_selected: bool,
+    dont_know_selected: Signal<bool>,
     native_language: NativeLanguage,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
 ) -> impl IntoView {
@@ -112,7 +112,8 @@ pub fn YesNoCardView(
             .as_ref()
             .map(|ctx| ctx.is_muted.get_untracked())
             .unwrap_or(false);
-        if !show_result && card_type != CardType::Kanji && is_speech_supported() && !is_muted {
+        if !show_result.get() && card_type != CardType::Kanji && is_speech_supported() && !is_muted
+        {
             speak_word(&question_text.get_value(), 1.0);
         }
     });
@@ -122,13 +123,13 @@ pub fn YesNoCardView(
     });
 
     let yesno_result = move || {
-        if dont_know_selected && show_result {
+        if dont_know_selected.get() && show_result.get() {
             return YesNoResult::DontKnow;
         }
         YesNoResult::from_answer(
             is_statement_correct,
             selected_answer.unwrap_or(false),
-            show_result,
+            show_result.get(),
         )
     };
 
@@ -136,7 +137,7 @@ pub fn YesNoCardView(
     let no_selected = selected_answer == Some(false);
 
     let no_btn_class = Signal::derive(move || {
-        if show_result {
+        if show_result.get() {
             if !is_statement_correct {
                 "quiz-option-correct".to_string()
             } else if no_selected {
@@ -150,7 +151,7 @@ pub fn YesNoCardView(
     });
 
     let yes_btn_class = Signal::derive(move || {
-        if show_result {
+        if show_result.get() {
             if is_statement_correct {
                 "quiz-option-correct".to_string()
             } else if yes_selected {
@@ -164,7 +165,7 @@ pub fn YesNoCardView(
     });
 
     let yes_variant = Signal::derive(move || {
-        if show_result {
+        if show_result.get() {
             ButtonVariant::Default
         } else {
             ButtonVariant::Olive
@@ -227,7 +228,7 @@ pub fn YesNoCardView(
                         test_id=Signal::derive(|| "yesno-no-btn".to_string())
                         variant=Signal::derive(|| ButtonVariant::Default)
                         class=no_btn_class
-                        disabled=Signal::derive(move || show_result)
+                        disabled=Signal::derive(move || show_result.get())
                         on_click=Callback::new(move |_| on_answer.run(false))
                     >
                         {t!(i18n, lesson.no)} <span class="hidden sm:inline">"[1]"</span>
@@ -237,7 +238,7 @@ pub fn YesNoCardView(
                         test_id=Signal::derive(|| "yesno-yes-btn".to_string())
                         variant=yes_variant
                         class=yes_btn_class
-                        disabled=Signal::derive(move || show_result)
+                        disabled=Signal::derive(move || show_result.get())
                         on_click=Callback::new(move |_| on_answer.run(true))
                     >
                         {t!(i18n, lesson.yes)} <span class="hidden sm:inline">"[2]"</span>
@@ -247,16 +248,16 @@ pub fn YesNoCardView(
                     data-testid="yesno-dont-know-btn"
                     class=move || {
                         let base = "w-full mt-2 p-2 sm:p-4 border text-center transition-all cursor-pointer flex items-center justify-center gap-2";
-                        if dont_know_selected {
+                        if dont_know_selected.get() {
                             format!("{} quiz-option-neutral ring-2 ring-[var(--accent-olive)]", base)
-                        } else if show_result {
+                        } else if show_result.get() {
                             format!("{} quiz-option-dimmed pointer-events-none", base)
                         } else {
                             format!("{} quiz-option-neutral", base)
                         }
                     }
                     on:click=move |_| {
-                        if !show_result {
+                        if !show_result.get() {
                             on_dont_know.run(());
                         }
                     }
@@ -265,7 +266,7 @@ pub fn YesNoCardView(
                     <span class="hidden sm:inline text-[var(--fg-muted)] text-xs font-mono">{t!(i18n, lesson.space_key)}</span>
                 </button>
 
-                <Show when=move || show_result>
+                <Show when=move || show_result.get()>
                     <Show when=move || yesno_result() == YesNoResult::Correct>
                         <div class="mt-6 text-center">
                             <Text size=TextSize::Default class="text-[var(--success)] font-bold">
@@ -295,7 +296,7 @@ pub fn YesNoCardView(
                 </Show>
 
                 <Show when=move || {
-                    show_result
+                    show_result.get()
                         && super::quiz_card::should_show_answer_display(
                             QuizResult::from(yesno_result()),
                             card_type,


### PR DESCRIPTION
## Summary

Preventive fix for the **Leptos 0.8 ArcMemo plain-bool-prop defect** — same template as PR #204 (PhraseCardView), applied to all remaining lesson card components.

### Defect
A plain Copy bool prop captured inside Show when=move || bool creates an ArcMemo with **no reactive dependency**. When Leptos patches (rather than recreates) the component, the Show does not re-evaluate — content flakily fails to render.

### Fix
- bool -> Signal<bool>, every read .get(), Signal::derive at the call site reading lesson_state inside the closure.
- Applied to: **QuizCardView**, **YesNoCardView**, **QuizOptions**, **QuizOptionsMulti**, **LessonCard**, **LessonCardHeader**, **render_lesson_card** helper.

### Side benefit
LessonCard's **TTS-reversed Effect** and **collapse-check Effect** were never re-running (plain bool frozen at mount) — now reactive, so reversed cards get TTS and the collapse UI appears as intended.

### Files changed (8)
- origa_ui/src/pages/lesson/lesson_card.rs
- origa_ui/src/pages/lesson/lesson_card_container.rs
- origa_ui/src/pages/lesson/lesson_card_header.rs
- origa_ui/src/pages/lesson/lesson_card_renderer.rs
- origa_ui/src/pages/lesson/quiz_card.rs
- origa_ui/src/pages/lesson/quiz_options.rs
- origa_ui/src/pages/lesson/quiz_options_multi.rs
- origa_ui/src/pages/lesson/yesno_card_view.rs

### Verification
- cargo clippy -p origa_ui --all-targets -- -D warnings — clean
- cargo fmt -p origa_ui -- --check — clean
- Cross-cutting grep: zero plain-bool prop declarations for show_result/show_answer/waiting_for_next/multi_submitted/dont_know_selected in all 8 files
- Cross-cutting grep: zero Show when=move || show_result / Show when=move || show_answer patterns remaining
