### PR TITLE
fix(ui): vertically center lesson card with scroll fallback

### DIFF
--- a/docs/decisions/ADR-027-shell-flex-column-for-vertical-fill.md
+++ b/docs/decisions/ADR-027-shell-flex-column-for-vertical-fill.md
@@ -1,0 +1,146 @@
+# ADR-027: Shell `<main>` as a flex column for vertical fill / centering
+
+## Status
+
+Accepted — supersedes the rejection rationale in [ADR-026](./ADR-026-touch-aware-safe-area-layout.md) §A1 for pages that must fill the viewport vertically.
+
+## Date
+
+2026-07-03
+
+## Context
+
+ADR-026 established that viewport-height (`100dvh`) and safe-area
+(`pt-safe-t`) live ONLY on the shell (`<body>`, `<main>`); page wrappers were
+stripped of viewport `min-height` and size to content. That breaks the overflow
+chain on notched devices (the original bug cluster ADR-026 fixed) and is the
+correct default — most pages do not need to fill the viewport.
+
+Bug #6 surfaced a page that DOES need vertical fill: the lesson view centers its
+content card vertically in the space between a pinned header and the page
+bottom. Centering (`flex-1` content area + `justify-content: safe center`)
+requires the page wrapper to have a viewport-derived height so `flex-1` has free
+space to distribute. With page wrappers sized to content (ADR-026), the only way
+to propagate the shell's height to the page is to make the shell itself a flex
+column so the page can `flex-1` it.
+
+ADR-026 §A1 explicitly considered and rejected making `<main>` a flex container,
+citing the fragile coupling to `leptos_router`'s `<Routes>` not wrapping the
+matched page view (if `<Routes>` ever inserts a wrapper DOM node, the page is no
+longer a direct flex child of `<main>` and `flex-1` stops filling). That
+coupling is real and remains the key risk — but it is the ONLY viable mechanism
+that does not reintroduce a nested viewport unit (ADR-026 §1) or re-derive
+`env(safe-area-inset-*)` per page (ADR-026 §2). The trade-off is accepted for
+pages that need vertical fill.
+
+## Decision
+
+The non-sidebar `<main>` shell branch is a flex column:
+
+```rust
+"paper-texture pt-safe-t min-h-[100dvh] flex flex-col"
+```
+
+This branch is used only where the sidebar is hidden — `/lesson`, `/onboarding`,
+`/login`, and pre-auth states (`sidebar_visible = false`). The sidebar branch
+(`.main-with-sidebar`) is unchanged.
+
+A page fills the shell by being a flex child with `flex-1`:
+
+```rust
+<div class="flex-1 flex flex-col py-4" data-testid="lesson-page">
+```
+
+No viewport unit or `env(safe-area-inset-*)` appears on page wrappers — they
+fill via flexbox only, keeping ADR-026's height/safe-area ownership on the shell.
+
+### Hard dependency: `<Routes>` must not wrap the matched view
+
+This contract holds because `leptos_router` 0.8 `<Routes>` renders the matched
+route's view inline (no wrapper DOM node), so the page component is a direct
+flex child of `<main>`. **If a `leptos_router` upgrade (or a manual edit) inserts
+a wrapper between `<main>` and the page, every `flex-1` page silently collapses
+to content height and vertical fill/centering breaks without a compile error.**
+
+The E2E suite guards this for `/lesson`: a test asserts the lesson content area
+has free vertical space on a tall viewport (i.e. `flex-1` is filling the shell,
+not collapsed). Pages added in the future that rely on vertical fill must either
+add an analogous guard or be covered by a shell-level layout test.
+
+## Alternatives Considered
+
+### B1: Reintroduce `min-h-screen` on the page wrapper
+
+- **Pros:** No shell change; page gets viewport height directly.
+- **Cons:** Directly violates ADR-026 §1 and reintroduces the exact overflow bug
+  it fixed: a nested `min-height: 100vh` child overflows the shell's
+  `pt-safe-t` padding by `env(safe-area-inset-top)` on notched devices →
+  spurious scroll.
+- **Rejected.**
+
+### B2: `min-h-[calc(100dvh-env(safe-area-inset-top))]` on the page wrapper
+
+- **Pros:** Stays off the shell; technically avoids the §1 overflow.
+- **Cons:** Re-derives `env(safe-area-inset-*)` per page — exactly what ADR-026
+  §2 centralized onto the shell to avoid. Brittle if the shell's padding
+  changes; sets a bad precedent (every centering page re-derives safe-area).
+- **Rejected.**
+
+### B3: `margin: auto` (`my-auto`) on the card wrapper instead of `justify-content: safe center`
+
+- **Pros:** Identical centering semantics without touching the shell.
+- **Cons:** Requires adding a `class` (+ a `data-testid` for E2E) to a previously
+  bare element in `LessonCardContainer`. tachys encodes each attribute as a
+  generic type parameter, so adding attributes to a deep element increases the
+  monomorphized view-type depth. The `origa_ui_bin` crate renders the entire
+  `<App/>` tree under its default `recursion_limit` (128; the lib crate has 512
+  but that is crate-scoped) and was already at the ceiling — the two new
+  attribute type-params tipped it over, producing `error: queries overflow the
+  depth limit!` during layout/monomorphization (platform-independent; would fail
+  CI). Raising the bin's limit to 512 let it compile but produced 2479 linker
+  errors from over-monomorphization. See the recursion-limit landmine note in
+  `origa_ui/AGENTS.md`.
+- **Rejected** in favor of `justify-content: safe center` on the existing
+  `lesson-content` div (a class-string change only — `Class<&str>` stays
+  `Class<&str>`, zero new type params; verified by byte-identical `origa_ui_bin`
+  artifact hash vs. `master`).
+
+`justify-content: safe center` is spec-defined to fall back to `flex-start` when
+centering would overflow (preventing data loss), so it is behaviorally equivalent
+to `my-auto`: center when the card fits, top-aligned + scrollable when it
+overflows, with no top-clipping.
+
+## Consequences
+
+### Positive
+
+- The lesson card (and any future page opting into vertical fill) can center /
+  fill without reintroducing nested viewport units or per-page safe-area math.
+- ADR-026's shell ownership of height + safe-area is preserved.
+
+### Negative
+
+- **Coupling to `<Routes>` non-wrapping** (see Decision). A `leptos_router`
+  change that wraps the matched view silently breaks vertical fill across all
+  `flex-1` pages. Mitigated by the `/lesson` E2E guard.
+- **The non-sidebar shell branch now differs structurally** (flex column) from
+  the sidebar branch (block). Pages in the non-sidebar branch are flex children;
+  this is a no-op for single content-sized pages (`/login`, `/onboarding`) but is
+  a behavior change reviewers must account for.
+
+## References
+
+- [ADR-026](./ADR-026-touch-aware-safe-area-layout.md) — shell owns viewport
+  height + safe-area; §A1 rejected `<main>` as flex (superseded here for
+  vertical-fill pages).
+- `origa_ui/src/routes.rs` — non-sidebar `<main>` `flex flex-col`.
+- `origa_ui/src/pages/lesson/mod.rs` — `lesson-page` `flex-1`.
+- `origa_ui/src/pages/lesson/content.rs` — `lesson-content`
+  `flex-1 min-h-0 overflow-y-auto flex flex-col justify-safe-center` (the
+  `justify-safe-center` class is a **literal rule** in `origa_ui/input.css`, not a
+  Tailwind utility — Tailwind v3 cannot express `safe center`; see §B3 and the
+  recursion_limit landmine note in `origa_ui/AGENTS.md`).
+- `origa_ui/AGENTS.md` — recursion-limit landmine note (why `my-auto` on a new
+  attribute was infeasible).
+- CSS Flexbox §8.4.1 (auto margins) and the `safe` alignment keyword
+  (CSS Box Alignment §3.x).

