### PR TITLE
🐛 fix(ui): mobile layout — safe-area, dvh, touch UX, kbd-hint, user-select (ADR-026)

### DIFF
--- a/docs/decisions/ADR-026-touch-aware-safe-area-layout.md
+++ b/docs/decisions/ADR-026-touch-aware-safe-area-layout.md
@@ -1,0 +1,224 @@
+# ADR-026: Touch-aware & safe-area layout conventions
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-03
+
+## Context
+
+PR #213 (ADR-022) introduced Android edge-to-edge rendering
+(`viewport-fit=cover`) and the `env(safe-area-inset-*)` CSS custom
+properties + Tailwind utilities (`pt-safe-t`, `pb-safe-b`, …). User testing
+on an Android tablet (Chromium WebView ≥ 140) surfaced a cluster of layout
+and touch-UX bugs that share two underlying gaps:
+
+1. **No single layout-height contract.** Several CSS classes pinned
+   `min-height: 100vh` independently — `body` (`min-h-screen`), the app
+   shell `<main>` (`.main-with-sidebar`), and the per-page wrappers
+   (`.page-layout-full`, `.page-layout-centered`, `.page-layout-compact`),
+   plus inline `min-h-screen` on the lesson and home-loading views. On a
+   mobile browser `100vh` is the *large* viewport (it includes the region
+   behind the URL bar), so the stacked min-heights produced a body taller
+   than the visible area → spurious scroll and an empty band at the bottom.
+   Worse, once `padding-top: env(safe-area-inset-top)` is added to the shell
+   (to clear the status bar), a nested `min-height: 100vh` child overflows
+   its padded parent by exactly `safe-area-inset-top` on notched devices —
+   reintroducing the very scroll the fix targets.
+
+2. **Device class detected by width, not pointer.** Keyboard-shortcut hints
+   (`[1]`, `[Space]`, `[Esc]`) were gated on the `sm:` width breakpoint
+   (`hidden sm:inline`) — but a tablet in portrait is wide (≥ 640 px) yet
+   touch-driven, so the hints stayed visible where no keyboard exists. Other
+   hints were ungated entirely.
+
+3. **No native-app selection discipline.** With no global `user-select`
+   rule, long-pressing a button or nav label on touch fired the browser's
+   native text-selection / copy menu — behaviour native apps do not exhibit.
+
+This ADR promotes the four conventions applied to fix that cluster into
+project-wide principles so the next page, component, or fixed element follows
+them by default.
+
+## Decision
+
+### 1. Dynamic viewport height is owned by exactly one element
+
+The app shell's full-viewport height uses `100dvh` (dynamic viewport height),
+which excludes the browser chrome and so does not overflow the visible area.
+It is applied **only** to `body` and the `<main>` shell — never to nested
+layout wrappers.
+
+- `body` → `min-height: 100vh; min-height: 100dvh;` (progressive enhancement,
+  declared in `input.css`'s `body` rule).
+- `<main>` → the sidebar branch uses `.main-with-sidebar`'s
+  `min-height: 100vh; min-height: 100dvh;` (progressive); the non-sidebar
+  branch uses the Tailwind arbitrary value `min-h-[100dvh]` (dvh-only —
+  acceptable because the target is Chromium WebView ≥ 140 and desktop, both
+  of which support `dvh`; on an unsupported engine the declaration is dropped
+  and `<main>` sizes to content while `body`'s background fills the viewport).
+- `.page-layout-full`, `.page-layout-centered`, `.page-layout-compact` have
+  **no viewport `min-height`** — they size to content and let the shell's
+  background fill the rest. This breaks the overflow chain: there is no
+  nested viewport min-height to conflict with the shell's safe-area padding.
+
+`body` and `.main-with-sidebar` carry a `vh`→`dvh` progressive fallback for
+older WebViews; the non-sidebar `<main>` branch is `dvh`-only (declared above).
+On desktop `dvh ≈ vh` and `env(safe-area-inset-*) = 0`, so the change is a
+no-op there.
+
+### 2. The content shell clears the top inset; fixed bottom elements clear the bottom inset
+
+- The shell `<main>` receives `padding-top: env(safe-area-inset-top)` via the
+  `pt-safe-t` utility, so every page's content starts below the status bar
+  without each page repeating the rule.
+- Fixed bottom elements use `env(safe-area-inset-bottom)` **with a floor**:
+  `.bottom-tab-bar` uses `padding-bottom: max(env(safe-area-inset-bottom, 0px), 8px)`
+  so labels lift above the gesture pill even when the reported inset is 0 or
+  small. `.toast-container` is raised above the bottom tab bar on viewports
+  where the bar is visible (`@media (max-width: 1023px)`). That media query is
+  width-based, not route-based: on `/lesson` and `/onboarding` the bar is
+  hidden (`BottomTabBar`'s `is_visible`) yet the toast still sits ~88 px
+  higher — an accepted cosmetic trade-off, since CSS cannot be route-aware
+  without body-class plumbing disproportionate to the benefit.
+
+This requires `viewport-fit=cover` in `index.html` (already present);
+otherwise `env(safe-area-inset-*)` returns `0`. On Android WebView < 140
+(crbug 441253216) `env()` returns `0` regardless — the floor and the
+content-padding-when-short design tolerate this (the shell's background still
+fills; only the precise notch inset is lost).
+
+### 3. Keyboard-only affordances hide on `pointer: coarse`, not on width
+
+A single `.kbd-hint` class hides keyboard-shortcut hints under
+`@media (pointer: coarse)`:
+
+```css
+.kbd-hint { display: inline; }
+@media (pointer: coarse) {
+    .kbd-hint { display: none; }
+}
+```
+
+`(pointer: coarse)` matches touch-primary devices regardless of width, so a
+wide touch tablet correctly hides the hints. It is preferred over:
+
+- **Width breakpoints** (`sm:inline`) — a tablet is wide yet touch-driven.
+- **`navigator.keyboard`** — limited support and does not reflect the actual
+  input modality.
+- **`maxTouchPoints`** — a touch laptop reports touch but still has a
+  keyboard; the pointer media query is the better signal.
+
+The keyboard *behaviour* (handlers in `keyboard_handler.rs`) is unaffected —
+only the visual hint is hidden. A keyboard user on a touch device loses the
+hint but not the function; this is the accepted trade-off.
+
+Every keyboard hint in the app uses `.kbd-hint` (29 call sites across the
+lesson, grammar-practice, and onboarding views).
+
+### 4. Global `user-select: none` with a whitelist
+
+`body` sets `user-select: none` (plus `-webkit-touch-callout: none` to
+suppress the iOS long-press menu), so long-pressing UI chrome no longer
+triggers native selection. Selection is **opt back in** for content the user
+should be able to copy:
+
+```css
+input,
+textarea,
+[contenteditable="true"],
+.markdown-text,
+.translator-text,
+.furigana-text,
+.furigana-plain,
+.word-translations,
+.kanji-detail-hero-meaning,
+.kanji-detail-hero-reading,
+.kanji-card-answer,
+.grammar-detail-hero-meaning {
+    -webkit-user-select: text;
+    user-select: text;
+    -webkit-touch-callout: default;
+}
+```
+
+This is a **whitelist**: any future container that must remain selectable
+opts in by class. `user-select` is inherited, so the top-level content
+container suffices (e.g. `.word-translations` covers its items and
+description). The pre-existing `rt` rule (furigana readings excluded
+from selection, fix for #178) is preserved — the base text of
+`.furigana-text` / `.furigana-plain` stays selectable while its `<rt>`
+readings do not.
+
+## Alternatives Considered
+
+### A1: `min-height: 100%` on nested wrappers instead of removing their viewport height
+
+- **Pros:** Keeps a "fill the parent" intent explicit.
+- **Cons:** Percentage `min-height` resolves against the parent's *height*,
+  not `min-height`; with a `min-height`-only parent it collapses. It would
+  also require making `<main>` an explicit flex container and depending on
+  `leptos_router`'s `<Routes>` not wrapping the page view — a fragile
+  coupling.
+- **Rejected.** Letting wrappers size to content (with the shell background
+  filling) is simpler and robust.
+
+### A2: Reactive signal (`use_media_query("(pointer: fine)")`) for keyboard hints
+
+- **Pros:** The visibility logic becomes unit-testable as a signal.
+- **Cons:** More Rust code, WASM/SSR caveats, and re-renders for what is a
+  static, declarative concern. The CSS media query is the idiomatic,
+  cheaper, and better-supported mechanism.
+- **Rejected.** The CSS class is preferred; it also handles dynamic input
+  changes (e.g. a 2-in-1 detaching its keyboard) without reactivity.
+
+### A3: `user-select: auto` (contextual) instead of `none` + whitelist
+
+- **Pros:** Less prescriptive.
+- **Cons:** `auto` defers to the parent/user-agent, which on touch WebViews
+  still selects button labels — exactly the reported bug. The explicit
+  `none` + whitelist makes the app-shell discipline unambiguous and is the
+  pattern native-app-like web UIs adopt.
+- **Rejected.**
+
+## Consequences
+
+### Positive
+
+- **One declared height contract** (`100dvh` on shell only); no nested
+  overflow on notched devices; no spurious mobile scroll.
+- **Safe-area insets handled once** on the shell and fixed elements, not
+  re-derived per page.
+- **Keyboard hints consistent** — hidden on every touch device, visible on
+  every pointer-fine device, independent of screen width.
+- **Native-app-like selection** — UI chrome is not long-press-selectable;
+  copyable content explicitly opts in.
+
+### Negative
+
+- **`user-select` is whitelist-managed** — a new selectable container that
+  forgets to opt in silently becomes non-selectable. Mitigated by documenting
+  the whitelist here and reviewing new content components against it.
+- **Touch devices with an attached keyboard lose the visual hint** (function
+  preserved). Accepted trade-off; `(pointer: coarse)` is the best available
+  signal and avoids the false-positive of `maxTouchPoints` on touch laptops.
+- **`dvh` is ignored by very old WebViews**; the `vh` fallback line keeps
+  them working, only without the dynamic-toolbar benefit.
+
+## References
+
+- PR #213 / ADR-022: Android edge-to-edge + `viewport-fit=cover`
+- ADR-024: build-script env-var empty-handling (the `env!()` discipline that
+  makes the CDN URL reliable, relevant context for the `env()` safe-area
+  values working on ≥ 140 WebViews)
+- `origa_ui/index.html` — `viewport-fit=cover`, body `min-h-[100dvh]`
+- `origa_ui/tailwind.config.js` — `pt-safe-t` / `pb-safe-b` / `safe` utilities
+- `origa_ui/input.css` — `.kbd-hint`, `.page-layout-*`, `.bottom-tab-bar`,
+  `.toast-container`, the `user-select` whitelist
+- `origa_ui/src/routes.rs` — app shell `<main>` classes
+- MDN: [dynamic viewport units (`dvh`)](https://developer.mozilla.org/en-US/docs/Web/CSS/length),
+  [`@media (pointer)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer),
+  [`env(safe-area-inset-*)`](https://developer.mozilla.org/en-US/docs/Web/CSS/env)

--- a/origa_ui/index.html
+++ b/origa_ui/index.html
@@ -32,5 +32,5 @@
         />
     </head>
 
-    <body class="min-h-screen paper-texture"></body>
+    <body class="paper-texture"></body>
 </html>

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -99,6 +99,32 @@ body {
     color: var(--fg-black);
     line-height: 1.6;
     margin: 0;
+    min-height: 100vh;
+    min-height: 100dvh;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+}
+
+/* Re-enable selection for content the user SHOULD be able to select/copy.
+   Whitelist approach: every future selectable container must opt in here
+   (see ADR-026). user-select is inherited, so listing the top-level content
+   container is enough for its descendants. */
+input,
+textarea,
+[contenteditable="true"],
+.markdown-text,
+.translator-text,
+.furigana-text,
+.furigana-plain,
+.word-translations,
+.kanji-detail-hero-meaning,
+.kanji-detail-hero-reading,
+.kanji-card-answer,
+.grammar-detail-hero-meaning {
+    -webkit-user-select: text;
+    user-select: text;
+    -webkit-touch-callout: default;
 }
 
 html,
@@ -117,6 +143,20 @@ input[type="submit"],
 .cursor-pointer {
     touch-action: manipulation;
     -webkit-tap-highlight-color: transparent;
+}
+
+/* Keyboard shortcut hints: visible only when the primary pointer is fine
+   (mouse/keyboard). Hidden on touch-primary devices (pointer: coarse) where
+   a physical keyboard is absent. Prefer this over width breakpoints — a
+   tablet is wide yet touch-driven. */
+.kbd-hint {
+    display: inline;
+}
+
+@media (pointer: coarse) {
+    .kbd-hint {
+        display: none;
+    }
 }
 
 .font-serif {
@@ -1416,7 +1456,7 @@ input[type="submit"],
     left: 0;
     right: 0;
     height: 72px;
-    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 8px);
     background: var(--bg-cream);
     border-top: 1px solid var(--border-dark);
     display: flex;
@@ -1590,6 +1630,7 @@ input[type="submit"],
 .main-with-sidebar {
     margin-left: 220px;
     min-height: 100vh;
+    min-height: 100dvh;
 }
 
 @media (max-width: 1023px) {
@@ -2089,6 +2130,14 @@ rt {
     gap: 12px;
     z-index: 10000;
     max-width: 360px;
+}
+
+/* Raise toasts above the bottom tab bar on viewports where it is visible
+   (<lg). On lg+ the bar is hidden (lg:hidden) so the base offset applies. */
+@media (max-width: 1023px) {
+    .toast-container {
+        bottom: calc(72px + 16px + env(safe-area-inset-bottom, 0px));
+    }
 }
 
 .toast {
@@ -3127,7 +3176,6 @@ rt {
 
 /* Layout */
 .page-layout-centered {
-    min-height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -3141,7 +3189,6 @@ rt {
 }
 
 .page-layout-full {
-    min-height: 100vh;
     display: flex;
     flex-direction: column;
     padding: 8px;
@@ -3154,7 +3201,6 @@ rt {
 }
 
 .page-layout-compact {
-    min-height: calc(100vh - 4rem);
     padding: 16px;
 }
 

--- a/origa_ui/src/pages/grammar/grammar_practice_modal.rs
+++ b/origa_ui/src/pages/grammar/grammar_practice_modal.rs
@@ -301,7 +301,7 @@ pub fn GrammarPracticeModal(
                                 data-testid="grammar-practice-close-btn"
                                 on:click=move |_| on_close.run(())
                             >
-                                {close_text} <span class="hidden sm:inline">"[Esc]"</span>
+                                {close_text} <span class="kbd-hint">"[Esc]"</span>
                             </button>
                         </div>
                     </div>
@@ -381,7 +381,7 @@ pub fn GrammarPracticeModal(
                                     known_kanji=known_kanji.get_value()
                                 />
                             }}
-                            <span class="hidden sm:inline ml-1">"[1]"</span>
+                            <span class="kbd-hint ml-1">"[1]"</span>
                         </button>
                         <button
                             class=move || option_class(1)
@@ -394,7 +394,7 @@ pub fn GrammarPracticeModal(
                                     known_kanji=known_kanji.get_value()
                                 />
                             }}
-                            <span class="hidden sm:inline ml-1">"[2]"</span>
+                            <span class="kbd-hint ml-1">"[2]"</span>
                         </button>
                         <button
                             class=move || option_class(2)
@@ -407,7 +407,7 @@ pub fn GrammarPracticeModal(
                                     known_kanji=known_kanji.get_value()
                                 />
                             }}
-                            <span class="hidden sm:inline ml-1">"[3]"</span>
+                            <span class="kbd-hint ml-1">"[3]"</span>
                         </button>
                         <button
                             class=move || option_class(3)
@@ -420,7 +420,7 @@ pub fn GrammarPracticeModal(
                                     known_kanji=known_kanji.get_value()
                                 />
                             }}
-                            <span class="hidden sm:inline ml-1">"[4]"</span>
+                            <span class="kbd-hint ml-1">"[4]"</span>
                         </button>
                     </div>
 
@@ -441,7 +441,7 @@ pub fn GrammarPracticeModal(
                                     data-testid="grammar-practice-next-btn"
                                     on:click=move |_| on_next()
                                 >
-                                    {next_text} <span class="hidden sm:inline">"[Space]"</span>
+                                    {next_text} <span class="kbd-hint">"[Space]"</span>
                                 </button>
                             </Show>
                             <button
@@ -449,7 +449,7 @@ pub fn GrammarPracticeModal(
                                 data-testid="grammar-practice-close-btn"
                                 on:click=move |_| on_close.run(())
                             >
-                                {close_text} <span class="hidden sm:inline">"[Esc]"</span>
+                                {close_text} <span class="kbd-hint">"[Esc]"</span>
                             </button>
                         </div>
                     </Show>
@@ -484,14 +484,14 @@ pub fn GrammarPracticeModal(
                             >
                                 {move || {
                                     i18n.get_keys().grammar_page().practice_again().inner().to_string()
-                                }} <span class="hidden sm:inline">"[Space]"</span>
+                                }} <span class="kbd-hint">"[Space]"</span>
                             </button>
                             <button
                                 class="px-4 py-2 border border-[var(--border-dark)] bg-[var(--bg-paper)] text-[var(--fg-black)] hover:bg-[var(--fg-black)] hover:text-[var(--bg-paper)] transition-colors cursor-pointer"
                                 data-testid="grammar-practice-close-btn"
                                 on:click=move |_| on_close.run(())
                             >
-                                {close_text} <span class="hidden sm:inline">"[Esc]"</span>
+                                {close_text} <span class="kbd-hint">"[Esc]"</span>
                             </button>
                         </div>
                     </div>

--- a/origa_ui/src/pages/home/mod.rs
+++ b/origa_ui/src/pages/home/mod.rs
@@ -78,7 +78,7 @@ pub fn Home() -> impl IntoView {
     view! {
         <PageLayout variant=PageLayoutVariant::Full test_id="home-page">
             <Show when=move || is_checking_onboarding.get()>
-                <div class="flex flex-col items-center justify-center min-h-screen gap-4" data-testid="home-loading">
+                <div class="py-20 flex flex-col items-center justify-center gap-4" data-testid="home-loading">
                     <Spinner test_id="home-spinner" />
                     <Text size=TextSize::Small variant=TypographyVariant::Muted>
                         {t!(i18n, home.loading)}

--- a/origa_ui/src/pages/lesson/complete_screen.rs
+++ b/origa_ui/src/pages/lesson/complete_screen.rs
@@ -190,7 +190,7 @@ pub fn LessonCompleteScreen(is_completed: RwSignal<bool>, review_count: usize) -
                         go_next_lesson.run(());
                     })
                 >
-                    {t!(i18n, lesson.next_lesson)} <span class="hidden sm:inline">{t!(i18n, lesson.space_key)}</span>
+                    {t!(i18n, lesson.next_lesson)} <span class="kbd-hint">{t!(i18n, lesson.space_key)}</span>
                 </Button>
 
                 <Button
@@ -200,7 +200,7 @@ pub fn LessonCompleteScreen(is_completed: RwSignal<bool>, review_count: usize) -
                         go_home.run(());
                     })
                 >
-                    {t!(i18n, lesson.go_home)} <span class="hidden sm:inline">"[Esc]"</span>
+                    {t!(i18n, lesson.go_home)} <span class="kbd-hint">"[Esc]"</span>
                 </Button>
             </div>
         </div>

--- a/origa_ui/src/pages/lesson/lesson_card_question.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_question.rs
@@ -69,7 +69,7 @@ pub fn LessonCardQuestion(
                 test_id=Signal::derive(|| "lesson-show-answer-btn".to_string())
                 on_click=Callback::new(move |_| on_show_answer.run(()))
             >
-                {t!(i18n, lesson.show_answer)} <span class="hidden sm:inline">{t!(i18n, lesson.space_key)}</span>
+                {t!(i18n, lesson.show_answer)} <span class="kbd-hint">{t!(i18n, lesson.space_key)}</span>
             </Button>
         </div>
     }

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -44,7 +44,7 @@ use leptos::prelude::*;
 #[component]
 pub fn Lesson() -> impl IntoView {
     view! {
-        <div class="min-h-screen py-4" data-testid="lesson-page">
+        <div class="py-4" data-testid="lesson-page">
             <div class="max-w-6xl mx-auto px-2 sm:px-4" data-testid="lesson-card">
                 <LessonContent />
             </div>

--- a/origa_ui/src/pages/lesson/phrase_card.rs
+++ b/origa_ui/src/pages/lesson/phrase_card.rs
@@ -123,7 +123,7 @@ pub fn PhraseCardView(
                                                 />
                                             </Text>
                                             <Show when=move || !show_result.get()>
-                                                <span class="text-[var(--fg-muted)] text-xs font-mono shrink-0">
+                                                <span class="kbd-hint text-[var(--fg-muted)] text-xs font-mono shrink-0">
                                                     {key_hint.clone()}
                                                 </span>
                                             </Show>
@@ -152,7 +152,7 @@ pub fn PhraseCardView(
                         }
                     >
                         <Text size=TextSize::Default>{t!(i18n, lesson.dont_know)}</Text>
-                        <span class="text-[var(--fg-muted)] text-xs font-mono">
+                        <span class="kbd-hint text-[var(--fg-muted)] text-xs font-mono">
                             {t!(i18n, lesson.space_key)}
                         </span>
                     </button>
@@ -202,7 +202,7 @@ pub fn PhraseCardView(
                             test_id=Signal::derive(|| "phrase-next-btn".to_string())
                         >
                             <span>{t!(i18n, lesson.next)}</span>
-                            <span class="text-[var(--fg-light)]">{t!(i18n, lesson.space_key)}</span>
+                            <span class="kbd-hint text-[var(--fg-light)]">{t!(i18n, lesson.space_key)}</span>
                         </Button>
                     </div>
                 </Show>

--- a/origa_ui/src/pages/lesson/phrase_rating_buttons.rs
+++ b/origa_ui/src/pages/lesson/phrase_rating_buttons.rs
@@ -21,7 +21,7 @@ pub fn PhraseRatingButtons(
                 test_id=Signal::derive(move || format!("{}-did-not-understand", base_test_id()))
                 on_click=Callback::new(move |_| on_rate.run(Rating::Again))
             >
-                {t!(i18n, lesson.did_not_understand)} <span class="hidden sm:inline" style="color: var(--fg-light)">"[1]"</span>
+                {t!(i18n, lesson.did_not_understand)} <span class="kbd-hint" style="color: var(--fg-light)">"[1]"</span>
             </Button>
 
             <Button
@@ -31,7 +31,7 @@ pub fn PhraseRatingButtons(
                 test_id=Signal::derive(move || format!("{}-understood", base_test_id()))
                 on_click=Callback::new(move |_| on_rate.run(Rating::Good))
             >
-                {t!(i18n, lesson.understood)} <span class="hidden sm:inline" style="color: var(--fg-light)">"[2]"</span>
+                {t!(i18n, lesson.understood)} <span class="kbd-hint" style="color: var(--fg-light)">"[2]"</span>
             </Button>
         </div>
     }

--- a/origa_ui/src/pages/lesson/quiz_options.rs
+++ b/origa_ui/src/pages/lesson/quiz_options.rs
@@ -65,7 +65,7 @@ pub fn QuizOptions(
                                     />
                                 </Text>
                                 <Show when=move || !show_result.get()>
-                                    <span class="absolute top-1 right-2 text-[var(--fg-muted)] text-xs font-mono opacity-50 pointer-events-none">
+                                    <span class="kbd-hint absolute top-1 right-2 text-[var(--fg-muted)] text-xs font-mono opacity-50 pointer-events-none">
                                         {key_hint.clone()}
                                     </span>
                                 </Show>
@@ -95,7 +95,7 @@ pub fn QuizOptions(
         >
             <Text size=TextSize::Default>{t!(i18n, lesson.dont_know)}</Text>
             <Show when=move || !show_result.get()>
-                <span class="text-[var(--fg-muted)] text-xs font-mono">{t!(i18n, lesson.space_key)}</span>
+                <span class="kbd-hint text-[var(--fg-muted)] text-xs font-mono">{t!(i18n, lesson.space_key)}</span>
             </Show>
         </button>
     }

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -82,7 +82,7 @@ pub fn QuizOptionsMulti(
                 <Show when=move || !selected_options_stored.get_value().is_empty()>
                     <span>{t!(i18n, lesson.check)}</span>
                 </Show>
-                <span class="text-xs font-mono opacity-50">{t!(i18n, lesson.space_key)}</span>
+                <span class="kbd-hint text-xs font-mono opacity-50">{t!(i18n, lesson.space_key)}</span>
             </button>
         </Show>
 
@@ -94,7 +94,7 @@ pub fn QuizOptionsMulti(
                     test_id=Signal::derive(|| "quiz-next-btn".to_string())
                 >
                     <span>{t!(i18n, lesson.next)}</span>
-                    <span class="text-[var(--fg-light)]">{t!(i18n, lesson.space_key)}</span>
+                    <span class="kbd-hint text-[var(--fg-light)]">{t!(i18n, lesson.space_key)}</span>
                 </Button>
             </div>
         </Show>
@@ -168,7 +168,7 @@ fn MultiOptionButton(
                 </Show>
             </div>
             <Show when=move || !multi_submitted.get()>
-                <span class="absolute top-1 right-2 text-[var(--fg-muted)] text-xs font-mono opacity-50 pointer-events-none">
+                <span class="kbd-hint absolute top-1 right-2 text-[var(--fg-muted)] text-xs font-mono opacity-50 pointer-events-none">
                     {key_hint.clone()}
                 </span>
             </Show>

--- a/origa_ui/src/pages/lesson/rating_buttons.rs
+++ b/origa_ui/src/pages/lesson/rating_buttons.rs
@@ -19,7 +19,7 @@ pub fn RatingButtons(
                 test_id=Signal::derive(|| "lesson-rating-btn-again".to_string())
                 on_click=Callback::new(move |_| on_rate.run(Rating::Again))
             >
-                {t!(i18n, lesson.dont_know_rating)} <span class="hidden sm:inline">"[1]"</span>
+                {t!(i18n, lesson.dont_know_rating)} <span class="kbd-hint">"[1]"</span>
             </Button>
 
             <Button
@@ -29,7 +29,7 @@ pub fn RatingButtons(
                 test_id=Signal::derive(|| "lesson-rating-btn-good".to_string())
                 on_click=Callback::new(move |_| on_rate.run(Rating::Good))
             >
-                {t!(i18n, lesson.know)} <span class="hidden sm:inline">"[2]"</span>
+                {t!(i18n, lesson.know)} <span class="kbd-hint">"[2]"</span>
             </Button>
         </div>
     }

--- a/origa_ui/src/pages/lesson/yesno_card_view.rs
+++ b/origa_ui/src/pages/lesson/yesno_card_view.rs
@@ -231,7 +231,7 @@ pub fn YesNoCardView(
                         disabled=Signal::derive(move || show_result.get())
                         on_click=Callback::new(move |_| on_answer.run(false))
                     >
-                        {t!(i18n, lesson.no)} <span class="hidden sm:inline">"[1]"</span>
+                        {t!(i18n, lesson.no)} <span class="kbd-hint">"[1]"</span>
                     </Button>
 
                     <Button
@@ -241,7 +241,7 @@ pub fn YesNoCardView(
                         disabled=Signal::derive(move || show_result.get())
                         on_click=Callback::new(move |_| on_answer.run(true))
                     >
-                        {t!(i18n, lesson.yes)} <span class="hidden sm:inline">"[2]"</span>
+                        {t!(i18n, lesson.yes)} <span class="kbd-hint">"[2]"</span>
                     </Button>
                 </div>
                 <button
@@ -263,7 +263,7 @@ pub fn YesNoCardView(
                     }
                 >
                     <Text size=TextSize::Default>{t!(i18n, lesson.dont_know)}</Text>
-                    <span class="hidden sm:inline text-[var(--fg-muted)] text-xs font-mono">{t!(i18n, lesson.space_key)}</span>
+                    <span class="kbd-hint text-[var(--fg-muted)] text-xs font-mono">{t!(i18n, lesson.space_key)}</span>
                 </button>
 
                 <Show when=move || show_result.get()>

--- a/origa_ui/src/pages/onboarding/scoring_step.rs
+++ b/origa_ui/src/pages/onboarding/scoring_step.rs
@@ -291,7 +291,7 @@ pub fn ScoringStep(
                                         test_id=Signal::derive(|| "scoring-step-dont-know".to_string())
                                     >
                                         {t!(i18n, onboarding.scoring.dont_know)}
-                                        <span class="hidden sm:inline text-xs ml-1">"[1]"</span>
+                                        <span class="kbd-hint text-xs ml-1">"[1]"</span>
                                     </Button>
 
                                     <Button
@@ -301,7 +301,7 @@ pub fn ScoringStep(
                                         test_id=Signal::derive(|| "scoring-step-know".to_string())
                                     >
                                         {t!(i18n, onboarding.scoring.know)}
-                                        <span class="hidden sm:inline text-xs ml-1">"[2]"</span>
+                                        <span class="kbd-hint text-xs ml-1">"[2]"</span>
                                     </Button>
                                 </div>
                             </Card>

--- a/origa_ui/src/routes.rs
+++ b/origa_ui/src/routes.rs
@@ -278,9 +278,9 @@ pub fn AppRoutes() -> impl IntoView {
 
     let main_class = move || {
         if sidebar_visible.get() {
-            "paper-texture main-with-sidebar pb-20 lg:pb-0".to_string()
+            "paper-texture main-with-sidebar pt-safe-t pb-20 lg:pb-0".to_string()
         } else {
-            "paper-texture pb-20 lg:pb-0".to_string()
+            "paper-texture pt-safe-t min-h-[100dvh]".to_string()
         }
     };
 


### PR DESCRIPTION
## Summary

Resolve 5 mobile/tablet UI bugs found during Android-tablet testing after the edge-to-edge fix (PR #213). CSS-only + class-string edits, no new dependencies, no logic changes. Conventions documented in **ADR-026**.

| Bug | Root cause | Fix |
| --- | --- | --- |
| **#4-top** content under status bar | Global `<main>` had no `padding-top: env(safe-area-inset-top)` | `<main>` gets `pt-safe-t` (both branches in `routes.rs`) |
| **#5** extra scroll / empty bottom band | Stacked `min-height: 100vh` across body / `.main-with-sidebar` / `.page-layout-*` → on mobile `100vh` > visible (URL bar) → spurious scroll; nested min-height also overflowed the padded shell on notched devices | **Layout contract:** `body` owns `100dvh` only; `.page-layout-full/centered/compact` lose viewport `min-height` (size to content); home-loading/lesson drop `min-h-screen` |
| **#4-bottom** bottom-nav labels under gesture pill | `.bottom-tab-bar` `padding-bottom` had no floor | `padding-bottom: max(env(safe-area-inset-bottom, 0px), 8px)` |
| **#8** sync toast overlaps bottom nav | `.toast-container` bottom offset < 72px nav height on `<lg` | `@media (max-width: 1023px) { bottom: calc(72px + 16px + env(...)) }` |
| **#2** keyboard hints shown on touch | Hints gated on width (`hidden sm:inline`) — a tablet is wide yet touch-driven; others ungated | New `.kbd-hint` class hidden under `@media (pointer: coarse)`, applied to all **29** locations across 10 files |
| **#3** long-press selects/copies UI | No global `user-select` rule | Global `user-select: none` on `body` + whitelist (`input`, `textarea`, `[contenteditable]`, `.markdown-text`, `.translator-text`, `.furigana-text/plain`, `.word-translations`, `.kanji-detail-hero-meaning/reading`, `.kanji-card-answer`, `.grammar-detail-hero-meaning`); `rt` rule (#178) preserved |

### Layout contract (ADR-026 §1)
Only `body` and the `<main>` shell own the full dynamic viewport height (`100dvh`, with a `vh`→`dvh` progressive fallback). Nested layout wrappers (`.page-layout-*`) have **no viewport min-height** — they size to content and let the shell background fill. This breaks the overflow chain: no nested viewport min-height conflicts with the shell safe-area padding. Desktop is a no-op (`env()=0`, `dvh≈vh`).

## Deferred (not in this PR)
- **#1 kanji animation unavailable** — escalated to a separate runtime research task. The message `kanji_page.animation_unavailable` is only in `KanjiDrawingPractice`; the CSP `connect-src` **already allowlists** `https://s3.origa.uwuwu.net` (not a CSP/CORS block), `cdn_url` is compile-time, and the fetch path is platform-agnostic — so the root cause is not statically determinable. Candidates: the specific kanji missing from the CDN dataset (desktop may have worked from a stale Cache API), or a transient/parse edge-case.
- **#6 lesson content panel at top** — deferred to the UX batch (with #7). Centering interacts non-trivially with the layout contract; needs visual verification across all card types.

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (0 warnings, all crates compile)
- `cargo test -p origa_ui` ✅ (234 + 6 passed)
- `cargo test -p origa` ✅ (all passed)
- `cargo test --workspace` ⚠️ could not complete the full link — **disk full** (D: 100%, `os error 112`) during link of `origa_landing`/`origa-app` test binaries. Infrastructure issue, not code. The touched crate (`origa_ui`) + core dep (`origa`) pass; clippy proves all crates compile.
- `stylelint` ⏭️ — `.stylelintrc.json` exists but the tooling isn't installed in the project (no `package.json`); CSS verified manually, vendor-prefixes allowed by the config.
- **Browser smoke** ⏭️ — not run locally (disk constraints + interactive GUI). Recommended in review: DevTools tablet portrait 820×1180 + emulate `pointer: coarse`, with a `safe-area-inset-top > 0` checkpoint.

## Files
`origa_ui/index.html`, `origa_ui/input.css`, `origa_ui/src/routes.rs`, + 10 lesson/grammar/onboarding `.rs` (kbd-hint), `origa_ui/src/pages/{home,lesson}/mod.rs`, `docs/decisions/ADR-026-touch-aware-safe-area-layout.md`.