### PR TITLE
🐛 fix(ui): hide leaked FsrsMetrics/Practice on mobile detail pages

### DIFF
--- a/end2end/tests/grammar.spec.ts
+++ b/end2end/tests/grammar.spec.ts
@@ -524,3 +524,29 @@ testWithFreshUser.describe("Grammar Page - Detail Page", () => {
         await expect(page).toHaveURL(/\/grammar$/);
     });
 });
+
+testWithFreshUser.describe("Grammar Page - Mobile Detail Layout", () => {
+    testWithFreshUser("should hide leaked top-bar FsrsMetrics and Practice on mobile viewport", async ({ page }) => {
+        test.setTimeout(60_000);
+        const grammarPage = await setupGrammarPage(page);
+
+        await grammarPage.openAddModal();
+        await grammarPage.selectRule("～ます");
+        await grammarPage.addSelectedRules();
+        await expect(grammarPage.grammarGrid).toBeVisible({ timeout: 10_000 });
+
+        await grammarPage.navigateToDetail(0);
+        await expect(grammarPage.detailContainer).toBeVisible({ timeout: 30_000 });
+
+        await page.setViewportSize({ width: 375, height: 667 });
+
+        // Regression guard: top-bar FsrsMetrics must not leak on mobile (dual-render CSS fix)
+        await expect(page.getByTestId("grammar-detail-fsrs")).not.toBeVisible();
+        await expect(page.getByTestId("grammar-detail-fsrs-mobile")).toBeVisible();
+        // Top-bar Practice button must not leak on mobile
+        await expect(page.getByTestId("grammar-detail-practice-btn")).not.toBeVisible();
+        await expect(
+            page.locator(".fsrs-metrics").filter({ visible: true }),
+        ).toHaveCount(1);
+    });
+});

--- a/end2end/tests/kanji.spec.ts
+++ b/end2end/tests/kanji.spec.ts
@@ -401,3 +401,27 @@ testWithFreshUser.describe("Kanji Page - Favorite Sync Persistence", () => {
         await expect.poll(async () => await kanjiPage.isFavorited(0), { timeout: 5000 }).toBe(false);
     });
 });
+
+testWithFreshUser.describe("Kanji Page - Mobile Detail Layout", () => {
+    testWithFreshUser("should hide leaked top-bar FsrsMetrics on mobile viewport", async ({ page }) => {
+        test.setTimeout(60_000);
+        const kanjiPage = await setupKanjiPage(page);
+        await addFirstKanji(kanjiPage);
+        await expect(kanjiPage.kanjiGrid).toBeVisible({ timeout: 10_000 });
+
+        const kanjiLink = page.locator('a[href*="/kanji/"]').first();
+        await kanjiLink.click();
+        await page.waitForURL(/\/kanji\//, { timeout: 5_000 });
+        const heroCard = page.locator(".kanji-detail-hero-card").first();
+        await expect(heroCard).toBeVisible({ timeout: 10_000 });
+
+        await page.setViewportSize({ width: 375, height: 667 });
+
+        // Regression guard: top-bar FsrsMetrics must not leak on mobile (dual-render CSS fix)
+        await expect(page.getByTestId("kanji-detail-fsrs")).not.toBeVisible();
+        await expect(page.getByTestId("kanji-detail-fsrs-mobile")).toBeVisible();
+        await expect(
+            page.locator(".fsrs-metrics").filter({ visible: true }),
+        ).toHaveCount(1);
+    });
+});

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -4598,6 +4598,14 @@ rt {
     .grammar-detail-top-bar .card-action-bar {
         display: none;
     }
+
+    .grammar-detail-top-bar .fsrs-metrics {
+        display: none;
+    }
+
+    .grammar-detail-top-bar .btn-olive {
+        display: none;
+    }
 }
 
 /* === Kanji Detail — Redesigned === */
@@ -4880,6 +4888,10 @@ rt {
     }
 
     .kanji-detail-top-bar .card-action-bar {
+        display: none;
+    }
+
+    .kanji-detail-top-bar .fsrs-metrics {
         display: none;
     }
 }


### PR DESCRIPTION
## Bug

On mobile/tablet (≤1023px), the kanji and grammar **detail pages** show duplicated content:
- **Statistics (FsrsMetrics) shown 2-3×** on one screen.
- **Training (Practice button) shown 2×** on one screen.

## Root cause

Both detail pages use a **dual-render architecture**: they emit desktop and mobile layouts into the same DOM simultaneously, hiding one via CSS. The mobile `@media (max-width: 1023px)` block (input.css) hid only `.card-action-bar` inside the top-bar — leaving the sibling `<FsrsMetrics>` (`.fsrs-metrics`) and the Practice `<button class="btn btn-olive">` visible. They **leak** onto the mobile view alongside their mobile-layout counterparts.

- `stats ×3`: top-bar FsrsMetrics (leak) + hero FsrsMetrics + stats-tab FsrsMetrics(expanded).
- `training ×2`: top-bar Practice button (leak) + practice-tab Practice button.

## Fix (Tier A — minimal, zero behavior change)

Extend the two existing `@media (max-width: 1023px)` blocks in `origa_ui/input.css` to also hide the leaked classes inside the top-bar:

\`\`\`css
/* grammar-detail media-query */
.grammar-detail-top-bar .fsrs-metrics { display: none; }
.grammar-detail-top-bar .btn-olive   { display: none; }
/* kanji-detail media-query */
.kanji-detail-top-bar .fsrs-metrics  { display: none; }
\`\`\`

Specificity `(0,2,0)` > base `.fsrs-metrics { display:flex }` `(0,1,0)` — cascade correct. Desktop (≥1024px) is entirely untouched (media-query gated). No `.rs` changes. Canvas/writing/stroke tabs untouched.

**Result:** mobile — exactly 1 FsrsMetrics (hero, compact) + optional 1 expanded on the stats tab; 1 Practice button; 1 CardActionBar.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check` | ✅ exit 0 |
| `cargo clippy -p origa_ui --all-targets -- -D warnings` | ✅ exit 0, 0 warnings |
| `cargo test -p origa_ui` | ✅ 234 unit + 6 integration pass |
| E2E **RED** (no fix, 375×667 viewport) | ✅ both guards FAIL — top-bar `kanji-detail-fsrs`/`grammar-detail-fsrs` "Received: visible" |
| E2E **GREEN** (with fix) | ✅ 2 passed — top-bar `not.toBeVisible()`, hero `toBeVisible()`, visible `.fsrs-metrics` count === 1 |

E2E guards are visibility-based (not DOM-count): `expect(getByTestId('kanji-detail-fsrs')).not.toBeVisible()` + `toBeVisible()` on the hero instance + `.fsrs-metrics` visible-count === 1 on the overview tab.

## Deferred (separate PRs, require product approval)

- **Tier B — grammar single-render:** eliminate the dual-render code duplication for the grammar page (content is pure markdown → behavior-safe). Optional debt paydown.
- **Tier C — kanji single-render:** BLOCKED. Kanji writing/stroke tabs use stateful components (`KanjiDrawingPractice` with CDN `LocalResource` + mount-time `Effect` + persistent `DrawingState`; `KanjiAnimation` with `spawn_local`/`TimeoutFuture`/abort-handles). Switching `<Show>` → CSS `display:none` would change their lifecycle (eager CDN fetch, state persistence, running timers). Requires a separate design decision.