--- a/end2end/tests/lesson.spec.ts
+++ b/end2end/tests/lesson.spec.ts
@@ -225,3 +225,45 @@ testWithFreshUser.describe("Lesson Page", () => {
     });
 
 });
+
+testWithFreshUser.describe("Lesson Card Vertical Layout", () => {
+    testWithFreshUser(
+        "content area fills the shell vertically (height-chain guard)",
+        async ({ page }) => {
+            test.setTimeout(90_000);
+
+            // Tablet portrait: where the top-aligned bug (Bug #6) was reported.
+            await page.setViewportSize({ width: 820, height: 1180 });
+
+            const lessonPage = await setupLessonWithCards(page);
+
+            // lesson-content is flex-1 of the shell's flex column (ADR-027). On a
+            // tall viewport the card fits, so the container must have free vertical
+            // space (scrollHeight <= clientHeight) and a near-viewport clientHeight.
+            // If the height chain breaks (e.g. a leptos_router upgrade wraps the
+            // matched view, so the page is no longer a direct flex child of <main>),
+            // lesson-content collapses to content height → scrollHeight ~= clientHeight
+            // and clientHeight is tiny → this fails.
+            //
+            // Exact card centering position is NOT asserted: that would require a
+            // testid on the card wrapper, adding a type param to the bin crate's
+            // view tree and re-triggering its recursion_limit fragility (ADR-027 §B3).
+            const dims = await lessonPage.lessonContent.evaluate((el) => {
+                const node = el as HTMLElement;
+                return {
+                    scrollHeight: node.scrollHeight,
+                    clientHeight: node.clientHeight,
+                    justifyContent: getComputedStyle(node).justifyContent,
+                };
+            });
+
+            expect(dims.scrollHeight).toBeLessThanOrEqual(dims.clientHeight);
+            expect(dims.clientHeight).toBeGreaterThan(700);
+            // Guards the centering rule itself (catches removal of the
+            // .justify-safe-center class/CSS). Chromium normalizes the resolved
+            // value of `safe center` to `center`, so this verifies the `center`
+            // half — the `safe` overflow fallback stays on manual smoke.
+            expect(dims.justifyContent).toContain("center");
+        },
+    );
+});

