### PR TITLE
fix(e2e): increase phrase spec timeouts for CDN loading under parallel workers

### DIFF
--- a/end2end/tests/phrase.spec.ts
+++ b/end2end/tests/phrase.spec.ts
@@ -174,14 +174,14 @@ testWithFreshUser.describe("Phrases after full onboarding", () => {
         await expect.poll(async () => {
             const textContent = await phraseText.textContent();
             return textContent?.trim().length ?? 0;
-        }, { timeout: 30_000, message: "Phrase text should not be empty on first load" }).toBeGreaterThan(0);
+        }, { timeout: 60_000, message: "Phrase text should not be empty on first load" }).toBeGreaterThan(0);
 
         // Also verify meaning is non-empty
         const meaning = firstCard.getByTestId("phrases-card-meaning");
         await expect.poll(async () => {
             const meaningContent = await meaning.textContent();
             return meaningContent?.trim().length ?? 0;
-        }, { timeout: 30_000, message: "Phrase meaning should not be empty on first load" }).toBeGreaterThan(0);
+        }, { timeout: 60_000, message: "Phrase meaning should not be empty on first load" }).toBeGreaterThan(0);
     });
 
     testWithFreshUser("should show phrase cards after completing onboarding with N5", async ({ page }) => {
@@ -364,7 +364,7 @@ testWithFreshUser.describe("Phrases Page - CRUD after onboarding", () => {
                     .catch(() => "");
                 return newFirstContent !== firstCardContent;
             },
-            { timeout: 10_000 }
+            { timeout: 30_000 }
         ).toBe(true);
     });
 


### PR DESCRIPTION
## Summary

phrase.spec.ts is the only flaky E2E spec (~6-7% failure rate). Root cause: CDN data loading race under 2 parallel Playwright workers — each running completeFullOnboarding() (~3 min), saturating the CDN mock, and Leptos WASM can't render phrase cards within the 30s expect.poll timeout.

## Fix

Increased 3 expect.poll timeouts:
- Phrase text poll: 30s -> 60s
- Phrase meaning poll: 30s -> 60s
- Delete verification poll: 10s -> 30s

These are polling timeouts (resolve immediately when condition is met), so the increase has zero cost on green runs — it only provides more headroom for CDN-contended CI runners.

## Deferred (Phase B)

Serial mode (test.describe.configure) — deferred pending post-merge monitoring. If flake recurs after this fix, serial mode will be applied as Phase B.

## Evidence

- Run 28681098482 (master): 1/16 phrase tests failed (Timeout 30000ms on expect.poll).
- Run 28333027458 (master): 1/13 phrase tests failed (same timeout pattern).
- All 12 other E2E specs pass green in the same runs — issue is isolated to phrase.