### PR TITLE
♻️ refactor(ci): tag-based releases — master CI-only, tags CD (ADR-025)

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -9,7 +9,7 @@ outputs:
         description: "Base version without suffix (0.3.0 or 0.2.1)"
         value: ${{ steps.calc.outputs.version_base }}
     version_type:
-        description: "Version type (stable or alpha)"
+        description: "Version type (stable, prerelease, or alpha)"
         value: ${{ steps.calc.outputs.version_type }}
     commit_sha:
         description: "Full commit SHA"
@@ -44,14 +44,21 @@ runs:
               echo "commit_short=${COMMIT_SHORT}" >> $GITHUB_OUTPUT
               echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
 
-              if [[ "${{ github.ref_type }}" == "tag" && "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                VERSION="${{ github.ref_name }}"
-                VERSION="${VERSION#v}"
-                VERSION_TYPE="stable"
+              REF_TYPE="${{ github.ref_type }}"
+              REF_NAME="${{ github.ref_name }}"
 
-                echo "version=${VERSION}" >> $GITHUB_OUTPUT
-                echo "version_base=${VERSION}" >> $GITHUB_OUTPUT
-                echo "version_type=${VERSION_TYPE}" >> $GITHUB_OUTPUT
+              # Stable: vX.Y.Z — numeric only, no pre-release suffix.
+              if [[ "$REF_TYPE" == "tag" && "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                VERSION="${REF_NAME#v}"
+                VERSION_BASE="${VERSION}"
+                VERSION_TYPE="stable"
+              # Prerelease: vX.Y.Z-rcN — trailing digit required, so a bare
+              # "rc" falls through to alpha. The rc-segment regex accepts both
+              # "rc1" and the dotted "rc.1" / "rc1.2" forms.
+              elif [[ "$REF_TYPE" == "tag" && "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9.]*[0-9]+$ ]]; then
+                VERSION="${REF_NAME#v}"
+                VERSION_BASE="${VERSION%%-rc*}"
+                VERSION_TYPE="prerelease"
               else
                 VERSION_TYPE="alpha"
 
@@ -78,8 +85,8 @@ runs:
 
                 VERSION_BASE="${MAJOR}.${MINOR}.${PATCH}"
                 VERSION="${VERSION_BASE}-alpha.${COMMIT_COUNT}"
-
-                echo "version=${VERSION}" >> $GITHUB_OUTPUT
-                echo "version_base=${VERSION_BASE}" >> $GITHUB_OUTPUT
-                echo "version_type=${VERSION_TYPE}" >> $GITHUB_OUTPUT
               fi
+
+              echo "version=${VERSION}" >> $GITHUB_OUTPUT
+              echo "version_base=${VERSION_BASE}" >> $GITHUB_OUTPUT
+              echo "version_type=${VERSION_TYPE}" >> $GITHUB_OUTPUT

--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -6,6 +6,13 @@ on:
             version:
                 type: string
                 required: true
+            # version_base and version_type are retained for caller
+            # compatibility (ci.yml and tauri.yml pass them) but are no longer
+            # consumed inside this workflow after ADR-025: artifact naming is
+            # unconditional (always versioned + fixed alias), and update-version
+            # receives the full `version` so prerelease binaries report their
+            # rc suffix. Kept as required to avoid a contract-breaking change
+            # to the workflow_call signature in the same PR.
             version_base:
                 type: string
                 required: true
@@ -102,7 +109,7 @@ jobs:
             - name: Update version in config files
               uses: ./.github/actions/update-version
               with:
-                  version: ${{ inputs.version_base }}
+                  version: ${{ inputs.version }}
 
             - name: Install build dependencies
               run: apt-get update && apt-get install -y nsis clang lld llvm protobuf-compiler
@@ -132,13 +139,18 @@ jobs:
               env:
                   TAURI_BUNDLE_NSIS: "true"
 
-            - name: Rename artifacts for latest release
-              if: inputs.version_type != 'stable'
-              working-directory: target/x86_64-pc-windows-msvc/release/bundle
+            - name: Create fixed-name alias
+              working-directory: target/x86_64-pc-windows-msvc/release/bundle/nsis
+              env:
+                  VERSION: ${{ inputs.version }}
               run: |
-                  # Rename NSIS
-                  for f in nsis/*.exe; do mv "$f" "nsis/origa_latest_x64-setup.exe"; done
-                  for f in nsis/*.sig; do mv "$f" "nsis/origa_latest_x64-setup.exe.sig"; done
+                  # Tauri emits Origa_<version>_x64-setup.exe (+ .exe.sig updater
+                  # signature). Mirror to a fixed-name alias so the landing
+                  # page's /releases/latest/download/Origa_x64-setup.exe link
+                  # resolves on every release — GitHub's "latest" download URL
+                  # requires a filename that does not change between releases.
+                  cp "Origa_${VERSION}_x64-setup.exe" "Origa_x64-setup.exe"
+                  [ -f "Origa_${VERSION}_x64-setup.exe.sig" ] && cp "Origa_${VERSION}_x64-setup.exe.sig" "Origa_x64-setup.exe.sig" || true
 
             - name: Extract signature
               id: signature
@@ -191,7 +203,7 @@ jobs:
             - name: Update version in config files
               uses: ./.github/actions/update-version
               with:
-                  version: ${{ inputs.version_base }}
+                  version: ${{ inputs.version }}
 
             - name: Cache APT packages
               uses: awalsh128/cache-apt-pkgs-action@v1.6.1
@@ -223,15 +235,17 @@ jobs:
               working-directory: tauri
               run: cargo tauri build --target x86_64-unknown-linux-gnu
 
-            - name: Rename artifacts for latest release
-              if: inputs.version_type != 'stable'
+            - name: Create fixed-name aliases
               working-directory: target/x86_64-unknown-linux-gnu/release/bundle
+              env:
+                  VERSION: ${{ inputs.version }}
               run: |
-                  # Rename AppImage
-                  for f in appimage/*.AppImage; do mv "$f" "appimage/origa_latest_amd64.AppImage"; done
-                  for f in appimage/*.sig; do mv "$f" "appimage/origa_latest_amd64.AppImage.sig"; done
-                  # Rename DEB
-                  for f in deb/*.deb; do mv "$f" "deb/origa_latest_amd64.deb"; done
+                  # Tauri emits Origa_<version>_amd64.AppImage/.deb (+ .AppImage.sig
+                  # updater signature). Mirror each to a fixed-name alias for the
+                  # landing page's /releases/latest/download/<fixed> links.
+                  cp "appimage/Origa_${VERSION}_amd64.AppImage" "appimage/Origa_amd64.AppImage"
+                  [ -f "appimage/Origa_${VERSION}_amd64.AppImage.sig" ] && cp "appimage/Origa_${VERSION}_amd64.AppImage.sig" "appimage/Origa_amd64.AppImage.sig" || true
+                  cp "deb/Origa_${VERSION}_amd64.deb" "deb/Origa_amd64.deb"
 
             - name: Extract signature
               id: signature
@@ -295,7 +309,7 @@ jobs:
             - name: Update version in config files
               uses: ./.github/actions/update-version
               with:
-                  version: ${{ inputs.version_base }}
+                  version: ${{ inputs.version }}
 
             - name: Install build dependencies
               run: apt-get update && apt-get install -y zip protobuf-compiler
@@ -323,6 +337,8 @@ jobs:
               run: echo "signature=" >> $GITHUB_OUTPUT
 
             - name: Create macOS app bundle
+              env:
+                  VERSION: ${{ inputs.version }}
               run: |
                   mkdir -p Origa.app/Contents/MacOS
                   mkdir -p Origa.app/Contents/Resources
@@ -350,13 +366,18 @@ jobs:
                   </plist>
                   EOF
                   chmod +x Origa.app/Contents/MacOS/origa
-                  zip -r Origa-macos-arm64.zip Origa.app
+                  # Versioned archive for release history, plus a fixed-name alias
+                  # for the landing page's /releases/latest/download/Origa_macos-arm64.zip.
+                  zip -r "Origa_${VERSION}_macos-arm64.zip" Origa.app
+                  cp "Origa_${VERSION}_macos-arm64.zip" "Origa_macos-arm64.zip"
 
             - name: Upload macOS artifacts
               uses: actions/upload-artifact@v4
               with:
                   name: macos-build
-                  path: Origa-macos-arm64.zip
+                  path: |
+                      Origa_${{ inputs.version }}_macos-arm64.zip
+                      Origa_macos-arm64.zip
                   retention-days: 7
 
     build-android:
@@ -391,7 +412,7 @@ jobs:
             - name: Update version in config files
               uses: ./.github/actions/update-version
               with:
-                  version: ${{ inputs.version_base }}
+                  version: ${{ inputs.version }}
 
             - name: Install system dependencies
               run: |
@@ -485,16 +506,22 @@ jobs:
                   echo "=== Start build ==="
                   cargo tauri android build 2>&1 || (echo "Build failed with exit code $?"; exit 1)
 
-            - name: Rename APK for latest release
-              if: inputs.version_type != 'stable'
+            - name: Rename APK to versioned and alias names
               working-directory: tauri/gen/android/app/build/outputs/apk
+              env:
+                  VERSION: ${{ inputs.version }}
               run: |
-                  for f in release/*.apk; do
-                    if [ -f "$f" ]; then
-                      mv "$f" "release/origa-latest.apk"
-                      echo "Renamed to origa-latest.apk"
-                    fi
-                  done
+                  # Gradle emits app-universal-release.apk. mv (not cp) the
+                  # source to the versioned name so the uninformative default
+                  # name does not leak into release assets, then cp to a fixed
+                  # alias for the landing page's /releases/latest/download/origa.apk.
+                  src=$(ls release/*.apk 2>/dev/null | head -1 || true)
+                  if [ -z "$src" ] || [ ! -f "$src" ]; then
+                    echo "::error::No APK produced by Gradle in release/"
+                    exit 1
+                  fi
+                  mv "$src" "release/origa_${VERSION}.apk"
+                  cp "release/origa_${VERSION}.apk" "release/origa.apk"
 
             - name: Upload Android APK
               uses: actions/upload-artifact@v4

--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -511,21 +511,28 @@ jobs:
               env:
                   VERSION: ${{ inputs.version }}
               run: |
-                  # Gradle emits app-universal-release.apk. mv (not cp) the
-                  # source to the versioned name so the uninformative default
-                  # name does not leak into release assets, then cp to a fixed
-                  # alias for the landing page's /releases/latest/download/origa.apk.
-                  src=$(ls release/*.apk 2>/dev/null | head -1 || true)
+                  # Gradle emits app-universal-release.apk under a per-ABI subdir
+                  # (e.g. universal/release/), whose depth varies across AGP/
+                  # Tauri versions — locate it with `find` instead of a fixed
+                  # `release/*.apk` glob, then cp to a versioned name and a fixed
+                  # alias for /releases/latest/download/origa.apk. The default
+                  # Gradle name is excluded from the release by the explicit
+                  # Upload paths below (the publish job copies every *.apk).
+                  src=$(find . -name "*.apk" -type f | head -1)
                   if [ -z "$src" ] || [ ! -f "$src" ]; then
-                    echo "::error::No APK produced by Gradle in release/"
+                    echo "::error::No APK produced by Gradle under $(pwd)"
+                    echo "--- Files under $(pwd) ---"
+                    find . -type f | head -30 || true
                     exit 1
                   fi
-                  mv "$src" "release/origa_${VERSION}.apk"
-                  cp "release/origa_${VERSION}.apk" "release/origa.apk"
+                  cp "$src" "origa_${VERSION}.apk"
+                  cp "$src" "origa.apk"
 
             - name: Upload Android APK
               uses: actions/upload-artifact@v4
               with:
                   name: android-apk
-                  path: tauri/gen/android/app/build/outputs/apk/**/*.apk
+                  path: |
+                      tauri/gen/android/app/build/outputs/apk/origa_${{ inputs.version }}.apk
+                      tauri/gen/android/app/build/outputs/apk/origa.apk
                   retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ permissions:
 jobs:
     version:
         name: Version
-        if: github.event_name == 'pull_request'
         permissions:
             contents: read
         runs-on: ubuntu-latest
@@ -386,7 +385,6 @@ jobs:
     build-tauri:
         name: Build Tauri
         needs: [version, e2e-build]
-        if: github.event_name == 'pull_request'
         uses: ./.github/workflows/_build-tauri.yml
         with:
             version: ${{ needs.version.outputs.version }}
@@ -409,7 +407,6 @@ jobs:
         name: Docker Build (landing)
         permissions:
             contents: read
-        if: github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
@@ -433,7 +430,6 @@ jobs:
         name: Docker Build (ui)
         permissions:
             contents: read
-        if: github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
@@ -477,8 +473,8 @@ jobs:
                   check "lint" "${{ needs.lint.result }}" "success"
                   check "test" "${{ needs.test.result }}" "success"
                   check "e2e" "${{ needs.e2e.result }}" "success"
-                  check "docker-build-landing" "${{ needs.docker-build-landing.result }}" "success" "skipped"
-                  check "docker-build-ui" "${{ needs.docker-build-ui.result }}" "success" "skipped"
-                  check "build-tauri" "${{ needs.build-tauri.result }}" "success" "skipped"
+                  check "docker-build-landing" "${{ needs.docker-build-landing.result }}" "success"
+                  check "docker-build-ui" "${{ needs.docker-build-ui.result }}" "success"
+                  check "build-tauri" "${{ needs.build-tauri.result }}" "success"
 
             - run: echo "All checks passed"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,6 @@
 name: Build and Push Docker Images
 
 on:
-    workflow_run:
-        workflows: ["CI"]
-        types: [completed]
-        branches: [master]
     push:
         tags:
             - "v*.*.*"
@@ -19,9 +15,46 @@ env:
     IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+    require-ci-green:
+        name: Require CI green
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+        steps:
+            - name: Verify CI passed for this commit
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  EVENT: ${{ github.event_name }}
+              run: |
+                  # workflow_dispatch is an operator escape-hatch: trust the
+                  # operator, skip the CI gate. Automatic tag-push CD requires
+                  # the commit's full CI (lint+test+e2e+build-tauri+docker-build)
+                  # to be green first, restoring the invariant the previous
+                  # workflow_run trigger implicitly enforced.
+                  if [ "$EVENT" != "push" ]; then
+                    echo "Manual dispatch ($EVENT) — bypassing CI gate"
+                    exit 0
+                  fi
+
+                  RUN_ID=$(gh run list \
+                    --repo ${{ github.repository }} \
+                    --workflow ci.yml \
+                    --commit "${{ github.sha }}" \
+                    --status success \
+                    --limit 1 \
+                    --json databaseId \
+                    --jq '.[0].databaseId' 2>/dev/null || echo "")
+
+                  if [ -z "$RUN_ID" ]; then
+                    echo "::error::No successful CI run found for commit ${{ github.sha }}. Tag-triggered CD requires a green CI run first."
+                    exit 1
+                  fi
+                  echo "CI run $RUN_ID is green for ${{ github.sha }}"
+
     version:
         permissions:
             contents: read
+        needs: [require-ci-green]
         runs-on: ubuntu-latest
         outputs:
             version: ${{ steps.version.outputs.version }}
@@ -42,11 +75,7 @@ jobs:
 
     build-and-push:
         name: Build and Push (${{ matrix.image }})
-        needs: [version]
-        if: >
-            github.event_name == 'push' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        needs: [require-ci-green, version]
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -91,8 +120,7 @@ jobs:
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}
                   tags: |
-                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-                      type=raw,value=edge,enable=${{ github.ref == 'refs/heads/master' }}
+                      type=raw,value=latest,enable=${{ needs.version.outputs.version_type == 'stable' }}
                       type=raw,value=${{ needs.version.outputs.version }}
                       type=sha,prefix=
 
@@ -114,8 +142,8 @@ jobs:
         name: Deploy to Railway
         permissions:
             contents: read
-        needs: [version, build-and-push]
-        if: success()
+        needs: [require-ci-green, version, build-and-push]
+        if: success() && startsWith(github.ref, 'refs/tags/v') && needs.version.outputs.version_type == 'stable'
         runs-on: ubuntu-latest
         container: ghcr.io/railwayapp/cli:latest
         steps:

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -1,10 +1,6 @@
 name: Build Tauri App
 
 on:
-    workflow_run:
-        workflows: ["CI"]
-        types: [completed]
-        branches: [master]
     push:
         tags:
             - "v*.*.*"
@@ -21,9 +17,46 @@ permissions:
     contents: read
 
 jobs:
+    require-ci-green:
+        name: Require CI green
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+        steps:
+            - name: Verify CI passed for this commit
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  EVENT: ${{ github.event_name }}
+              run: |
+                  # workflow_dispatch is an operator escape-hatch: trust the
+                  # operator, skip the CI gate. Automatic tag-push CD requires
+                  # the commit's full CI (lint+test+e2e+build-tauri+docker-build)
+                  # to be green first, restoring the invariant the previous
+                  # workflow_run trigger implicitly enforced.
+                  if [ "$EVENT" != "push" ]; then
+                    echo "Manual dispatch ($EVENT) — bypassing CI gate"
+                    exit 0
+                  fi
+
+                  RUN_ID=$(gh run list \
+                    --repo ${{ github.repository }} \
+                    --workflow ci.yml \
+                    --commit "${{ github.sha }}" \
+                    --status success \
+                    --limit 1 \
+                    --json databaseId \
+                    --jq '.[0].databaseId' 2>/dev/null || echo "")
+
+                  if [ -z "$RUN_ID" ]; then
+                    echo "::error::No successful CI run found for commit ${{ github.sha }}. Tag-triggered CD requires a green CI run first."
+                    exit 1
+                  fi
+                  echo "CI run $RUN_ID is green for ${{ github.sha }}"
+
     version:
         permissions:
             contents: read
+        needs: [require-ci-green]
         runs-on: ubuntu-latest
         outputs:
             version: ${{ steps.version.outputs.version }}
@@ -46,11 +79,7 @@ jobs:
         name: Build Frontend
         permissions:
             contents: read
-        needs: [version]
-        if: >
-            github.event_name == 'push' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        needs: [require-ci-green, version]
         runs-on: ubuntu-24.04
         env:
             ORIGA_VERSION: ${{ needs.version.outputs.version }}
@@ -63,7 +92,7 @@ jobs:
             - name: Update version in config files
               uses: ./.github/actions/update-version
               with:
-                  version: ${{ needs.version.outputs.version_base }}
+                  version: ${{ needs.version.outputs.version }}
 
             - name: Cache APT packages
               uses: awalsh128/cache-apt-pkgs-action@v1.6.1
@@ -104,11 +133,7 @@ jobs:
 
     build-tauri:
         name: Build Tauri
-        needs: [version, build-frontend]
-        if: >
-            github.event_name == 'push' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        needs: [require-ci-green, version, build-frontend]
         uses: ./.github/workflows/_build-tauri.yml
         with:
             version: ${{ needs.version.outputs.version }}
@@ -129,11 +154,8 @@ jobs:
 
     generate-latest-json:
         name: Generate latest.json
-        if: >
-            github.event_name == 'push' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
-        needs: [version, build-tauri]
+        if: startsWith(github.ref, 'refs/tags/v') && needs.version.outputs.version_type == 'stable'
+        needs: [require-ci-green, version, build-tauri]
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -141,23 +163,27 @@ jobs:
             - name: Generate latest.json
               env:
                   VERSION: ${{ needs.version.outputs.version }}
-                  VERSION_TYPE: ${{ needs.version.outputs.version_type }}
+                  GIT_TAG: ${{ github.ref_name }}
                   WIN_SIG: ${{ needs.build-tauri.outputs.windows-signature }}
                   LINUX_SIG: ${{ needs.build-tauri.outputs.linux-signature }}
               run: |
-                  if [ "$VERSION_TYPE" != "stable" ]; then
-                    FILE_VERSION="latest"
-                  else
-                    FILE_VERSION="${VERSION}"
-                  fi
+                  # Stable-only: prereleases deliberately do NOT refresh the
+                  # updater manifest, so users on the stable channel never get
+                  # auto-updated to an rc build. The URL tag segment is the git
+                  # tag (v-prefixed, e.g. v1.0.0) — it MUST match the release's
+                  # tag_name (github.ref_name), not the stripped version. The
+                  # asset filename segment keeps the stripped version because
+                  # Tauri stamps bundle names from tauri.conf.json:version (no v).
+                  # The manifest's `version` field is the bare version (1.0.0)
+                  # the updater compares against.
                   jq -n \
                     --arg version "$VERSION" \
                     --arg notes "Release $VERSION" \
                     --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
                     --arg win_sig "$WIN_SIG" \
                     --arg linux_sig "$LINUX_SIG" \
-                    --arg win_url "https://github.com/yurvon-screamo/origa/releases/download/${FILE_VERSION}/origa_${FILE_VERSION}_x64-setup.exe" \
-                    --arg linux_url "https://github.com/yurvon-screamo/origa/releases/download/${FILE_VERSION}/origa_${FILE_VERSION}_amd64.AppImage" \
+                    --arg win_url "https://github.com/yurvon-screamo/origa/releases/download/${GIT_TAG}/Origa_${VERSION}_x64-setup.exe" \
+                    --arg linux_url "https://github.com/yurvon-screamo/origa/releases/download/${GIT_TAG}/Origa_${VERSION}_amd64.AppImage" \
                     '{
                       version: $version,
                       notes: $notes,
@@ -183,13 +209,19 @@ jobs:
                   retention-days: 7
 
     release:
-        name: Update Latest Release
+        name: Publish Release
         if: >
-            github.event_name == 'push' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+            always() &&
+            needs.require-ci-green.result == 'success' &&
+            needs.build-tauri.result == 'success' &&
+            startsWith(github.ref, 'refs/tags/v') &&
+            (needs.version.outputs.version_type == 'stable' ||
+             needs.version.outputs.version_type == 'prerelease') &&
+            (needs.version.outputs.version_type != 'stable' ||
+             needs.generate-latest-json.result == 'success')
         needs:
             [
+                require-ci-green,
                 version,
                 build-tauri,
                 generate-latest-json,
@@ -207,49 +239,58 @@ jobs:
               run: |
                   mkdir -p release_assets
                   # Keep only installable bundles + the updater manifest.
-                  # Intermediate artifacts (frontend-dist WASM, *.sig updater
-                  # signatures already embedded into latest.json by the
-                  # generate-latest-json job) are intentionally excluded so the
-                  # release stays small and uncluttered.
+                  # Each platform ships BOTH a versioned name (release history
+                  # + the exact asset latest.json points at) and a fixed-name
+                  # alias (so /releases/latest/download/<alias> resolves for the
+                  # landing page). Intermediate artifacts (frontend-dist WASM,
+                  # *.sig signatures already embedded into latest.json) are
+                  # excluded so the release stays small. cp -f (not -n): every
+                  # tag is a fresh release, no accumulation across runs.
                   find artifacts -type f \( \
                       -name '*-setup.exe' -o \
                       -name '*.msi' -o \
                       -name '*.AppImage' -o \
                       -name '*.deb' -o \
                       -name '*.dmg' -o \
-                      -name 'Origa-macos-arm64.zip' -o \
+                      -name 'Origa_*macos-arm64.zip' -o \
                       -name '*.apk' -o \
                       -name 'latest.json' \
-                  \) -exec cp -n {} release_assets/ \;
+                  \) -exec cp -f {} release_assets/ \;
                   echo "Release assets content:"
                   ls -la release_assets/
 
-            - name: Update latest release
+            - name: Publish release
               uses: softprops/action-gh-release@v2
               with:
-                  tag_name:
-                      ${{ needs.version.outputs.version_type == 'stable' &&
-                      needs.version.outputs.version || 'latest' }}
-                  name: ${{ needs.version.outputs.version_type == 'stable' &&
-                      format('Release {0}', needs.version.outputs.version) || format('Latest
-                      Build ({0})', needs.version.outputs.version) }}
+                  tag_name: ${{ github.ref_name }}
+                  name: ${{ needs.version.outputs.version_type == 'prerelease' && format('Pre-release {0}', needs.version.outputs.version) || format('Release {0}', needs.version.outputs.version) }}
                   body: |
-                      Автоматическая сборка от ${{ github.sha }}
+                      ${{ needs.version.outputs.version_type == 'prerelease' && 'Pre-release build — not for the stable update channel.' || format('Release {0}', needs.version.outputs.version) }}
+
+                      Commit: ${{ github.sha }}
 
                       ## Windows
-                      - `origa_*_x64-setup.exe` - NSIS инсталлятор
+                      - `Origa_${{ needs.version.outputs.version }}_x64-setup.exe` — NSIS installer
+                      - `Origa_x64-setup.exe` — fixed-name alias (latest direct download)
 
                       ## Linux
-                      - `*.AppImage` - Portable версия
-                      - `*.deb` - Debian/Ubuntu пакет
+                      - `Origa_${{ needs.version.outputs.version }}_amd64.AppImage` — portable
+                      - `Origa_amd64.AppImage` — fixed-name alias
+                      - `Origa_${{ needs.version.outputs.version }}_amd64.deb` — Debian/Ubuntu
+                      - `Origa_amd64.deb` — fixed-name alias
 
                       ## macOS
-                      - `Origa-macos-arm64.zip` - Apple Silicon
+                      - `Origa_${{ needs.version.outputs.version }}_macos-arm64.zip` — Apple Silicon
+                      - `Origa_macos-arm64.zip` — fixed-name alias
 
                       ## Android
-                      - `origa-latest.apk` - Android APK
+                      - `origa_${{ needs.version.outputs.version }}.apk`
+                      - `origa.apk` — fixed-name alias
+
+                      ## Updater
+                      - `latest.json` — Tauri updater manifest (stable releases only)
                   generate_release_notes: true
                   files: release_assets/*
-                  prerelease: ${{ needs.version.outputs.version_type != 'stable' }}
+                  prerelease: ${{ needs.version.outputs.version_type == 'prerelease' }}
                   draft: false
-                  make_latest: true
+                  make_latest: ${{ needs.version.outputs.version_type == 'stable' }}

--- a/docs/decisions/ADR-025-ci-cd-tag-based-releases.md
+++ b/docs/decisions/ADR-025-ci-cd-tag-based-releases.md
@@ -1,0 +1,409 @@
+# ADR-025: Tag-based CI/CD — stable / prerelease / alpha channels
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-03
+
+## Context
+
+Before this ADR, the CI/CD topology conflated two concerns: **verifying a
+commit** (CI) and **shipping it** (CD). Three workflows ran CD on every
+successful master CI run via the `workflow_run` trigger:
+
+- `docker.yml` — built and pushed both Docker images to GHCR, then redeployed
+  Railway (production landing + UI).
+- `tauri.yml` — built all four Tauri clients, regenerated `latest.json`, and
+  published/updated a **perpetual release tagged `latest`** on every master CI
+  success.
+
+This had several problems:
+
+1. **Production deployed on every master push.** `workflow_run` with
+   `conclusion == 'success'` redeployed Railway as soon as CI was green — no
+   human gate, no tag, no version bump. A master push was effectively a
+   release.
+2. **The `latest` pseudo-release accumulated garbage.** `tauri.yml:185`
+   created/updated a GitHub release tagged `latest` on every master CI success.
+   Because `softprops/action-gh-release` keeps existing assets by default and
+   the asset filter used `cp -n` (no-clobber), the `latest` release accumulated
+   **130+ assets** across historical runs — WASM bundles (`origa_ui-*.wasm`),
+   dictionary binaries (`char_def.bin`, `dict.*`), landing images (`anki.svg`),
+   CSS, and `index.html`. It was marked `prerelease: true`, so GitHub excluded
+   it from `/releases/latest` resolution — meaning the pseudo-release was
+   simultaneously noisy (130 junk assets) and functionally invisible.
+3. **No prerelease channel.** The `version` action distinguished only `stable`
+   (numeric tag) and `alpha` (everything else). There was no way to cut an `rc`
+   build for validation without it being treated as either a full release or an
+   alpha.
+4. **Inconsistent artifact names.** `_build-tauri.yml` renamed artifacts to
+   `origa_latest_*` (lowercase) only when `version_type != 'stable'`. Stable
+   builds kept Tauri's default `Origa_<version>_*` (capital). The landing page
+   linked to `/releases/latest` (the GitHub release UI), not to specific files,
+   so users landed on a web page rather than getting a direct download.
+5. **CI verified Tauri/Docker builds only on PRs.** `ci.yml` gated
+   `build-tauri`, `docker-build-landing`, and `docker-build-ui` behind
+   `if: github.event_name == 'pull_request'`. On master push these were skipped
+   — so a master commit could merge, deploy to production via `workflow_run`,
+   and never have had its Tauri or Docker build verified by CI (only by the CD
+   pipeline itself, where a failure means a failed production deploy).
+
+### Current state at the time of this ADR (verified)
+
+- Stable releases **exist**: 0.2.0 → 0.4.0. The `0.4.0` release is
+  `make_latest` (marked "Latest" by GitHub), `prerelease: false`, with assets
+  `Origa_0.4.0_x64-setup.exe`, `Origa_0.4.0_amd64.AppImage/.deb`,
+  `Origa-macos-arm64.zip`, `app-universal-release.apk`, and a working
+  `latest.json`.
+- The Tauri updater endpoint (`tauri/tauri.conf.json:56`) is
+  `/releases/latest/download/latest.json`. It currently resolves to 0.4.0's
+  `latest.json` → **the updater is functional for the 0.4.0 install base.**
+- The `latest`-tagged pseudo-release is `prerelease: true`, so it is **excluded**
+  from `/releases/latest` resolution. Deleting it is **cosmetic cleanup**
+  (removes 130 junk assets), not a functional fix — the updater and
+  `/releases/latest` are unaffected by its presence or absence.
+- Historical bare tags `0.2.0`–`0.4.0` (without the `v` prefix) exist because
+  the old `release` job used `tag_name: ${{ needs.version.outputs.version }}`
+  (the version with `v` stripped), creating a second tag alongside the git tag
+  `v0.4.0`.
+
+## Decision
+
+### 1. Master push = full CI only; tags = CD
+
+- `ci.yml` triggers on `pull_request`, `push` (master), and `workflow_dispatch`.
+  It now runs the **full** CI matrix on every event: lint, test, e2e,
+  `build-tauri` (compile verification, no publish), and both `docker-build-*`
+  jobs (build verification, `push: false`). The `version`, `build-tauri`,
+  `docker-build-landing`, and `docker-build-ui` jobs previously gated on
+  `pull_request` now run unconditionally — the `check` (CI Gate) job requires
+  `success` for all of them (no longer tolerates `skipped`).
+- `docker.yml` and `tauri.yml` trigger **only** on `push: tags: [v*.*.*]` and
+  `workflow_dispatch`. The `workflow_run` trigger is removed entirely. There is
+  no CD on master push.
+
+### 2. `require-ci-green` restores the "CI green before CD" invariant
+
+Removing `workflow_run` also removed its implicit gate — that CD only ran after
+CI concluded `success`. To restore this invariant for tag-triggered CD, both
+`docker.yml` and `tauri.yml` gain a first job `require-ci-green` that queries
+the GitHub API (via the pre-installed `gh` CLI) for a successful `ci.yml` run
+matching the tagged commit's full SHA:
+
+```bash
+gh run list --workflow ci.yml --commit <sha> --status success --limit 1
+```
+
+Every downstream job lists `require-ci-green` in its `needs`. On
+`workflow_dispatch`, the job auto-succeeds (operator escape-hatch — the operator
+is the gate). On `push` (tag), it fails closed if no green CI run exists for the
+commit. This was empirically verified: `gh run list --commit <full-sha>
+--status success` returns the run databaseId, and an empty result prints an
+empty string (not `null`), so the `[ -z "$RUN_ID" ]` guard is correct.
+`--commit` matches only the full 40-character SHA; `github.sha` in CI is always
+full.
+
+### 3. Three version channels via the `version` action
+
+`version/action.yml` now emits `version_type ∈ {stable, prerelease, alpha}`:
+
+- **stable** — tag matches `^v[0-9]+\.[0-9]+\.[0-9]+$` (e.g. `v1.0.0`).
+  `version` = `1.0.0`, `version_base` = `1.0.0`.
+- **prerelease** — tag matches `^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9.]*[0-9]+$`,
+  covering both `v1.0.0-rc1` and `v1.0.0-rc.1`. A bare `rc` (no trailing digit)
+  falls through to alpha. `version` = `1.0.0-rc1`, `version_base` = `1.0.0`.
+- **alpha** — everything else (master push, PR, non-conforming tag). Unchanged:
+  derives `MAJOR.MINOR.PATCH-alpha.<commit-count>` via `git describe`.
+
+All existing consumers use `== 'stable'` or `!= 'stable'` comparisons, so
+adding `prerelease` is backward-compatible — no consumer breaks.
+
+### 4. Release semantics (`tauri.yml` `release` job)
+
+- `if:` requires a `v` tag **and** `version_type ∈ {stable, prerelease}`. An
+  alpha-type tag (e.g. a hypothetical `v1.0.0-beta1` → alpha) does **not**
+  create a release; build jobs still run (minor waste, acceptable).
+- `tag_name: ${{ github.ref_name }}` — the actual git tag (`v1.0.0` or
+  `v1.0.0-rc1`). This attaches the release to the tag that triggered the
+  workflow and **stops creating duplicate bare tags** (the old
+  `tag_name: version` created `0.4.0` alongside `v0.4.0`).
+- `make_latest: ${{ version_type == 'stable' }}` — only stable releases become
+  GitHub's "Latest". Prereleases are `make_latest: false`, so
+  `/releases/latest` keeps pointing at the prior stable until a new stable tag
+  supersedes it.
+- `prerelease: ${{ version_type == 'prerelease' }}` — rc releases are marked
+  prerelease (GitHub excludes them from `/releases/latest`).
+- `name` — `Release <version>` for stable, `Pre-release <version>` for
+  prerelease.
+- `cp -f` (not `-n`) in `Prepare release assets`: every tag is a fresh release,
+  no cross-run asset accumulation.
+
+### 5. `latest.json` is stable-only
+
+`generate-latest-json` runs `if: startsWith(github.ref, 'refs/tags/v') &&
+version_type == 'stable'`. Prereleases deliberately do **not** refresh the
+updater manifest — users on the stable channel never get auto-updated to an rc.
+The manifest's URL tag segment is the **git tag** (`github.ref_name`, e.g.
+`v1.0.0`) — it must match the release's `tag_name` (§4); using the stripped
+version (`1.0.0`) would 404, because the new `tag_name: github.ref_name` no
+longer creates a duplicate bare tag the way the old `tag_name: version` did.
+The asset filename segment keeps the stripped version (`Origa_1.0.0_*`) because
+Tauri stamps bundle names from `tauri.conf.json:version` (no `v`). The
+manifest's `version` field is the bare version (`1.0.0`) the updater compares
+against. (Research finding: the official `tauri-action` generates `latest.json`
+with GitHub API asset URLs — so the manifest is filename-agnostic; only the
+landing page needs fixed names.)
+
+The `release` job lists `generate-latest-json` in `needs` (for artifact
+ordering — `latest.json` must be uploaded before `release` downloads it), with
+`if: always() && ... && (version_type != 'stable' ||
+generate-latest-json.result == 'success')`: for stable, a failed
+`generate-latest-json` blocks the release (no broken updater manifest); for
+prerelease, the skipped `generate-latest-json` is tolerated.
+
+### 6. Dual artifact naming (versioned + fixed alias)
+
+`_build-tauri.yml` produces **two** files per platform after every build:
+
+| Platform | Versioned (release history + updater target) | Fixed alias (landing direct download) |
+| --- | --- | --- |
+| Windows NSIS | `Origa_<version>_x64-setup.exe` | `Origa_x64-setup.exe` |
+| Linux AppImage | `Origa_<version>_amd64.AppImage` | `Origa_amd64.AppImage` |
+| Linux DEB | `Origa_<version>_amd64.deb` | `Origa_amd64.deb` |
+| macOS zip | `Origa_<version>_macos-arm64.zip` | `Origa_macos-arm64.zip` |
+| Android APK | `origa_<version>.apk` | `origa.apk` |
+
+Desktop uses `Origa_` (capital) to match Tauri's `productName: "Origa"` default
+output (verified against the 0.4.0 release assets); Android uses lowercase
+`origa` because Gradle's output (`app-universal-release.apk`) carries no
+productName and the historical `origa-latest.apk` convention was lowercase. The
+versioned file is Tauri's/Gradle's default output (not renamed); the alias is
+created via `cp` (not `mv`) so both exist. The previous `Rename artifacts for
+latest release` steps (`if: version_type != 'stable'`) are deleted — naming is
+now unconditional across all channels.
+
+The release job's `find` glob was updated: the macOS pattern changed from
+`-name 'Origa-macos-arm64.zip'` (hyphen) to `-name 'Origa_*macos-arm64.zip'`
+(underscore, matches both versioned and alias). Windows/Linux/Android globs
+(`*-setup.exe`, `*.AppImage`, `*.deb`, `*.apk`) already matched both names.
+
+### 7. `update-version` receives the full version
+
+All `update-version` call sites (`tauri.yml` build-frontend, `_build-tauri.yml`
+four build jobs) now pass `version` (full) instead of `version_base`. Rationale:
+a prerelease binary must report its rc suffix so the Tauri updater can order it
+correctly. For `v1.0.0-rc1`, `tauri.conf.json` is stamped `1.0.0-rc1`; when
+stable `1.0.0` ships, `latest.json.version = 1.0.0` and the updater compares
+`1.0.0-rc1 < 1.0.0` (semver pre-release ordering) → offers the stable update to
+rc users. For stable, `version == version_base` (no change). For alpha, the
+binary now reports `0.4.1-alpha.N` instead of the bare base (more informative;
+harmless). `version_base` is retained as a `version` action output for
+reference but no longer feeds `update-version`.
+
+### 8. Railway deploy is stable-only
+
+`docker.yml` `deploy-to-railway`: `if: success() && startsWith(github.ref,
+'refs/tags/v') && version_type == 'stable'`. `build-and-push` (GHCR image push)
+runs on any `v` tag (rc images land in GHCR, no production effect until Railway
+redeploys), but Railway production redeploy happens only on stable tags. This
+makes the rc-first validation strategy (see Migration) safe for the landing
+page: an rc tag does not redeploy production with new fixed-alias URLs while
+`/releases/latest` still points at the prior stable (which lacks alias assets).
+The `:latest` Docker image tag is likewise gated on stable (`type=raw,value=latest,
+enable=${{ version_type == 'stable' }}`); the dead `:edge` tag (master-only,
+now that docker.yml no longer runs on master) is removed.
+
+### 9. Landing direct download links
+
+`origa_landing/src/pages/download.rs` replaces the single `GITHUB_RELEASES_URL`
+(which linked to the release UI page) with per-platform constants pointing at
+`/releases/latest/download/<fixed-alias>`. Clicking starts the file download
+directly (GitHub serves these with `Content-Disposition: attachment`); no
+`target="_blank"` (direct-download URLs keep the current tab and trigger the
+file save dialog). Research finding: `/releases/latest/download/<name>` requires
+a **fixed** filename — versioned names break on every release — which is why
+the fixed aliases in §6 exist.
+
+## Migration (post-merge, manual — documented in the PR)
+
+The refactor ships behind the normal tag-based pipeline. Because a live 0.4.0
+install base depends on the updater, the first post-merge tag is validated with
+**rc-first** rather than directly on stable:
+
+1. **(Merge this PR.)** Master now runs full CI; `docker.yml`/`tauri.yml` are
+   dormant until a tag is pushed.
+2. **Push `v0.4.1-rc1`.** This triggers CD with `version_type=prerelease`:
+   - `require-ci-green` verifies the commit's CI is green.
+   - Tauri builds produce dual-named artifacts.
+   - A prerelease GitHub release is created (`make_latest: false`, marked
+     prerelease). `/releases/latest` still points at 0.4.0 (unaffected).
+   - `latest.json` is **not** regenerated (prerelease).
+   - Railway is **not** redeployed (stable-only). Production landing keeps its
+     pre-refactor download links.
+   - Validate: release assets include both versioned and alias names for all
+     five platforms; the macOS glob matched; no asset accumulation.
+3. **Push `v0.4.1` (stable).** This triggers the full stable path:
+   - `make_latest: true` → `/releases/latest` now points at 0.4.1.
+   - `latest.json` regenerated with 0.4.1 asset URLs → updater offers 0.4.1 to
+     0.4.0 users.
+   - Railway redeploys landing + UI. The landing's fixed-alias download links
+     now resolve (0.4.1 has the alias assets).
+4. **Delete the `latest` pseudo-release (cosmetic).** Anytime after step 3:
+
+   ```bash
+   gh release delete latest --yes
+   git push --delete origin latest
+   ```
+
+   This removes the 130 junk assets. It is purely cosmetic — the pseudo-release
+   was already excluded from `/releases/latest` resolution by virtue of being
+   `prerelease: true`.
+
+### Known window: landing fixed-alias 404 on stable push
+
+On a stable tag push, `docker.yml` (Railway landing redeploy) and `tauri.yml`
+(asset upload + release) run in parallel. Sequence: Docker image build (~5 min)
+→ Railway redeploy (~2 min) = landing live in ~7 min; Tauri build (~15–20 min)
+→ release. The new stable release becomes `make_latest` only after the
+`release` job completes. During this window (~10–15 min), the redeployed
+landing's fixed-alias URLs may 404 if `/releases/latest` has not yet flipped to
+the new release (the prior stable lacks the alias assets only if it predates
+this ADR; after the first post-refactor stable, all subsequent stables have
+aliases, so the window is only the gap between Railway live and release
+`make_latest`). Accepted trade-off: releases are infrequent (weekly+), the
+window is short, and users retry. Rejected alternative: cross-workflow ordering
+(`docker.yml` waits on `tauri.yml`'s release) — adds coupling and a single
+point of failure for two otherwise-independent pipelines.
+
+### Operations: tagging discipline
+
+- **Tag only after CI is green on master.** If a tag is pushed while CI is still
+  running, `require-ci-green` fails (fail-closed — no deploy). Recovery: wait
+  for CI to complete, then either delete and re-push the tag (`git tag -d vX.Y.Z
+  && git push --delete origin vX.Y.Z && git tag vX.Y.Z && git push origin
+  vX.Y.Z`) or trigger the CD workflow via `workflow_dispatch` from the Actions
+  UI (which bypasses the CI gate as an operator escape-hatch).
+- **rc tags must be numbered** (`v1.0.0-rc1`, not `v1.0.0-rc`). A bare `rc`
+  falls through to alpha and produces no release.
+- **Only `rc` is a recognized prerelease suffix.** `-beta1`, `-alpha2`, etc. →
+  alpha → no release (build jobs run, release skips).
+
+## Alternatives Considered
+
+### A1: Keep `workflow_run`, gate CD on a manual promotion label/commit
+
+- **Pros:** No new CI-status-check job; reuses the existing trigger.
+- **Cons:** `workflow_run` fires on every master CI success — to make CD opt-in,
+  you'd need a label/commit-message convention parsed inside the workflow, which
+  is fragile and re-introduces the "CD triggered by CI" coupling this ADR
+  removes. Does not address the `latest` pseudo-release or the missing
+  prerelease channel.
+- **Rejected.**
+
+### A2: Single release per stable tag; no prerelease channel
+
+- **Pros:** Simplest — stable tags release, nothing else does.
+- **Cons:** No safe way to validate the release pipeline (artifacts, globs,
+  `latest.json`) without risking the live updater install base. The rc-first
+  migration strategy depends on a prerelease channel that does not disturb
+  `/releases/latest`.
+- **Rejected.** Prerelease support is cheap (one regex branch + two conditional
+  flags) and pays for itself in the first migration.
+
+### A3: Versioned-only artifact names; landing links to `/releases/latest` (UI page)
+
+- **Pros:** No dual naming; `_build-tauri.yml` stays simpler.
+- **Cons:** The landing's download buttons would open the GitHub release UI page
+  (extra click, version noise, no direct download). The explicit goal (§9) is
+  direct file downloads. Fixed aliases are required for
+  `/releases/latest/download/<name>` to resolve.
+- **Rejected.**
+
+### A4: Cross-workflow ordering to eliminate the §Migration landing 404 window
+
+- **Pros:** Zero 404 window on stable push.
+- **Cons:** Couples `docker.yml` and `tauri.yml` (one must trigger/wait on the
+  other). Adds a single point of failure: if the Tauri release job fails, the
+  landing never redeploys (or vice versa). Two independent pipelines become one
+  fragile chain.
+- **Rejected.** The ~10–15 min window on an infrequent event is a better
+  trade-off than coupling.
+
+### A5: Remove `version_base` and `version_type` from `_build-tauri.yml` inputs
+
+- **Pros:** Eliminates now-vestigial inputs cleanly.
+- **Cons:** Contract-breaking change to the `workflow_call` signature requires
+  updating both callers (`ci.yml`, `tauri.yml`) in the same PR, expanding scope
+  and risk. The inputs are workflow inputs (not Rust code), so they do not
+  trigger the `#[allow(dead_code)]` rule; they are retained with a comment
+  explaining they are kept for signature stability.
+- **Rejected** for this PR. A follow-up may clean them up once the pipeline is
+  proven.
+
+## Consequences
+
+### Positive
+
+- **Production deploys are a deliberate human act** (tag push), not an automatic
+  consequence of CI passing on master.
+- **CI verifies the full build matrix on master** (Tauri compile, Docker build)
+  — a regression on master is caught before it could be tagged, not after.
+- **The `latest` pseudo-release stops accumulating** and can be deleted.
+- **Prerelease channel** (`v*.*.*-rc*`) enables safe pipeline validation without
+  disturbing the stable install base or `/releases/latest`.
+- **Direct download links** on the landing page (one click → file download,
+  no GitHub UI interstitial).
+- **Consistent artifact naming** across all channels (always versioned + alias;
+  no more `origa_latest_*` lowercase divergence from `Origa_<version>_*`).
+- **No duplicate bare tags** (`0.4.0` alongside `v0.4.0`) — `tag_name:
+  github.ref_name` attaches the release to the triggering git tag.
+- **CI-gate invariant restored** via `require-ci-green`, replacing the implicit
+  `workflow_run.conclusion == 'success'` gate that the trigger removal deleted.
+
+### Negative
+
+- **Master push no longer deploys anything.** Operators must push a tag to ship.
+  This is the intended behavior but is a workflow change that requires team
+  awareness (documented in the PR and this ADR).
+- **CI cost on master increases**: `build-tauri` (4-platform cross-compile) and
+  both `docker-build-*` now run on every master push, not just PRs. Accepted —
+  this is the explicit goal (§1, problem 5) and the alternative (shipping
+  unverified master commits to production) is worse.
+- **`version_base` and `version_type` inputs in `_build-tauri.yml` are
+  vestigial** (retained for signature stability; see A5). Documented in a
+  comment.
+- **macOS `CFBundleShortVersionString` for rc** = `1.0.0-rc1` (non-numeric).
+  Apple prefers `n.n.n`, but this is a manual `.app` bundle (not a notarized
+  `.dmg`), and alpha already carried non-numeric versions (`0.4.1-alpha.N`).
+  No regression.
+- **Landing fixed-alias 404 window** (~10–15 min) on each stable push while
+  Railway redeploy races the Tauri release. Accepted (§Migration).
+
+## Verification
+
+CI/CD workflows cannot be exercised end-to-end locally (they run in GitHub
+Actions). Verification is therefore layered:
+
+| Check | Command | Scope |
+| --- | --- | --- |
+| Workflow syntax/semantics | `actionlint` on all 4 workflows + version action | Local; all pass |
+| Landing compiles + lints | `cargo clippy -p origa_landing --all-targets --features ssr -- -D warnings` | Local; 0 warnings |
+| Landing format | `cargo fmt --check -p origa_landing` | Local; clean |
+| Landing tests | `cargo test -p origa_landing --features ssr` | Local; 30+ tests pass (security_headers, seo_meta, sitemap, build_config) |
+| `require-ci-green` query | `gh run list --workflow ci.yml --commit <full-sha> --status success` | Empirically verified: returns run ID for green commits, empty string otherwise |
+| **End-to-end (rc-first)** | Push `v0.4.1-rc1` → inspect prerelease release assets | Post-merge; the migration itself is the final E2E test |
+| **Manual latest.json check** | Before pushing `v0.4.1`, dry-run the `generate-latest-json` jq locally with `VERSION=0.4.1 GIT_TAG=v0.4.1` and confirm the URL `releases/download/v0.4.1/Origa_0.4.1_x64-setup.exe` resolves against the asset name the release will publish | rc-first does NOT exercise this (generate-latest-json is stable-only), so the URL tag/asset-segment consistency must be verified by hand |
+| **End-to-end (stable)** | Push `v0.4.1` → verify `/releases/latest` flips, `latest.json` updated, updater offers to 0.4.0 | Post-merge |
+
+## References
+
+- ADR-009: Tauri config parameterization (`tauri.conf.json` `version` field consumed by bundlers)
+- ADR-024: Build-script env var empty-handling pattern (version-stamping conventions)
+- Tauri updater `latest.json` format: <https://v2.tauri.app/plugin/updater/>
+- GitHub `/releases/latest/download/<asset>` behavior: requires a fixed filename; versioned names break the URL on each release
+- `softprops/action-gh-release` v2 (current `@v2` resolves to v2.6.2; v2.5.0 had a prerelease-detection bug fixed in v2.5.1+)
+- `tauri/tauri.conf.json:56` — updater endpoint `/releases/latest/download/latest.json` (unchanged by this ADR)
+- Existing stable release (0.4.0) assets verified via `gh api repos/yurvon-screamo/origa/releases/latest`

--- a/origa_landing/src/pages/download.rs
+++ b/origa_landing/src/pages/download.rs
@@ -3,7 +3,20 @@ use leptos::prelude::*;
 use crate::components::seo::{PageMeta, SchemaOrg, breadcrumb_schema};
 use crate::content::Locale;
 
-const GITHUB_RELEASES_URL: &str = "https://github.com/yurvon-screamo/origa/releases/latest";
+// Fixed-name aliases published alongside the versioned assets on every
+// stable release (see ADR-025 and .github/workflows/_build-tauri.yml). GitHub's
+// /releases/latest/download/<name> URL requires a filename that does not change
+// between releases, so each platform links to its alias rather than the
+// versioned asset. Clicking starts the file download directly (GitHub serves
+// these with Content-Disposition: attachment), skipping the release UI.
+const DOWNLOAD_WINDOWS: &str =
+    "https://github.com/yurvon-screamo/origa/releases/latest/download/Origa_x64-setup.exe";
+const DOWNLOAD_LINUX_APPIMAGE: &str =
+    "https://github.com/yurvon-screamo/origa/releases/latest/download/Origa_amd64.AppImage";
+const DOWNLOAD_MACOS: &str =
+    "https://github.com/yurvon-screamo/origa/releases/latest/download/Origa_macos-arm64.zip";
+const DOWNLOAD_ANDROID: &str =
+    "https://github.com/yurvon-screamo/origa/releases/latest/download/origa.apk";
 const WEB_APP_URL: &str = env!("ORIGA_APP_BASE_URL");
 
 #[component]
@@ -35,7 +48,7 @@ pub fn DownloadPage() -> impl IntoView {
                             <p class="download-platform__formats">{c.download_windows_formats}</p>
                         </div>
                     </div>
-                    <a href=GITHUB_RELEASES_URL class="btn btn-filled btn-lg download-primary__btn">
+                    <a href=DOWNLOAD_WINDOWS class="btn btn-filled btn-lg download-primary__btn">
                         {c.download_button}
                         " →"
                     </a>
@@ -64,21 +77,21 @@ pub fn DownloadPage() -> impl IntoView {
                     icon=view! { <IconApple /> }.into_any()
                     name=c.download_macos
                     formats=c.download_macos_formats
-                    href=GITHUB_RELEASES_URL
+                    href=DOWNLOAD_MACOS
                     button_text=c.download_button
                 />
                 <DownloadCard
                     icon=view! { <IconLinux /> }.into_any()
                     name=c.download_linux
                     formats=c.download_linux_formats
-                    href=GITHUB_RELEASES_URL
+                    href=DOWNLOAD_LINUX_APPIMAGE
                     button_text=c.download_button
                 />
                 <DownloadCard
                     icon=view! { <IconAndroid /> }.into_any()
                     name=c.download_android
                     formats=c.download_android_formats
-                    href=GITHUB_RELEASES_URL
+                    href=DOWNLOAD_ANDROID
                     button_text=c.download_button
                 />
                 // iOS — coming soon (no download button)


### PR DESCRIPTION
## Summary

Refactors CI/CD so that **master push = full CI only** (no deploy) and **CD runs exclusively on git tags** (`vX.Y.Z` stable, `vX.Y.Z-rcN` prerelease). Removes the perpetual `latest` pseudo-release that accumulated 130+ junk assets (WASM bundles, dictionary binaries, landing images, CSS). Adds a prerelease (rc) channel, dual artifact naming (versioned + fixed alias), and direct download links on the landing page.

Full design rationale, alternatives, and known trade-offs: **[ADR-025](docs/decisions/ADR-025-ci-cd-tag-based-releases.md)**.

## Why

Before this PR, `workflow_run` triggered `docker.yml` (Railway production deploy) and `tauri.yml` (Tauri build + a release tagged `latest`) on **every successful master CI run**. Consequences:
- Production redeployed on every master push — no human gate, no version bump.
- The `latest` release accumulated 130+ assets across historical runs (`cp -n` + softprops keep-existing), all junk to the end user.
- CI verified Tauri/Docker builds only on PRs, not on master — a master commit could deploy to production without ever having its Tauri/Docker build verified by CI.
- No prerelease channel — no safe way to validate the release pipeline against the live `0.4.0` install base.

## Changes

| Area | File | Change |
| --- | --- | --- |
| Version | `.github/actions/version/action.yml` | Add `prerelease` channel: `vX.Y.Z-rcN` → `prerelease` (covers `rc1` and `rc.1`; bare `rc` → alpha) |
| CI | `.github/workflows/ci.yml` | `version`/`build-tauri`/`docker-build-*` run on all events (not just PR); `check` gate requires `success` |
| CD (Docker) | `.github/workflows/docker.yml` | Drop `workflow_run` (tag-only CD); add `require-ci-green` job (restores "CI green before CD" invariant); `deploy-to-railway` stable-only; `:latest` Docker tag stable-only; remove dead `:edge` |
| CD (Tauri) | `.github/workflows/tauri.yml` | Drop `workflow_run`; add `require-ci-green`; `release` uses `tag_name: github.ref_name` (no duplicate bare tags), `make_latest`/`prerelease` conditional; `generate-latest-json` stable-only with correct git-tag URL segment |
| Build | `.github/workflows/_build-tauri.yml` | Dual artifact naming (versioned + fixed alias via `cp`); remove `origa_latest_*` rename steps; `update-version` receives full version so rc binaries report their suffix |
| Landing | `origa_landing/src/pages/download.rs` | Per-platform `/releases/latest/download/<fixed-alias>` direct links (no GitHub UI hop) |
| Docs | `docs/decisions/ADR-025-...md` | New ADR: rationale, rc-first migration, alternatives, known windows |

## Migration (post-merge, manual)

A live `0.4.0` install base depends on the Tauri updater (`/releases/latest/download/latest.json` currently resolves to 0.4.0). The first post-merge tag is validated **rc-first** to avoid disturbing it:

1. **Merge this PR.** Master now runs full CI; `docker.yml`/`tauri.yml` are dormant until a tag is pushed.
2. **Push `v0.4.1-rc1`.** Triggers CD with `version_type=prerelease`:
   - `require-ci-green` verifies the commit's CI is green.
   - Prerelease GitHub release created (`make_latest: false` → `/releases/latest` still points at 0.4.0, unaffected).
   - `latest.json` **not** regenerated. Railway **not** redeployed (stable-only).
   - **Validate:** release assets include both versioned and alias names for all 5 platforms; macOS glob matched; no asset accumulation.
3. **Before pushing stable, dry-run `generate-latest-json`** with `VERSION=0.4.1 GIT_TAG=v0.4.1` and confirm the URL `releases/download/v0.4.1/Origa_0.4.1_x64-setup.exe` matches the asset name. rc-first does NOT exercise `generate-latest-json` (stable-only), so this URL consistency check is manual.
4. **Push `v0.4.1` (stable).** Full stable path: `make_latest: true` → `/releases/latest` flips; `latest.json` regenerated → updater offers 0.4.1 to 0.4.0 users; Railway redeploys.
5. **(Optional, cosmetic) Delete the `latest` pseudo-release** — anytime after step 4:
   ```bash
   gh release delete latest --yes
   git push --delete origin latest
   ```
   This is purely cosmetic — the pseudo-release was already `prerelease: true`, so GitHub excluded it from `/releases/latest`. It just removes 130 junk assets.

**Known window:** on each stable tag push, Railway landing redeploy (~7 min) races the Tauri release job (~15–20 min). During this ~10–15 min window the redeployed landing's fixed-alias download URLs may briefly 404 until the new release becomes `make_latest`. Accepted trade-off (infrequent event, short window); cross-workflow ordering was rejected as coupling. See ADR-025 §Migration.

## Verification

| Check | Result |
| --- | --- |
| `actionlint` (all 5 workflows) | PASS |
| `cargo fmt --check` (workspace) | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 warnings |
| `cargo clippy -p origa_landing --all-targets --features ssr -- -D warnings` | 0 warnings |
| `cargo test -p origa_landing --features ssr` | 30+ tests pass (security_headers, seo_meta, sitemap, build_config) — no regressions |
| `require-ci-green` query | empirically verified: `gh run list --commit <full-sha> --status success` returns run ID |
| Code review (GATE 2) | `approve` after fixing 1 High (latest.json URL tag/asset segment) + 1 Common (junk APK) |

End-to-end CI/CD validation is the migration itself (rc-first → stable), since workflows can't be exercised locally.

## Reviewer iterations

- **Plan GATE 1:** 3 rounds — closed 4 High (version-job skip on master, migration facts, lost CI-gate, find-glob) + 1 new High (rc breaks landing → stable-only `deploy-to-railway`). Verdict: `ready`.
- **Implementation GATE 2:** 2 rounds — closed 1 High (`latest.json` URL tag segment mismatch after `tag_name: github.ref_name`) + 1 Common (Android `app-universal-release.apk` junk via `cp`→`mv`). Verdict: `approve`.

## Constraints honored

- Branched from `origin/master` (`a96d3a84`); PR #213/#214 untouched (already merged).
- `latest` tag/release deletion is a **post-merge manual step** (documented), not in this PR.
- `softprops/action-gh-release@v2` kept (floating major, matches repo convention; resolves to v2.6.2 ≥ v2.5.1 bugfix; Dependabot tracks).

---
🤖 Generated with assistance from the architect-refactor + engineer-leptos + rules-clean-code skills. Plan and implementation both passed the `@code-quality-reviewer` gate.