--- a/origa_ui/AGENTS.md
+++ b/origa_ui/AGENTS.md
@@ -114,6 +114,25 @@ Routes defined in `routes.rs`: `/` (home), `/login`, `/onboarding`, `/profile`,
 well-known set metadata, and env vars (`ORIGA_CDN_BASE_URL` required, plus optional
 `ORIGA_CDN_REGION`, `ORIGA_VERSION`, `ORIGA_COMMIT`, `ORIGA_BUILD_DATE`, `ORIGA_PUBLIC_BASE_URL`).
 
+### `recursion_limit` landmine (bin crate)
+
+`lib.rs` has `#![recursion_limit = "512"]` but `main.rs` (the `origa_ui_bin`
+crate) does NOT — it inherits the default 128. The bin mounts the entire `<App/>`
+view tree, and tachys encodes every element's attributes/classes as deeply
+nested generic type tuples, so the bin is near the 128 query-depth ceiling. Adding
+**new attributes** (`class`, `data-testid`, a second class) to a deep component
+tips it over → `error: queries overflow the depth limit!` during
+layout/monomorphization (platform-independent; fails `cargo test --workspace`).
+Raising the bin's limit to 512 lets it compile but produces mass linker errors
+from over-monomorphization — so raising the limit is NOT a fix.
+
+**Guidance:** prefer changing an existing element's class **string** (type-neutral:
+`Class<&str>` stays `Class<&str>`) over adding new attributes. The structural fix
+is to split deep views into sub-components (delegating rendering to the lib crate,
+which has the higher limit) or to add the attribute to a shallower element. See
+ADR-027 §B3 for the concrete case that forced `justify-[safe_center]` over
+`my-auto` + a new `data-testid`.
+
 ## Development
 
 ```powershell

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -3175,6 +3175,16 @@ rt {
 }
 
 /* Layout */
+
+/* Tailwind v3 does not generate justify-[safe_center] (the `safe` overflow
+   keyword is dropped by arbitrary-value validation), so this is a literal
+   rule. `safe center` centers when the flex child fits and falls back to
+   flex-start when it overflows — no top-clipping. Used by lesson-content for
+   vertical card centering (ADR-027). */
+.justify-safe-center {
+    justify-content: safe center;
+}
+
 .page-layout-centered {
     display: flex;
     align-items: center;

--- a/origa_ui/src/pages/lesson/content.rs
+++ b/origa_ui/src/pages/lesson/content.rs
@@ -277,7 +277,7 @@ pub fn LessonContent() -> impl IntoView {
         </Show>
 
         <Show when=move || !is_loading.get() && !is_completed.get() && error_message.get().is_none()>
-            <div data-testid="lesson-content" class="relative">
+            <div data-testid="lesson-content" class="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col justify-safe-center">
                 <Show when=move || is_syncing_cards.get()>
                     <div data-testid="lesson-sync-indicator" class="absolute top-0 right-0 flex items-center gap-1 text-sm text-muted-foreground p-2">
                         <Spinner test_id="lesson-sync-spinner" class=Signal::derive(|| "".to_string()) size=Signal::derive(|| "sm".to_string()) />

--- a/origa_ui/src/pages/lesson/header.rs
+++ b/origa_ui/src/pages/lesson/header.rs
@@ -25,7 +25,7 @@ pub fn LessonHeader() -> impl IntoView {
     let back_label = Signal::derive(move || i18n.get_keys().common().back().inner().to_string());
 
     view! {
-        <div class="flex items-center gap-2 mb-2" data-testid="lesson-header">
+        <div class="flex items-center gap-2 mb-2 shrink-0" data-testid="lesson-header">
             <button
                 data-testid="lesson-back-btn"
                 class="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors shrink-0 cursor-pointer"

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -44,8 +44,8 @@ use leptos::prelude::*;
 #[component]
 pub fn Lesson() -> impl IntoView {
     view! {
-        <div class="py-4" data-testid="lesson-page">
-            <div class="max-w-6xl mx-auto px-2 sm:px-4" data-testid="lesson-card">
+        <div class="flex-1 flex flex-col py-4" data-testid="lesson-page">
+            <div class="max-w-6xl mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
                 <LessonContent />
             </div>
         </div>

--- a/origa_ui/src/routes.rs
+++ b/origa_ui/src/routes.rs
@@ -276,11 +276,13 @@ pub fn AppRoutes() -> impl IntoView {
         authenticated && !hidden_path && has_user
     });
 
+    // Non-sidebar <main> is a flex column so pages can fill the shell via flex-1
+    // (e.g., lesson card centering). See ADR-027; height + safe-area stay on the shell.
     let main_class = move || {
         if sidebar_visible.get() {
             "paper-texture main-with-sidebar pt-safe-t pb-20 lg:pb-0".to_string()
         } else {
-            "paper-texture pt-safe-t min-h-[100dvh]".to_string()
+            "paper-texture pt-safe-t min-h-[100dvh] flex flex-col".to_string()
         }
     };
 


### PR DESCRIPTION
## Bug #6

The lesson content card sat at the **top** of the viewport. On a tablet (especially portrait) reaching the top is uncomfortable — users stretch their thumb/arm up. Cross-platform (mobile / tablet / desktop).

## Root cause

Normal document flow top-aligns block content. **ADR-026** (PR #216, merged the same day) established that viewport-height (`100dvh`) and safe-area (`pt-safe-t`) live ONLY on the shell (`<body>`, `<main>`); page wrappers were stripped of viewport `min-height` (lesson-page lost `min-h-screen`) and size to content. With no height on the page wrapper, the card has no space to center within.

## Fix

Vertically center the card in the space between the pinned header and the page bottom, with a graceful fallback to **top-aligned + scroll** when the card is taller than the available space.

The non-sidebar `<main>` becomes a **flex column** so the page can fill it via `flex-1` — no viewport unit or safe-area on the page itself (keeps ADR-026's shell ownership of height + safe-area). This supersedes ADR-026 §A1's rejection of a flex `<main>` for vertical-fill pages; see **ADR-027** for the contract and the hard dependency on `leptos_router <Routes>` not wrapping the matched view.

Centering uses `justify-content: safe center` (centers when the card fits, falls back to `flex-start` with **no top-clipping** when it overflows — the `safe` alignment keyword).

## Why this approach (the approved plan changed mid-task)

The original plan was `my-auto` + a `data-testid` on a wrapper `<div>`. That proved **infeasible**: adding attributes to a deep element tipped the `origa_ui_bin` crate (which renders the full `<App/>` view tree under the default `recursion_limit` of 128; the lib has 512 but it is crate-scoped) over the query-depth ceiling (`error: queries overflow the depth limit!`), and raising the bin limit to 512 only shifted the failure to mass linker errors. The shipped approach is **type-neutral** (only class-string changes on existing elements) — the bin artifact is byte-identical to master. See the `recursion_limit` landmine note in `origa_ui/AGENTS.md` and ADR-027 §B3.

A second discovery during review: Tailwind v3 **cannot** generate `justify-[safe_center]` (the `safe` keyword is dropped by arbitrary-value validation), so the centering class is a **literal `.justify-safe-center` rule** in `input.css` (verified present in the built dist CSS).

## Files (8)
- `origa_ui/src/routes.rs` — non-sidebar `<main>` `flex flex-col` (+ 2-line ADR-027 pointer)
- `origa_ui/src/pages/lesson/mod.rs` — `lesson-page` `flex-1 flex flex-col`; column `flex-1 flex flex-col min-h-0`
- `origa_ui/src/pages/lesson/header.rs` — `+shrink-0` (pinned header)
- `origa_ui/src/pages/lesson/content.rs` — `lesson-content` `flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col justify-safe-center`
- `origa_ui/input.css` — literal `.justify-safe-center { justify-content: safe center; }`
- `end2end/tests/lesson.spec.ts` — height-chain + computed-style regression guard
- `docs/decisions/ADR-027-shell-flex-column-for-vertical-fill.md` — new ADR
- `origa_ui/AGENTS.md` — recursion_limit landmine note

## Verification (all green)
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings)
- `cargo test --workspace --exclude origa_landing` (CI's exact command)
- `trunk build` — dist CSS contains `justify-content: safe center`
- Playwright: lesson 11/11; login+onboarding+lesson 28/28 (confirms the shared-shell change does not break `/login` or `/onboarding`)
- Code review: `@code-quality-reviewer` approved (0 findings, 3 cycles)

## NOT touched
- Lesson card **content** (quiz logic, writing canvas, phrase audio, etc.) — only the layout wrapper.
- Card variants' internal layout.
- Other pages (home, kanji/grammar detail) — separate tasks.
- ADR-026 itself (this PR adds ADR-027, which supersedes ADR-026 §A1 for vertical-fill pages).