### PR TITLE
refactor(lesson): remove DEFAULT_LANG, thread user native_language through generation

### DIFF
--- a/origa/src/domain/knowledge/kanji_companions.rs
+++ b/origa/src/domain/knowledge/kanji_companions.rs
@@ -6,7 +6,7 @@ use super::lesson::{LessonCard, LessonData, LessonViewGenerator};
 use super::{Card, KnowledgeSet, MAX_COMPANION_WORDS};
 use crate::dictionary::kanji::get_kanji_info;
 use crate::domain::japanese::JapaneseChar;
-use crate::domain::value_objects::JapaneseLevel;
+use crate::domain::value_objects::{JapaneseLevel, NativeLanguage};
 
 const MAX_COMPANION_CARDS_PER_LESSON: usize = 15;
 const MAX_REVERSE_COMPANION_CARDS_PER_LESSON: usize = 10;
@@ -15,19 +15,31 @@ pub(crate) fn add_kanji_companions(
     lesson_data: LessonData,
     knowledge_set: &KnowledgeSet,
     user_level: JapaneseLevel,
+    native_language: NativeLanguage,
 ) -> LessonData {
     let already_in_lesson: HashSet<Ulid> = lesson_data.cards.iter().map(|(id, _)| *id).collect();
 
-    let (lesson_data, already_in_lesson) =
-        add_forward_companions(lesson_data, knowledge_set, already_in_lesson);
+    let (lesson_data, already_in_lesson) = add_forward_companions(
+        lesson_data,
+        knowledge_set,
+        already_in_lesson,
+        native_language,
+    );
 
-    add_reverse_companions(lesson_data, knowledge_set, user_level, &already_in_lesson)
+    add_reverse_companions(
+        lesson_data,
+        knowledge_set,
+        user_level,
+        &already_in_lesson,
+        native_language,
+    )
 }
 
 fn add_forward_companions(
     lesson_data: LessonData,
     knowledge_set: &KnowledgeSet,
     mut already_in_lesson: HashSet<Ulid>,
+    native_language: NativeLanguage,
 ) -> (LessonData, HashSet<Ulid>) {
     let kanji_ids = collect_kanji_ids(&lesson_data, knowledge_set);
     if kanji_ids.is_empty() {
@@ -44,7 +56,7 @@ fn add_forward_companions(
     }
 
     (
-        append_companions(lesson_data, knowledge_set, &companions),
+        append_companions(lesson_data, knowledge_set, &companions, native_language),
         already_in_lesson,
     )
 }
@@ -54,6 +66,7 @@ fn add_reverse_companions(
     knowledge_set: &KnowledgeSet,
     user_level: JapaneseLevel,
     already_in_lesson: &HashSet<Ulid>,
+    native_language: NativeLanguage,
 ) -> LessonData {
     let kanji_index: HashMap<char, (&Ulid, &super::StudyCard)> = knowledge_set
         .study_cards()
@@ -86,7 +99,7 @@ fn add_reverse_companions(
         .take(MAX_REVERSE_COMPANION_CARDS_PER_LESSON)
         .collect();
 
-    append_companions(lesson_data, knowledge_set, &capped)
+    append_companions(lesson_data, knowledge_set, &capped, native_language)
 }
 
 fn collect_kanji_from_vocab(
@@ -215,8 +228,9 @@ fn append_companions(
     mut lesson_data: LessonData,
     knowledge_set: &KnowledgeSet,
     companions: &[(Ulid, &super::StudyCard)],
+    native_language: NativeLanguage,
 ) -> LessonData {
-    let mut generator = LessonViewGenerator::new(knowledge_set);
+    let mut generator = LessonViewGenerator::new(knowledge_set, native_language);
 
     let companion_lessons: Vec<(Ulid, LessonCard)> = companions
         .iter()
@@ -256,7 +270,7 @@ mod tests {
         knowledge_set: &KnowledgeSet,
         card_ids: &[Ulid],
     ) -> LessonData {
-        let mut generator = LessonViewGenerator::new(knowledge_set);
+        let mut generator = LessonViewGenerator::new(knowledge_set, NativeLanguage::Russian);
         let cards: Vec<(Ulid, LessonCard)> = card_ids
             .iter()
             .map(|id| {
@@ -281,7 +295,7 @@ mod tests {
         let vocab_sc = ks.create_card(create_vocab_card(&first_popular)).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*kanji_sc.card_id()]);
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5, NativeLanguage::Russian);
 
         assert!(
             result.contains_key(vocab_sc.card_id()),
@@ -331,7 +345,7 @@ mod tests {
         );
 
         let lesson = build_empty_lesson_with_cards(&ks, &lesson_card_ids);
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5, NativeLanguage::Russian);
 
         let companion_count = result.len() - lesson_card_ids.len();
         assert!(
@@ -357,7 +371,12 @@ mod tests {
 
         let lesson =
             build_empty_lesson_with_cards(&ks, &[*kanji_sc.card_id(), *vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson.clone(), &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(
+            lesson.clone(),
+            &ks,
+            JapaneseLevel::N5,
+            NativeLanguage::Russian,
+        );
 
         let count = result
             .cards
@@ -378,7 +397,12 @@ mod tests {
         let vocab_sc = ks.create_card(create_vocab_card("猫")).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson.clone(), &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(
+            lesson.clone(),
+            &ks,
+            JapaneseLevel::N5,
+            NativeLanguage::Russian,
+        );
 
         assert_eq!(
             result.len(),
@@ -403,7 +427,7 @@ mod tests {
         let kanji_hon_sc = ks.create_card(create_kanji_card("本")).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5, NativeLanguage::Russian);
 
         assert!(
             result.contains_key(kanji_nichi_sc.card_id()),
@@ -447,7 +471,7 @@ mod tests {
         let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
 
         let user_level = nichi_level;
-        let result = add_kanji_companions(lesson, &ks, user_level);
+        let result = add_kanji_companions(lesson, &ks, user_level, NativeLanguage::Russian);
 
         assert!(
             result.contains_key(kanji_nichi_sc.card_id()),
@@ -469,7 +493,7 @@ mod tests {
 
         let lesson =
             build_empty_lesson_with_cards(&ks, &[*kanji_nichi_sc.card_id(), *vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5, NativeLanguage::Russian);
 
         let count = result
             .cards
@@ -491,7 +515,7 @@ mod tests {
         let kanji_nichi_sc = ks.create_card(create_kanji_card("日")).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*vocab_sc.card_id()]);
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5, NativeLanguage::Russian);
 
         assert!(
             result.contains_key(kanji_nichi_sc.card_id()),
@@ -522,7 +546,7 @@ mod tests {
             &ks,
             &[*vocab_nihon_sc.card_id(), *vocab_nichiyoubi_sc.card_id()],
         );
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5, NativeLanguage::Russian);
 
         let count = result
             .cards
@@ -555,7 +579,7 @@ mod tests {
         vocab_ids.push(*vocab_sc.card_id());
 
         let lesson = build_empty_lesson_with_cards(&ks, &vocab_ids);
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5, NativeLanguage::Russian);
 
         let reverse_count = result.cards.len() - vocab_ids.len();
         assert!(
@@ -600,7 +624,7 @@ mod tests {
         );
 
         let lesson = build_empty_lesson_with_cards(&ks, &lesson_card_ids);
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N1);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N1, NativeLanguage::Russian);
 
         let reverse_count = result.cards.len() - lesson_card_ids.len();
         assert_eq!(
@@ -637,7 +661,7 @@ mod tests {
         let _vocab_sc = ks.create_card(create_vocab_card(&popular_word)).unwrap();
 
         let lesson = build_empty_lesson_with_cards(&ks, &[*kanji_nichi_sc.card_id()]);
-        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5);
+        let result = add_kanji_companions(lesson, &ks, JapaneseLevel::N5, NativeLanguage::Russian);
 
         assert!(
             result.contains_key(extra_kanji_sc.card_id()),

--- a/origa/src/domain/knowledge/lesson/view_generator/generation.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/generation.rs
@@ -307,6 +307,7 @@ pub(crate) fn cached_kanji_info<'a>(
 pub(crate) fn generate_grammar_quiz(
     original_card: Card,
     knowledge_set: &KnowledgeSet,
+    lang: &NativeLanguage,
 ) -> Result<LessonCardView, OrigaError> {
     let grammar_rule_card = match &original_card {
         Card::Grammar(grc) => grc,
@@ -376,11 +377,11 @@ pub(crate) fn generate_grammar_quiz(
     let quiz = QuizCard::new(original_card.clone(), options, QuizMode::Single);
 
     let grammar_title = grammar_rule_card
-        .title(&DEFAULT_LANG)
+        .title(lang)
         .map(|q| q.text().to_string())
         .unwrap_or_else(|_| grammar_rule_card.rule_id().to_string());
     let grammar_desc = grammar_rule_card
-        .description(&DEFAULT_LANG)
+        .description(lang)
         .map(|a| answer_display_text(&a))
         .unwrap_or_default();
 
@@ -394,5 +395,3 @@ pub(crate) fn generate_grammar_quiz(
 
     Ok(LessonCardView::GrammarQuiz(grammar_quiz))
 }
-
-const DEFAULT_LANG: NativeLanguage = NativeLanguage::Russian;

--- a/origa/src/domain/knowledge/lesson/view_generator/mod.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/mod.rs
@@ -36,17 +36,17 @@ const PROB_GRAMMAR_QUIZ: f32 = 0.50;
 
 const EASY_REVIEWS_FOR_REVERSED: usize = 2;
 const GOOD_REVIEWS_FOR_REVERSED: usize = 4;
-const DEFAULT_LANG: NativeLanguage = NativeLanguage::Russian;
 
 pub struct LessonViewGenerator<'a> {
     knowledge_set: &'a KnowledgeSet,
     cards_by_type: HashMap<CardType, Vec<Card>>,
     known_grammars: Vec<GrammarRuleCard>,
     kanji_cache: HashMap<String, &'static KanjiInfo>,
+    native_language: NativeLanguage,
 }
 
 impl<'a> LessonViewGenerator<'a> {
-    pub fn new(knowledge_set: &'a KnowledgeSet) -> Self {
+    pub fn new(knowledge_set: &'a KnowledgeSet, native_language: NativeLanguage) -> Self {
         let cards_by_type = knowledge_set.build_cards_by_type();
         let known_grammars: Vec<_> = knowledge_set
             .study_cards()
@@ -62,6 +62,7 @@ impl<'a> LessonViewGenerator<'a> {
             cards_by_type,
             known_grammars,
             kanji_cache: HashMap::new(),
+            native_language,
         }
     }
 
@@ -85,8 +86,12 @@ impl<'a> LessonViewGenerator<'a> {
             CardType::Grammar if !is_new => {
                 let rand_val = rng.random::<f32>();
                 if rand_val < PROB_GRAMMAR_QUIZ {
-                    generation::generate_grammar_quiz(card.clone(), self.knowledge_set)
-                        .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
+                    generation::generate_grammar_quiz(
+                        card.clone(),
+                        self.knowledge_set,
+                        &self.native_language,
+                    )
+                    .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
                 } else {
                     LessonCardView::Normal(card.clone())
                 }
@@ -102,7 +107,13 @@ impl<'a> LessonViewGenerator<'a> {
                     .get(&card_type)
                     .map(|v| v.as_slice())
                     .unwrap_or(&[]);
-                Self::select_review_kanji_view(card, same_type_cards, &mut self.kanji_cache, rng)
+                Self::select_review_kanji_view(
+                    card,
+                    same_type_cards,
+                    &mut self.kanji_cache,
+                    rng,
+                    self.native_language,
+                )
             },
             CardType::Vocabulary if is_new => {
                 let same_type_cards = self.same_type_cards(&card_type);
@@ -129,7 +140,7 @@ impl<'a> LessonViewGenerator<'a> {
         if rand_val < PROB_NEW_KANJI_NORMAL {
             LessonCardView::Normal(card.clone())
         } else if rand_val < PROB_NEW_KANJI_QUIZ {
-            generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+            generation::generate_quiz(card.clone(), same_type_cards, &self.native_language)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         } else {
             LessonCardView::Writing(card.clone())
@@ -141,6 +152,7 @@ impl<'a> LessonViewGenerator<'a> {
         same_type_cards: &[Card],
         kanji_cache: &mut HashMap<String, &'static KanjiInfo>,
         rng: &mut R,
+        native_language: NativeLanguage,
     ) -> LessonCardView {
         let rand_val = rng.random::<f32>();
         if rand_val < PROB_KANJI_NORMAL {
@@ -149,10 +161,10 @@ impl<'a> LessonViewGenerator<'a> {
             generation::generate_kanji_reading_quiz(card.clone(), same_type_cards, kanji_cache)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         } else if rand_val < PROB_KANJI_QUIZ {
-            generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+            generation::generate_quiz(card.clone(), same_type_cards, &native_language)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         } else if rand_val < PROB_KANJI_YESNO {
-            generation::generate_yesno(card.clone(), same_type_cards, &DEFAULT_LANG, rng)
+            generation::generate_yesno(card.clone(), same_type_cards, &native_language, rng)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         } else {
             LessonCardView::Writing(card.clone())
@@ -169,7 +181,7 @@ impl<'a> LessonViewGenerator<'a> {
         if rand_val < PROB_NEW_VOCAB_NORMAL {
             LessonCardView::Normal(card.clone())
         } else {
-            generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+            generation::generate_quiz(card.clone(), same_type_cards, &self.native_language)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         }
     }
@@ -190,15 +202,20 @@ impl<'a> LessonViewGenerator<'a> {
         if rand_val < PROB_NORMAL_VIEW {
             LessonCardView::Normal(card.clone())
         } else if rand_val < PROB_QUIZ_VIEW {
-            generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+            generation::generate_quiz(card.clone(), same_type_cards, &self.native_language)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         } else if !is_high_difficulty && rand_val < PROB_YESNO_VIEW {
-            generation::generate_yesno(card.clone(), same_type_cards, &DEFAULT_LANG, rng)
+            generation::generate_yesno(card.clone(), same_type_cards, &self.native_language, rng)
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone()))
         } else if eligible_for_reversed && rand_val < PROB_REVERSED_VIEW {
-            transforms::apply_reversed(card)
+            transforms::apply_reversed(card, &self.native_language)
         } else if eligible_for_advanced {
-            transforms::apply_grammar_mutated(card, &self.known_grammars, rng)
+            transforms::apply_grammar_mutated(
+                card,
+                &self.known_grammars,
+                rng,
+                &self.native_language,
+            )
         } else {
             LessonCardView::Normal(card.clone())
         }
@@ -222,7 +239,7 @@ impl<'a> LessonViewGenerator<'a> {
             return LessonCardView::Normal(card.clone());
         }
 
-        generation::generate_phrase_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+        generation::generate_phrase_quiz(card.clone(), same_type_cards, &self.native_language)
             .unwrap_or_else(|| LessonCardView::Normal(card.clone()))
     }
 
@@ -257,7 +274,7 @@ impl<'a> LessonViewGenerator<'a> {
         if is_new {
             build_distinct_views(vec![
                 LessonCardView::Normal(card.clone()),
-                generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+                generation::generate_quiz(card.clone(), same_type_cards, &self.native_language)
                     .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
             ])
         } else {
@@ -269,23 +286,29 @@ impl<'a> LessonViewGenerator<'a> {
                 || memory.good_review_count() >= GOOD_REVIEWS_FOR_REVERSED;
 
             let mut candidates = vec![
-                generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+                generation::generate_quiz(card.clone(), same_type_cards, &self.native_language)
                     .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
             ];
             if !is_high_difficulty {
                 candidates.push(
-                    generation::generate_yesno(card.clone(), same_type_cards, &DEFAULT_LANG, rng)
-                        .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
+                    generation::generate_yesno(
+                        card.clone(),
+                        same_type_cards,
+                        &self.native_language,
+                        rng,
+                    )
+                    .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
                 );
             }
             if eligible_for_reversed {
-                candidates.push(transforms::apply_reversed(card));
+                candidates.push(transforms::apply_reversed(card, &self.native_language));
             }
             if eligible_for_advanced {
                 candidates.push(transforms::apply_grammar_mutated(
                     card,
                     &self.known_grammars,
                     rng,
+                    &self.native_language,
                 ));
             }
             candidates.push(LessonCardView::Normal(card.clone()));
@@ -310,7 +333,7 @@ impl<'a> LessonViewGenerator<'a> {
         if is_new {
             build_distinct_views(vec![
                 LessonCardView::Normal(card.clone()),
-                generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+                generation::generate_quiz(card.clone(), same_type_cards, &self.native_language)
                     .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
                 LessonCardView::Writing(card.clone()),
             ])
@@ -322,10 +345,15 @@ impl<'a> LessonViewGenerator<'a> {
                     &mut self.kanji_cache,
                 )
                 .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
-                generation::generate_quiz(card.clone(), same_type_cards, &DEFAULT_LANG)
+                generation::generate_quiz(card.clone(), same_type_cards, &self.native_language)
                     .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
-                generation::generate_yesno(card.clone(), same_type_cards, &DEFAULT_LANG, rng)
-                    .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
+                generation::generate_yesno(
+                    card.clone(),
+                    same_type_cards,
+                    &self.native_language,
+                    rng,
+                )
+                .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
                 LessonCardView::Writing(card.clone()),
                 LessonCardView::Normal(card.clone()),
             ])
@@ -343,8 +371,12 @@ impl<'a> LessonViewGenerator<'a> {
             vec![LessonCardView::Normal(card.clone())]
         } else {
             build_distinct_views(vec![
-                generation::generate_grammar_quiz(card.clone(), self.knowledge_set)
-                    .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
+                generation::generate_grammar_quiz(
+                    card.clone(),
+                    self.knowledge_set,
+                    &self.native_language,
+                )
+                .unwrap_or_else(|_| LessonCardView::Normal(card.clone())),
                 LessonCardView::Normal(card.clone()),
             ])
         }

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/card_views.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/card_views.rs
@@ -28,7 +28,7 @@ mod grammar_card_view_tests {
         let rule_id = ulid::Ulid::from_string("01KJ9AVWBGC2BT0DMFPDYYFEWB").unwrap();
         let sc = StudyCard::new(Card::Grammar(GrammarRuleCard::new_test_with_id(rule_id)));
         let ks = make_ks();
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
         for seed in 0u64..50 {
             let mut rng = StdRng::seed_from_u64(seed);
             assert!(matches!(
@@ -43,7 +43,7 @@ mod grammar_card_view_tests {
         let rule_id = ulid::Ulid::from_string("01KJ9AVWBGC2BT0DMFPDYYFEWB").unwrap();
         let sc = StudyCard::new(Card::Grammar(GrammarRuleCard::new_test_with_id(rule_id)));
         let ks = make_ks();
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
         for seed in 0u64..50 {
             let mut rng = StdRng::seed_from_u64(seed);
             assert!(matches!(
@@ -88,7 +88,7 @@ mod kanji_view_tests {
         init_real_dictionaries();
         let ks = make_ks();
         let sc = StudyCard::new(Card::Kanji(KanjiCard::new_test("日".to_string())));
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
         let mut counts = std::collections::HashMap::<&str, usize>::new();
 
         for seed in 0..300 {
@@ -112,7 +112,7 @@ mod kanji_view_tests {
         init_real_dictionaries();
         let ks = make_ks();
         let sc = make_reviewed_kanji("日", 5.0, 3.0, Rating::Good);
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
 
         let mut yesno_count = 0;
         for seed in 0..300 {
@@ -135,7 +135,7 @@ mod kanji_view_tests {
         init_real_dictionaries();
         let ks = make_ks();
         let sc = make_reviewed_kanji("日", 5.0, 3.0, Rating::Good);
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
 
         let mut writing_count = 0;
         for seed in 0..300 {
@@ -173,7 +173,7 @@ mod new_vocab_view_tests {
         init_real_dictionaries();
         let ks = make_ks();
         let sc = StudyCard::new(create_vocab_card("猫"));
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
         let mut normal = 0;
         let mut quiz = 0;
 

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/filtering.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/filtering.rs
@@ -29,7 +29,7 @@ mod yesno_view_filtering {
     const ITERATIONS: u64 = 500;
 
     fn count_yesno_views(study_card: &StudyCard, ks: &KnowledgeSet) -> (usize, usize) {
-        let mut generator = LessonViewGenerator::new(ks);
+        let mut generator = LessonViewGenerator::new(ks, NativeLanguage::Russian);
         let mut yesno_count = 0;
         let mut other_count = 0;
 
@@ -108,7 +108,7 @@ mod reversed_view_filtering {
     const ITERATIONS: u64 = 500;
 
     fn count_view_types(study_card: &StudyCard, ks: &KnowledgeSet) -> (usize, usize, usize) {
-        let mut generator = LessonViewGenerator::new(ks);
+        let mut generator = LessonViewGenerator::new(ks, NativeLanguage::Russian);
         let mut reversed_count = 0;
         let mut grammar_mutated_count = 0;
         let mut normal_count = 0;
@@ -239,7 +239,7 @@ mod reversed_view_easy_reviews {
 
         assert_eq!(study_card.memory().easy_review_count(), 3);
 
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
         let mut reversed_count = 0;
 
         for seed in 0..ITERATIONS {
@@ -267,7 +267,7 @@ mod reversed_view_easy_reviews {
 
         assert_eq!(study_card.memory().easy_review_count(), 2);
 
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
 
         for seed in 0..ITERATIONS {
             let mut rng = StdRng::seed_from_u64(seed);
@@ -286,7 +286,7 @@ mod reversed_view_easy_reviews {
         let ks = create_knowledge_set_with_vocab(DISTRACTOR_WORDS);
         let study_card = create_high_difficulty_card_with_easy_reviews("猫", 3);
 
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
 
         for seed in 0..ITERATIONS {
             let mut rng = StdRng::seed_from_u64(seed);
@@ -307,7 +307,7 @@ mod reversed_view_easy_reviews {
 
         assert_eq!(study_card.memory().good_review_count(), 4);
 
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
         let mut reversed_count = 0;
 
         for seed in 0..ITERATIONS {
@@ -335,7 +335,7 @@ mod reversed_view_easy_reviews {
 
         assert_eq!(study_card.memory().good_review_count(), 3);
 
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
 
         for seed in 0..ITERATIONS {
             let mut rng = StdRng::seed_from_u64(seed);
@@ -354,7 +354,7 @@ mod reversed_view_easy_reviews {
         let ks = create_knowledge_set_with_vocab(DISTRACTOR_WORDS);
         let study_card = create_high_difficulty_card_with_good_reviews("猫", 4);
 
-        let mut generator = LessonViewGenerator::new(&ks);
+        let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
 
         for seed in 0..ITERATIONS {
             let mut rng = StdRng::seed_from_u64(seed);

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/kanji_reading_quiz.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/kanji_reading_quiz.rs
@@ -312,7 +312,7 @@ fn review_kanji_produces_reading_quiz() {
     let ks = make_kanji_knowledge_set(&["日", "月", "水", "火", "木"]);
     let sc = make_reviewed_kanji("日", 5.0, 3.0, Rating::Good);
     assert!(!sc.memory().is_high_difficulty());
-    let mut generator = LessonViewGenerator::new(&ks);
+    let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
 
     let mut count = 0;
     for seed in 0..300 {
@@ -333,7 +333,7 @@ fn new_kanji_never_reading_quiz() {
 
     let ks = make_kanji_knowledge_set(&["日", "月", "水", "火", "木"]);
     let sc = StudyCard::new(Card::Kanji(KanjiCard::new_test("日".to_string())));
-    let mut generator = LessonViewGenerator::new(&ks);
+    let mut generator = LessonViewGenerator::new(&ks, NativeLanguage::Russian);
 
     for seed in 0..300 {
         let mut rng = StdRng::seed_from_u64(seed);

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/mod.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/mod.rs
@@ -1,7 +1,7 @@
 use crate::domain::knowledge::KnowledgeSet;
 use crate::domain::knowledge::VocabularyCard;
 use crate::domain::memory::{Difficulty, MemoryState, Rating, ReviewLog, Stability};
-use crate::domain::value_objects::Question;
+use crate::domain::value_objects::{NativeLanguage, Question};
 use crate::domain::{Card, GrammarRuleCard, StudyCard};
 use chrono::{Duration, Utc};
 use ulid::Ulid;
@@ -10,6 +10,7 @@ mod card_views;
 mod filtering;
 mod kanji_reading_quiz;
 mod quiz;
+mod transforms;
 mod types;
 mod yesno;
 
@@ -57,4 +58,15 @@ pub(crate) fn create_knowledge_set_with_vocab(words: &[&str]) -> KnowledgeSet {
         .unwrap();
     }
     ks
+}
+
+pub(super) fn answer_text(card: &Card, lang: NativeLanguage) -> String {
+    use crate::domain::CardAnswer;
+    match card
+        .answer(&lang)
+        .expect("translation must exist for fixture")
+    {
+        CardAnswer::Vocabulary { translations, .. } => translations.join(", "),
+        CardAnswer::Text(s) => s,
+    }
 }

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/quiz.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/quiz.rs
@@ -144,7 +144,8 @@ mod generate_grammar_quiz_tests {
         let grammar_card = create_grammar_card(rule_id);
 
         let ks = crate::domain::knowledge::KnowledgeSet::new();
-        let result = generation::generate_grammar_quiz(grammar_card.clone(), &ks);
+        let result =
+            generation::generate_grammar_quiz(grammar_card.clone(), &ks, &NativeLanguage::Russian);
 
         match result.unwrap() {
             LessonCardView::Normal(card) => assert_eq!(card, grammar_card),
@@ -161,7 +162,7 @@ mod generate_grammar_quiz_tests {
 
         let ks = create_known_vocab_set("食べる");
 
-        let result = generation::generate_grammar_quiz(grammar_card, &ks);
+        let result = generation::generate_grammar_quiz(grammar_card, &ks, &NativeLanguage::Russian);
         let view = result.expect("should succeed");
 
         match &view {
@@ -190,7 +191,8 @@ mod generate_grammar_quiz_tests {
         let grammar_card = create_grammar_card(rule_id);
 
         let ks = crate::domain::knowledge::KnowledgeSet::new();
-        let result = generation::generate_grammar_quiz(grammar_card.clone(), &ks);
+        let result =
+            generation::generate_grammar_quiz(grammar_card.clone(), &ks, &NativeLanguage::Russian);
 
         match result.unwrap() {
             LessonCardView::Normal(card) => assert_eq!(card, grammar_card),
@@ -263,6 +265,45 @@ mod generate_quiz_vocab_kanji_tests {
                 assert_eq!(quiz.options().iter().filter(|o| o.is_correct()).count(), 1);
             },
             other => panic!("Expected Quiz for kanji, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn generate_quiz_uses_english_translations_for_english_locale() {
+        init_real_dictionaries();
+        let words = ["猫", "犬", "鳥", "魚"];
+        let cards: Vec<Card> = words.iter().map(|w| create_vocab_card(w)).collect();
+
+        let english_text = answer_text(&cards[0], NativeLanguage::English);
+        let russian_text = answer_text(&cards[0], NativeLanguage::Russian);
+        assert_ne!(
+            english_text, russian_text,
+            "test fixture: EN and RU translations must differ for {:?}",
+            words[0]
+        );
+
+        let result =
+            generation::generate_quiz(cards[0].clone(), &cards[1..], &NativeLanguage::English);
+
+        match result.expect("English-locale quiz must be generated") {
+            LessonCardView::Quiz(quiz) => {
+                let correct = quiz
+                    .options()
+                    .iter()
+                    .find(|o| o.is_correct())
+                    .expect("quiz must have a correct option");
+                assert_eq!(
+                    correct.text(),
+                    english_text,
+                    "correct option must be the ENGLISH translation"
+                );
+                assert_ne!(
+                    correct.text(),
+                    russian_text,
+                    "regression guard: option must not be the Russian translation"
+                );
+            },
+            other => panic!("Expected Quiz, got {:?}", other),
         }
     }
 }

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/transforms.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/transforms.rs
@@ -1,0 +1,89 @@
+use super::*;
+use crate::domain::knowledge::lesson::types::LessonCardView;
+use crate::domain::knowledge::lesson::view_generator::transforms;
+use crate::use_cases::init_real_dictionaries;
+use rand::{SeedableRng, rngs::StdRng};
+
+#[test]
+fn apply_reversed_uses_english_translation_for_english_locale() {
+    init_real_dictionaries();
+    let card = create_vocab_card("猫");
+
+    let english_text = answer_text(&card, NativeLanguage::English);
+    let russian_text = answer_text(&card, NativeLanguage::Russian);
+    assert_ne!(
+        english_text, russian_text,
+        "test fixture: EN and RU translations must differ"
+    );
+
+    let view = transforms::apply_reversed(&card, &NativeLanguage::English);
+
+    let reversed_word = match view {
+        LessonCardView::Reversed(Card::Vocabulary(reversed)) => reversed.word().text().to_string(),
+        other => panic!("Expected Reversed, got {other:?}"),
+    };
+
+    assert_eq!(
+        reversed_word, english_text,
+        "reversed card question must be the ENGLISH translation"
+    );
+    assert_ne!(
+        reversed_word, russian_text,
+        "regression guard: reversed card must not use the Russian translation"
+    );
+}
+
+#[test]
+fn apply_grammar_mutated_uses_english_description_for_english_locale() {
+    init_real_dictionaries();
+
+    let vocab = VocabularyCard::from_known_word("食べる", &NativeLanguage::English).expect(
+        "test fixture: 食べる must have an English translation for the grammar-mutated EN path",
+    );
+    let card = Card::Vocabulary(vocab);
+
+    let rule_id = ulid::Ulid::from_string("01G00000000000000024000000").expect("Invalid ULID");
+    let grammar_card = GrammarRuleCard::new(rule_id).expect("verb grammar rule must exist");
+
+    let desc_en = short_description_text(&grammar_card, NativeLanguage::English);
+    let desc_ru = short_description_text(&grammar_card, NativeLanguage::Russian);
+    assert_ne!(
+        desc_en, desc_ru,
+        "test fixture: grammar rule EN and RU short descriptions must differ"
+    );
+
+    let mut rng = StdRng::seed_from_u64(11);
+    let view = transforms::apply_grammar_mutated(
+        &card,
+        std::slice::from_ref(&grammar_card),
+        &mut rng,
+        &NativeLanguage::English,
+    );
+
+    let actual_description = match view {
+        LessonCardView::GrammarMutated { grammar_info, .. } => {
+            grammar_info.description().to_string()
+        },
+        other => panic!("Expected GrammarMutated, got {other:?}"),
+    };
+
+    assert_eq!(
+        actual_description, desc_en,
+        "grammar description must be the ENGLISH short description"
+    );
+    assert_ne!(
+        actual_description, desc_ru,
+        "regression guard: grammar description must not be the Russian short description"
+    );
+}
+
+fn short_description_text(card: &GrammarRuleCard, lang: NativeLanguage) -> String {
+    use crate::domain::CardAnswer;
+    match card
+        .short_description(&lang)
+        .expect("grammar rule must have a short description for fixture")
+    {
+        CardAnswer::Text(s) => s,
+        CardAnswer::Vocabulary { translations, .. } => translations.join(", "),
+    }
+}

--- a/origa/src/domain/knowledge/lesson/view_generator/tests/yesno.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/tests/yesno.rs
@@ -269,3 +269,47 @@ fn generate_yesno_stores_word_and_statement_separately() {
         "statement must carry the answer/distractor"
     );
 }
+
+#[test]
+fn generate_yesno_uses_english_statement_for_english_locale() {
+    init_real_dictionaries();
+
+    let vocab_words = ["猫", "犬", "鳥", "魚"];
+    let cards: Vec<Card> = vocab_words
+        .iter()
+        .map(|w| create_vocab_card_with_word(w))
+        .collect();
+
+    let english_texts: Vec<String> = cards
+        .iter()
+        .map(|c| answer_text(c, NativeLanguage::English))
+        .collect();
+    let russian_texts: Vec<String> = cards
+        .iter()
+        .map(|c| answer_text(c, NativeLanguage::Russian))
+        .collect();
+
+    let mut rng = StdRng::seed_from_u64(7);
+    let result = generation::generate_yesno(
+        cards[0].clone(),
+        &cards[1..],
+        &NativeLanguage::English,
+        &mut rng,
+    );
+
+    let yesno = match result.expect("English-locale yesno must be generated") {
+        LessonCardView::YesNo(yn) => yn,
+        other => panic!("Expected YesNo, got {other:?}"),
+    };
+
+    assert!(
+        english_texts.iter().any(|t| t == yesno.statement()),
+        "statement must be an ENGLISH translation, got '{}'",
+        yesno.statement()
+    );
+    assert!(
+        !russian_texts.iter().any(|t| t == yesno.statement()),
+        "regression guard: statement must not be a Russian translation, got '{}'",
+        yesno.statement()
+    );
+}

--- a/origa/src/domain/knowledge/lesson/view_generator/transforms.rs
+++ b/origa/src/domain/knowledge/lesson/view_generator/transforms.rs
@@ -1,13 +1,13 @@
 use crate::dictionary::grammar::get_rule_by_id;
+use crate::domain::value_objects::NativeLanguage;
 use crate::domain::{Card, GrammarRuleCard, VocabularyCard};
 use rand::{Rng, seq::SliceRandom};
 
 use super::super::types::{GrammarInfo, LessonCardView};
-use super::DEFAULT_LANG;
 
-pub(crate) fn apply_reversed(card: &Card) -> LessonCardView {
+pub(crate) fn apply_reversed(card: &Card, lang: &NativeLanguage) -> LessonCardView {
     match card {
-        Card::Vocabulary(vocab) => match vocab.revert(&DEFAULT_LANG) {
+        Card::Vocabulary(vocab) => match vocab.revert(lang) {
             Ok(reverted) => LessonCardView::Reversed(Card::Vocabulary(reverted)),
             Err(_) => LessonCardView::Normal(card.clone()),
         },
@@ -19,16 +19,17 @@ pub(crate) fn apply_grammar_mutated<R: Rng>(
     card: &Card,
     known_grammars: &[GrammarRuleCard],
     rng: &mut R,
+    lang: &NativeLanguage,
 ) -> LessonCardView {
     match card {
         Card::Vocabulary(vocab) => match select_applicable_grammar(vocab, known_grammars, rng) {
             Some(grammar_card) => {
                 let rule = get_rule_by_id(grammar_card.rule_id());
                 match rule {
-                    Some(r) => match vocab.with_grammar_rule(r, &DEFAULT_LANG) {
+                    Some(r) => match vocab.with_grammar_rule(r, lang) {
                         Ok((mutated, grammar_description)) => {
                             let grammar_title = grammar_card
-                                .title(&DEFAULT_LANG)
+                                .title(lang)
                                 .map(|q| q.text().to_string())
                                 .unwrap_or_else(|_| grammar_card.rule_id().to_string());
                             let grammar_info = GrammarInfo::new(

--- a/origa/src/domain/knowledge/lesson_builder.rs
+++ b/origa/src/domain/knowledge/lesson_builder.rs
@@ -6,7 +6,7 @@ use ulid::Ulid;
 
 use super::lesson::{LessonCard, LessonCardView, LessonData, LessonViewGenerator};
 use super::{Card, CardType, KnowledgeSet, StudyCard};
-use crate::domain::{JapaneseLevel, JlptContent};
+use crate::domain::{JapaneseLevel, JlptContent, NativeLanguage};
 
 const MIN_LESSON_SIZE: usize = 15;
 pub(crate) const MAX_LESSON_SIZE: usize = 22;
@@ -62,6 +62,7 @@ pub(crate) fn build_lesson_core(
     knowledge_set: &KnowledgeSet,
     daily_new_limit: usize,
     jlpt_content: &JlptContent,
+    native_language: NativeLanguage,
 ) -> (LessonData, HashSet<Ulid>) {
     let mut all_cards = knowledge_set.study_cards().iter().collect::<Vec<_>>();
     all_cards.sort_by_key(|(_, card)| card.memory().next_review_date());
@@ -100,6 +101,7 @@ pub(crate) fn build_lesson_core(
         &selected_cards,
         &padding_cards,
         knowledge_set,
+        native_language,
     );
     cards.shuffle(&mut rand::rng());
     let core_count = cards.len();
@@ -566,6 +568,7 @@ fn collect_anchored_phrase_card_ids(
 pub(crate) fn add_phrases(
     mut lesson_data: LessonData,
     knowledge_set: &KnowledgeSet,
+    native_language: NativeLanguage,
     phrase_new_budget: &mut usize,
 ) -> LessonData {
     let core_count = lesson_data.core_count;
@@ -641,7 +644,7 @@ pub(crate) fn add_phrases(
         return lesson_data;
     }
 
-    let mut generator = LessonViewGenerator::new(knowledge_set);
+    let mut generator = LessonViewGenerator::new(knowledge_set, native_language);
     let phrase_lessons: Vec<(Ulid, LessonCard)> = selected_ids
         .iter()
         .filter_map(|card_id| {
@@ -797,6 +800,7 @@ fn compute_expansion_views(
 pub(crate) fn expand_repeated_views(
     lesson_data: LessonData,
     knowledge_set: &KnowledgeSet,
+    native_language: NativeLanguage,
     primary_card_ids: &HashSet<Ulid>,
 ) -> LessonData {
     let original_cards = lesson_data.cards;
@@ -804,7 +808,7 @@ pub(crate) fn expand_repeated_views(
 
     let (core_cards, tail_cards) = original_cards.split_at(core_count_before);
 
-    let mut generator = LessonViewGenerator::new(knowledge_set);
+    let mut generator = LessonViewGenerator::new(knowledge_set, native_language);
     let mut new_core: Vec<(Ulid, LessonCard)> = Vec::with_capacity(core_cards.len() * 2);
     let mut pending: Vec<(usize, Ulid, LessonCardView, bool)> = Vec::new();
 
@@ -947,9 +951,10 @@ fn build_core_lesson_cards(
     selected_cards: &[(&Ulid, &StudyCard)],
     padding_cards: &[(&Ulid, &StudyCard)],
     knowledge_set: &KnowledgeSet,
+    native_language: NativeLanguage,
 ) -> Vec<(Ulid, LessonCard)> {
     let padding_ids: HashSet<_> = padding_cards.iter().map(|(id, _)| **id).collect();
-    let mut generator = LessonViewGenerator::new(knowledge_set);
+    let mut generator = LessonViewGenerator::new(knowledge_set, native_language);
 
     let favorite_lessons: Vec<_> = favorite_cards
         .iter()
@@ -1237,7 +1242,7 @@ mod tests {
         };
 
         let mut budget = 5;
-        let result = add_phrases(lesson, &ks, &mut budget);
+        let result = add_phrases(lesson, &ks, NativeLanguage::Russian, &mut budget);
         let phrases = lesson_phrase_ids(&result);
 
         assert!(
@@ -1299,7 +1304,7 @@ mod tests {
         };
 
         let mut budget = 2;
-        let result = add_phrases(lesson, &ks, &mut budget);
+        let result = add_phrases(lesson, &ks, NativeLanguage::Russian, &mut budget);
         let new_phrases_count = lesson_phrase_ids(&result).len();
 
         assert!(
@@ -1314,6 +1319,7 @@ mod tests {
                 core_count: 1,
             },
             &ks,
+            NativeLanguage::Russian,
             &mut zero_budget,
         );
         assert_eq!(
@@ -1362,7 +1368,7 @@ mod tests {
         };
 
         let mut budget = 5;
-        let result = add_phrases(lesson, &ks, &mut budget);
+        let result = add_phrases(lesson, &ks, NativeLanguage::Russian, &mut budget);
         let phrases = lesson_phrase_ids(&result);
 
         assert!(
@@ -1401,7 +1407,7 @@ mod tests {
         };
 
         let mut budget = 10;
-        let result = add_phrases(lesson, &ks, &mut budget);
+        let result = add_phrases(lesson, &ks, NativeLanguage::Russian, &mut budget);
         let phrases = lesson_phrase_ids(&result);
 
         assert!(
@@ -1805,7 +1811,7 @@ mod tests {
         };
 
         let mut budget = 5;
-        let result = add_phrases(lesson, &ks, &mut budget);
+        let result = add_phrases(lesson, &ks, NativeLanguage::Russian, &mut budget);
         let phrases = lesson_phrase_ids(&result);
 
         assert!(
@@ -1838,7 +1844,12 @@ mod tests {
             ks.create_card(phrase_card(pid)).expect("create phrase");
         }
 
-        let lesson = ks.cards_to_lesson(1, &JlptContent::new(), JapaneseLevel::N5);
+        let lesson = ks.cards_to_lesson(
+            1,
+            &JlptContent::new(),
+            JapaneseLevel::N5,
+            NativeLanguage::Russian,
+        );
 
         let mut all_phrase_ids: Vec<Ulid> = lesson
             .cards
@@ -1882,7 +1893,12 @@ mod tests {
             ks.create_card(phrase_card(pid)).expect("create phrase");
         }
 
-        let lesson = ks.cards_to_lesson(1, &JlptContent::new(), JapaneseLevel::N5);
+        let lesson = ks.cards_to_lesson(
+            1,
+            &JlptContent::new(),
+            JapaneseLevel::N5,
+            NativeLanguage::Russian,
+        );
 
         let phrases_in_lesson: usize = lesson
             .cards
@@ -1962,7 +1978,12 @@ mod tests {
         let budget = compute_phrase_new_budget(daily_new_limit, 0);
         assert_eq!(budget, 2, "fixture sanity: PHRASE_NEW_RATIO=2");
 
-        let lesson = ks.cards_to_lesson(daily_new_limit, &JlptContent::new(), JapaneseLevel::N5);
+        let lesson = ks.cards_to_lesson(
+            daily_new_limit,
+            &JlptContent::new(),
+            JapaneseLevel::N5,
+            NativeLanguage::Russian,
+        );
 
         let new_phrases_in_lesson = lesson
             .cards
@@ -2113,7 +2134,7 @@ mod tests {
         };
 
         let mut budget = 10;
-        let result = add_phrases(lesson, &ks, &mut budget);
+        let result = add_phrases(lesson, &ks, NativeLanguage::Russian, &mut budget);
 
         let phrase_ids = lesson_phrase_ids(&result);
         assert!(
@@ -2153,7 +2174,7 @@ mod tests {
         };
 
         let mut budget = 20;
-        let result = add_phrases(lesson, &ks, &mut budget);
+        let result = add_phrases(lesson, &ks, NativeLanguage::Russian, &mut budget);
 
         let positions = first_showing_positions(&result);
         let anchor_vocab: Vec<(&Ulid, &str)> =
@@ -2194,7 +2215,7 @@ mod tests {
         };
 
         let mut budget = 10;
-        let result = add_phrases(lesson, &ks, &mut budget);
+        let result = add_phrases(lesson, &ks, NativeLanguage::Russian, &mut budget);
 
         let phrase_indices: Vec<usize> = result
             .cards
@@ -2233,7 +2254,12 @@ mod tests {
         ks.create_card(phrase_card(phrase_id_hello()))
             .expect("create phrase"); // tokens [test, hello]
 
-        let lesson = ks.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
+        let lesson = ks.cards_to_lesson(
+            5,
+            &JlptContent::new(),
+            JapaneseLevel::N5,
+            NativeLanguage::Russian,
+        );
 
         let anchor_id = *anchor_sc.card_id();
         let anchor_showings: Vec<usize> = lesson
@@ -2306,7 +2332,7 @@ mod tests {
             core_count: 1,
         };
         let primary_set: HashSet<Ulid> = [primary_id].into_iter().collect();
-        expand_repeated_views(lesson, ks, &primary_set)
+        expand_repeated_views(lesson, ks, NativeLanguage::Russian, &primary_set)
     }
 
     #[test]
@@ -2398,7 +2424,7 @@ mod tests {
             core_count: 2,
         };
         let primary_set: HashSet<Ulid> = [primary_id].into_iter().collect();
-        let result = expand_repeated_views(lesson, &ks, &primary_set);
+        let result = expand_repeated_views(lesson, &ks, NativeLanguage::Russian, &primary_set);
 
         let companion_showings = result.find_by_card_id(companion_id);
         assert_eq!(
@@ -2421,7 +2447,7 @@ mod tests {
             core_count: 1,
         };
         let primary_set: HashSet<Ulid> = [phrase_id].into_iter().collect();
-        let result = expand_repeated_views(lesson, &ks, &primary_set);
+        let result = expand_repeated_views(lesson, &ks, NativeLanguage::Russian, &primary_set);
 
         let showings = result.find_by_card_id(phrase_id);
         assert_eq!(
@@ -2468,7 +2494,7 @@ mod tests {
             core_count: 1,
         };
         let primary_set: HashSet<Ulid> = [card_id].into_iter().collect();
-        let result = expand_repeated_views(lesson, &ks, &primary_set);
+        let result = expand_repeated_views(lesson, &ks, NativeLanguage::Russian, &primary_set);
 
         let added = result.find_by_card_id(card_id).len() - 1;
         assert_eq!(
@@ -2511,7 +2537,7 @@ mod tests {
             core_count: 1,
         };
         let primary_set: HashSet<Ulid> = [hd_id].into_iter().collect();
-        let result = expand_repeated_views(original, &ks, &primary_set);
+        let result = expand_repeated_views(original, &ks, NativeLanguage::Russian, &primary_set);
 
         for (_, lc) in result.cards[result.core_count..].iter() {
             assert!(
@@ -2557,7 +2583,7 @@ mod tests {
         let core_count = cards.len();
         let original = LessonData { cards, core_count };
         let primary_set: HashSet<Ulid> = [hd_id].into_iter().collect();
-        let result = expand_repeated_views(original, &ks, &primary_set);
+        let result = expand_repeated_views(original, &ks, NativeLanguage::Russian, &primary_set);
 
         let positions: Vec<usize> = result
             .cards
@@ -2622,7 +2648,7 @@ mod tests {
         let core_count = cards.len();
         let original = LessonData { cards, core_count };
         let primary_set: HashSet<Ulid> = [anchor_id].into_iter().collect();
-        expand_repeated_views(original, ks, &primary_set)
+        expand_repeated_views(original, ks, NativeLanguage::Russian, &primary_set)
     }
 
     fn showing_positions(result: &LessonData, card_id: Ulid) -> Vec<usize> {
@@ -2773,7 +2799,7 @@ mod tests {
         let core_count = cards.len();
         let original = LessonData { cards, core_count };
         let primary_set: HashSet<Ulid> = [a_id, b_id].into_iter().collect();
-        let result = expand_repeated_views(original, &ks, &primary_set);
+        let result = expand_repeated_views(original, &ks, NativeLanguage::Russian, &primary_set);
 
         for card_id in [a_id, b_id] {
             let positions = showing_positions(&result, card_id);

--- a/origa/src/domain/knowledge/mod.rs
+++ b/origa/src/domain/knowledge/mod.rs
@@ -291,17 +291,25 @@ impl KnowledgeSet {
         daily_new_limit: usize,
         jlpt_content: &JlptContent,
         user_level: JapaneseLevel,
+        native_language: NativeLanguage,
     ) -> LessonData {
         let (core, primary_card_ids) =
-            lesson_builder::build_lesson_core(self, daily_new_limit, jlpt_content);
-        let with_companions = kanji_companions::add_kanji_companions(core, self, user_level);
+            lesson_builder::build_lesson_core(self, daily_new_limit, jlpt_content, native_language);
+        let with_companions =
+            kanji_companions::add_kanji_companions(core, self, user_level, native_language);
         let interleaved = lesson_builder::interleave_core_by_type(with_companions);
         let mut phrase_new_budget = lesson_builder::compute_phrase_new_budget(
             daily_new_limit,
             self.phrase_cards_studied_today(),
         );
-        let with_phrases = lesson_builder::add_phrases(interleaved, self, &mut phrase_new_budget);
-        lesson_builder::expand_repeated_views(with_phrases, self, &primary_card_ids)
+        let with_phrases =
+            lesson_builder::add_phrases(interleaved, self, native_language, &mut phrase_new_budget);
+        lesson_builder::expand_repeated_views(
+            with_phrases,
+            self,
+            native_language,
+            &primary_card_ids,
+        )
     }
 
     pub(crate) fn rate_card(

--- a/origa/src/domain/knowledge/tests.rs
+++ b/origa/src/domain/knowledge/tests.rs
@@ -2,6 +2,7 @@ use super::lesson_builder::MAX_LESSON_SIZE;
 use super::*;
 use crate::domain::JapaneseLevel;
 use crate::domain::JlptContent;
+use crate::domain::NativeLanguage;
 use crate::domain::memory::{KNOWN_CARD_STABILITY_THRESHOLD, MemoryState};
 use crate::domain::value_objects::Question;
 use chrono::Duration;
@@ -93,7 +94,12 @@ fn cards_to_lesson_includes_favorite_cards() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        10,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
     assert!(result.contains_key(&card_id));
 }
 
@@ -115,7 +121,12 @@ fn cards_to_lesson_includes_high_difficulty_cards() {
         .rate_card(*study2.card_id(), Rating::Easy, RateMode::StandardLesson)
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        10,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     assert!(result.contains_key(study1.card_id()));
 }
@@ -538,7 +549,12 @@ fn recalculate_daily_stats_preserves_new_cards_on_create_card() {
             .unwrap();
     }
 
-    let lesson_cards = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
+    let lesson_cards = knowledge_set.cards_to_lesson(
+        10,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
     let new_in_lesson = lesson_cards
         .iter()
         .filter(|(id, _)| knowledge_set.get_card(**id).unwrap().memory().is_new())
@@ -602,7 +618,8 @@ fn new_cards_sorted_by_jlpt_level() {
         .create_card(create_vocab_card("走る"))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(2, &jlpt_content, JapaneseLevel::N5);
+    let result =
+        knowledge_set.cards_to_lesson(2, &jlpt_content, JapaneseLevel::N5, NativeLanguage::Russian);
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -634,7 +651,8 @@ fn new_cards_unknown_level_go_last() {
         .create_card(create_vocab_card("食べる"))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(1, &jlpt_content, JapaneseLevel::N5);
+    let result =
+        knowledge_set.cards_to_lesson(1, &jlpt_content, JapaneseLevel::N5, NativeLanguage::Russian);
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -679,7 +697,12 @@ fn new_cards_jlpt_sort_does_not_affect_other_categories() {
         .toggle_favorite(*study_nichi.card_id())
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &jlpt_content, JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        10,
+        &jlpt_content,
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     assert!(
         result.contains_key(study_taberu.card_id()),
@@ -740,7 +763,12 @@ fn new_cards_interleaved_by_type_within_jlpt_level() {
         )))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(15, &jlpt_content, JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        15,
+        &jlpt_content,
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let distinct_card_ids: HashSet<Ulid> = result.values().map(|lc| lc.card_id()).collect();
     assert_eq!(
@@ -789,7 +817,8 @@ fn new_cards_interleave_handles_missing_type() {
         knowledge_set.create_card(create_vocab_card(word)).unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &jlpt_content, JapaneseLevel::N5);
+    let result =
+        knowledge_set.cards_to_lesson(5, &jlpt_content, JapaneseLevel::N5, NativeLanguage::Russian);
 
     assert_eq!(
         result.len(),
@@ -838,7 +867,8 @@ fn new_cards_interleave_across_jlpt_levels() {
         .create_card(Card::Kanji(KanjiCard::new_test("n4k1".to_string())))
         .unwrap();
 
-    let result = knowledge_set.cards_to_lesson(4, &jlpt_content, JapaneseLevel::N5);
+    let result =
+        knowledge_set.cards_to_lesson(4, &jlpt_content, JapaneseLevel::N5, NativeLanguage::Russian);
 
     let distinct_card_ids: HashSet<Ulid> = result.values().map(|lc| lc.card_id()).collect();
     assert_eq!(
@@ -903,7 +933,8 @@ fn new_cards_interleave_preserves_jlpt_priority() {
         knowledge_set.create_card(create_vocab_card(word)).unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(3, &jlpt_content, JapaneseLevel::N5);
+    let result =
+        knowledge_set.cards_to_lesson(3, &jlpt_content, JapaneseLevel::N5, NativeLanguage::Russian);
 
     assert!(
         result.contains_key(study_n5.card_id()),
@@ -958,7 +989,12 @@ fn phrase_new_cards_limited() {
 
     // daily_new_limit = 1 -> new-phrase budget = 1 * PHRASE_NEW_RATIO (2).
     // Four phrases are available, so the budget must be the binding constraint.
-    let result = knowledge_set.cards_to_lesson(1, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        1,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let (core_phrases, tail_phrases) = count_phrases(&result);
     let total_phrases = core_phrases + tail_phrases;
@@ -1014,7 +1050,12 @@ fn phrase_new_cards_zero_when_limit_below_ratio() {
     }
 
     // daily_new_limit=0 → phrase_new_limit=0
-    let result = knowledge_set.cards_to_lesson(0, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        0,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let phrase_count = result
         .keys()
@@ -1083,7 +1124,12 @@ fn limited_types_still_respect_daily_limit() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        5,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     assert!(
         result.len() <= 5,
@@ -1109,7 +1155,12 @@ fn lesson_size_respects_max_limit() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(100, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        100,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     assert!(
         result.len() <= MAX_LESSON_SIZE,
@@ -1132,7 +1183,12 @@ fn high_difficulty_cards_respect_max_lesson_size() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        10,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     assert!(
         result.len() <= MAX_LESSON_SIZE,
@@ -1164,7 +1220,12 @@ fn phrases_added_after_core_cards_learning() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        5,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let core_count = result
         .keys()
@@ -1205,7 +1266,12 @@ fn phrases_added_after_core_cards_review() {
             .unwrap();
     }
 
-    let result = knowledge_set.cards_to_lesson(5, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        5,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let core_count = result
         .keys()
@@ -1246,7 +1312,12 @@ fn onboarding_scoring_does_not_consume_daily_limit() {
         "OnboardingScoring should not increment new_cards_studied_today"
     );
 
-    let result = knowledge_set.cards_to_lesson(15, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        15,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let new_in_lesson = result
         .iter()
@@ -1272,7 +1343,12 @@ fn favorite_card_appears_once_when_due_high_difficulty() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        10,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let count = result
         .card_ids()
@@ -1301,7 +1377,12 @@ fn favorite_card_appears_once_when_new() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        10,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let count = result
         .card_ids()
@@ -1327,7 +1408,12 @@ fn favorite_card_appears_once_when_due_known() {
 
     knowledge_set.toggle_favorite(card_id).unwrap();
 
-    let result = knowledge_set.cards_to_lesson(10, &JlptContent::new(), JapaneseLevel::N5);
+    let result = knowledge_set.cards_to_lesson(
+        10,
+        &JlptContent::new(),
+        JapaneseLevel::N5,
+        NativeLanguage::Russian,
+    );
 
     let count = result
         .card_ids()

--- a/origa/src/use_cases/select_cards_to_lesson.rs
+++ b/origa/src/use_cases/select_cards_to_lesson.rs
@@ -23,9 +23,13 @@ impl<'a, R: UserRepository> SelectCardsToLessonUseCase<'a, R> {
 
         let daily_new_limit = user.daily_load().new_cards_per_day();
         let user_level = user.current_japanese_level();
-        let lesson_data =
-            user.knowledge_set()
-                .cards_to_lesson(daily_new_limit, jlpt_content, user_level);
+        let native_language = *user.native_language();
+        let lesson_data = user.knowledge_set().cards_to_lesson(
+            daily_new_limit,
+            jlpt_content,
+            user_level,
+            native_language,
+        );
 
         info!(user_id = %user.id(), count = lesson_data.total_count(), "Cards selected for lesson");
 


### PR DESCRIPTION
## Summary

Removes the hardcoded `DEFAULT_LANG` (NativeLanguage::Russian) from lesson content generation and threads the user's actual `native_language` through the entire pipeline.

### Problem

Quiz options, yesno statements, phrase answers, and grammar descriptions were ALWAYS produced in Russian regardless of the user's `native_language` setting. English-locale users saw Russian quiz answers.

### Change

- Remove both `DEFAULT_LANG` const definitions (in `view_generator/mod.rs` and `generation.rs` — the duplicate was itself a code smell)
- `KnowledgeSet::cards_to_lesson` now takes `native_language` parameter
- Threaded through: `build_lesson_core`, `add_kanji_companions`, `add_phrases`, `expand_repeated_views` → `LessonViewGenerator` (stored as field) → `generate_grammar_quiz`, `transforms::apply_reversed`/ `apply_grammar_mutated`
- `generate_kanji_reading_quiz` is untouched (on/kun readings are language-independent)

### Impact

- **Russian users**: byte-identical output
- **English users**: now get English content
- **Tests**: 1504 passed (+ new English-locale regression tests for quiz/yesno/transforms that would fail if Russian were hardcoded back)

### Files

15 files changed (13 modified + 1 new test file + 1 use_case file), all under `origa/src/` only.

### Note

Pre-existing flaky test `domain::srs::tests::kanji_review_easy_gives_shorter_or_equal_interval_than_standard` (srs.rs:364) is unrelated to this refactor and may flicker on CI.