### PR TITLE
fix(android): register mobile deep-link scheme for OAuth callback

### DIFF
--- a/tauri/capabilities/mobile.json
+++ b/tauri/capabilities/mobile.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "../gen/schemas/mobile-schema.json",
+	"identifier": "mobile",
+	"description": "Capability for the mobile platforms (Android/iOS) — deep-link + opener for OAuth",
+	"platforms": ["iOS", "android"],
+	"permissions": [
+		"core:default",
+		"core:event:default",
+		"tts:default",
+		"deep-link:default",
+		"updater:default",
+		{
+			"identifier": "opener:default",
+			"allow": [
+				{ "url": "https://origa.uwuwu.net/*" },
+				{ "url": "https://app.origa.uwuwu.net/*" }
+			]
+		}
+	]
+}

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -43,7 +43,13 @@
         "deep-link": {
             "desktop": {
                 "schemes": ["origa"]
-            }
+            },
+            "mobile": [
+                {
+                    "scheme": ["origa"],
+                    "appLink": false
+                }
+            ]
         },
         "updater": {
             "endpoints": [


### PR DESCRIPTION
## Root cause

Google/Yandex login buttons did nothing on Android (brief flicker, then silent) while working fine on Windows. The OAuth flow redirects from the external browser back to `origa://auth/callback`, which Android's intent-filter catches — but the Tauri deep-link plugin runtime never emitted the deep-link event because `plugins.deep-link` in `tauri.conf.json` only declared a **desktop** section.

## Fix

1. **Add `mobile` entry** to `plugins.deep-link` in `tauri.conf.json` — custom scheme `origa`, `appLink: false`, per Tauri v2 docs.
2. **Add `tauri/capabilities/mobile.json`** — mobile-specific capability file (platforms: iOS + android) with `deep-link:default`, `core:event:default`, and `opener` allow-list, mirroring the existing desktop capability.

The existing `AndroidManifest.xml` intent-filter was already correct; only the runtime plugin config was missing.

## Notes

- `tauri-plugin-opener` is v2.5.3 (in the [GH#2913](https://github.com/tauri-apps/plugins-workspace/issues/2913) range) but **left unchanged** — the mobile deep-link config is the primary fix. If opening the browser still fails on a real device, the opener version can be revisited separately.
- Android build validation is deferred to CI.