### PR TITLE
fix(android): disable pinch-zoom and overscroll for native app feel

### DIFF
--- a/origa_ui/index.html
+++ b/origa_ui/index.html
@@ -2,7 +2,10 @@
 <html lang="ru">
     <head>
         <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+        />
         <meta name="theme-color" content="#3d4535" />
         <meta
             name="description"

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -101,6 +101,13 @@ body {
     margin: 0;
 }
 
+html,
+body {
+    overscroll-behavior: none;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+}
+
 /* Touch оптимизация */
 button,
 [role="button"],

--- a/origa_ui/public/auth/desktop-callback.html
+++ b/origa_ui/public/auth/desktop-callback.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <title>Origa - Авторизация</title>
     <style>
         body {

--- a/tauri/gen/android/app/src/main/java/net/uwuwu/origa/MainActivity.kt
+++ b/tauri/gen/android/app/src/main/java/net/uwuwu/origa/MainActivity.kt
@@ -1,3 +1,34 @@
 package net.uwuwu.origa
 
-class MainActivity : TauriActivity()
+import android.view.View
+import android.webkit.WebView
+
+class MainActivity : TauriActivity() {
+    override fun onStart() {
+        super.onStart()
+        configureWebView()
+    }
+
+    private fun configureWebView() {
+        val decorView = window?.decorView ?: return
+        decorView.post {
+            applyNativeScrollSettings(decorView.rootView)
+        }
+    }
+
+    private fun applyNativeScrollSettings(view: View) {
+        if (view is WebView) {
+            with(view.settings) {
+                setSupportZoom(false)
+                builtInZoomControls = false
+                displayZoomControls = false
+            }
+            view.overScrollMode = View.OVER_SCROLL_NEVER
+        }
+        if (view is android.view.ViewGroup) {
+            for (i in 0 until view.childCount) {
+                applyNativeScrollSettings(view.getChildAt(i))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three-layer fix to make the Android app feel native instead of a web page wrapped in a WebView:

1. **Viewport meta** ( + ): added `maximum-scale=1.0, user-scalable=no, viewport-fit=cover` to prevent browser-level pinch-zoom.
2. **CSS** (): `html,body { overscroll-behavior: none; touch-action: manipulation; -webkit-tap-highlight-color: transparent }` — kills double-tap zoom and CSS overscroll. The kanji drawing canvas keeps its own `touch-action: none` (overrides the parent).
3. **Kotlin** (`MainActivity.kt`): `onStart` override walks the view tree (deferred via `decorView.post` so the wry WebView is attached) and sets `WebSettings setSupportZoom(false)` + `builtInZoomControls/displayZoomControls false` + `overScrollMode = OVER_SCROLL_NEVER`. This is the only way to disable Android's native overscroll stretch (CSS `overscroll-behavior` does not affect WebView native overscroll — see Capacitor #5384).

### Notes
- `MainActivity.kt` is git-tracked and Tauri v2 never overwrites it once it exists (only `BuildTask.kt` is regenerated).
- `user-select: none` is deliberately NOT applied globally to keep OCR/STT text inputs working.
- Inner scroll containers (modals) keep their own `overscroll-behavior`.
- **Manual smoke test on a real device is still needed** — CI validates compilation only.