### PR TITLE
fix(ui): intercept reload accelerators to prevent system browser on Android

### DIFF
--- a/origa_ui/src/app.rs
+++ b/origa_ui/src/app.rs
@@ -48,6 +48,11 @@ pub fn App() -> impl IntoView {
     check_url_oauth_callback(&auth_store, &i18n);
     setup_oauth_listener(auth_store.clone(), i18n);
 
+    // Intercept reload accelerators (Ctrl+R / Cmd+R / F5) so that on Android
+    // (physical keyboard) they reload the WebView instead of leaking the
+    // tauri.localhost origin to the system browser. No-op in the browser.
+    crate::hooks::keyboard_shortcuts::install_reload_guard();
+
     let update_info = RwSignal::new(None::<updater::UpdateInfo>);
     let download_progress = RwSignal::new(None::<f32>);
 

--- a/origa_ui/src/core/tauri.rs
+++ b/origa_ui/src/core/tauri.rs
@@ -60,6 +60,80 @@ pub fn opener_open_url_fn() -> Option<Function> {
         .and_then(|v| v.dyn_into::<Function>().ok())
 }
 
+/// Reload the current Tauri WebView.
+///
+/// Primary path: `window.__TAURI__.webview.getCurrentWebview().reload()`
+/// (Tauri v2.4.0+, added in tauri-apps/tauri#12818). This is the native WebView
+/// reload and, by design, does not perform a top-level navigation to the origin,
+/// so it does not reach the URL-navigation policy that can leak
+/// `tauri.localhost` to the system browser on Android.
+///
+/// Fallback: `window.location.reload()`, used when the native `reload` method is
+/// unavailable on the running Tauri version. Combined with `preventDefault()` on
+/// the keydown accelerator (see `hooks::keyboard_shortcuts`), this keeps the
+/// reload inside the WebView instead of letting the accelerator's default
+/// handling run.
+///
+/// Returns `Err` only if `window` itself is unavailable (effectively never in a
+/// browser/WASM context).
+pub fn reload_current_webview() -> Result<(), String> {
+    let window = window().ok_or("window not available")?;
+
+    if try_native_webview_reload() {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        "Native Tauri WebView reload unavailable; falling back to window.location.reload()"
+    );
+    window
+        .location()
+        .reload()
+        .map_err(|e| format!("window.location.reload() failed: {e:?}"))
+}
+
+/// Attempt `window.__TAURI__.webview.getCurrentWebview().reload()`.
+///
+/// Returns `false` if any step of the JS property/call chain is unavailable so
+/// the caller can fall back. Resilient to Tauri versions that do not expose the
+/// `reload` method on the `Webview` instance.
+fn try_native_webview_reload() -> bool {
+    let obj = match tauri_object() {
+        Some(o) => o,
+        None => return false,
+    };
+
+    let webview_mod = match Reflect::get(&obj, &JsValue::from_str("webview")) {
+        Ok(v) if !v.is_undefined() && !v.is_null() => v,
+        _ => return false,
+    };
+
+    let get_current = match Reflect::get(&webview_mod, &JsValue::from_str("getCurrentWebview")) {
+        Ok(v) => match v.dyn_into::<Function>() {
+            Ok(f) => f,
+            Err(_) => return false,
+        },
+        Err(_) => return false,
+    };
+
+    let webview = match get_current.call0(&JsValue::UNDEFINED) {
+        Ok(v) if !v.is_undefined() && !v.is_null() => v,
+        _ => return false,
+    };
+
+    let reload_fn = match Reflect::get(&webview, &JsValue::from_str("reload")) {
+        Ok(v) => match v.dyn_into::<Function>() {
+            Ok(f) => f,
+            // reload() method absent on this Tauri version → fall back.
+            Err(_) => return false,
+        },
+        Err(_) => return false,
+    };
+
+    // reload() is an instance method — call with the webview as `this`.
+    reload_fn.call0(&webview).is_ok()
+}
+
 /// Calls a Tauri command with the given arguments object and awaits the result.
 ///
 /// `args` must be a JS object whose keys match the command's parameter names

--- a/origa_ui/src/hooks/keyboard_shortcuts.rs
+++ b/origa_ui/src/hooks/keyboard_shortcuts.rs
@@ -1,0 +1,93 @@
+//! Global keyboard shortcut interception for the Tauri WebView.
+//!
+//! On Android, unhandled browser accelerators (Ctrl+R, Cmd+R, F5) can trigger a
+//! top-level reload that leaks the WebView origin (`tauri.localhost`) to the
+//! system browser. With a hardware keyboard attached — the precondition for
+//! this bug — Android WebView delivers key events to the page's DOM, so a
+//! `keydown` listener can intercept them. This module does so at the earliest
+//! JS interception point and redirects the reload to a native WebView reload.
+
+use leptos::prelude::*;
+use leptos_use::use_event_listener;
+
+/// Returns `true` if the keyboard event is a reload accelerator.
+///
+/// Matches: Ctrl+R, Cmd+R, F5 (and their Shift variants — hard-reload is still
+/// a reload and must be intercepted, so Shift is intentionally ignored).
+/// Does NOT match: plain R, Ctrl+C, Ctrl+S, Enter, etc.
+pub(crate) fn is_reload_accelerator(code: &str, ctrl: bool, meta: bool) -> bool {
+    let is_r = code == "KeyR";
+    let is_f5 = code == "F5";
+    (is_r && (ctrl || meta)) || is_f5
+}
+
+/// Install a global `keydown` listener that intercepts reload accelerators.
+///
+/// Inside a Tauri WebView the handler calls `prevent_default()` +
+/// `stop_propagation()` (cancelling the accelerator's default reload handling)
+/// and then triggers a reload via [`crate::core::tauri::reload_current_webview`]
+/// so it stays inside the WebView.
+///
+/// Outside a Tauri WebView (web dev via `trunk serve`) this is a no-op, leaving
+/// the browser's native reload intact for the developer workflow.
+pub(crate) fn install_reload_guard() {
+    if !crate::core::tauri::is_tauri() {
+        return;
+    }
+
+    // use_event_listener (leptos-use 0.18) auto-registers cleanup on the
+    // current reactive owner, so the return value can be discarded. App() owns
+    // the guard for the whole app lifetime.
+    let _ = use_event_listener(window(), leptos::ev::keydown, move |ev| {
+        if !is_reload_accelerator(&ev.code(), ev.ctrl_key(), ev.meta_key()) {
+            return;
+        }
+
+        ev.prevent_default();
+        ev.stop_propagation();
+
+        if let Err(e) = crate::core::tauri::reload_current_webview() {
+            tracing::error!("reload guard: native reload failed: {e}");
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ctrl_r_is_reload() {
+        assert!(is_reload_accelerator("KeyR", true, false));
+    }
+
+    #[test]
+    fn cmd_r_is_reload() {
+        assert!(is_reload_accelerator("KeyR", false, true));
+    }
+
+    #[test]
+    fn f5_is_reload() {
+        assert!(is_reload_accelerator("F5", false, false));
+    }
+
+    #[test]
+    fn plain_r_is_not_reload() {
+        assert!(!is_reload_accelerator("KeyR", false, false));
+    }
+
+    #[test]
+    fn ctrl_c_is_not_reload() {
+        assert!(!is_reload_accelerator("KeyC", true, false));
+    }
+
+    #[test]
+    fn ctrl_s_is_not_reload() {
+        assert!(!is_reload_accelerator("KeyS", true, false));
+    }
+
+    #[test]
+    fn enter_is_not_reload() {
+        assert!(!is_reload_accelerator("Enter", false, false));
+    }
+}

--- a/origa_ui/src/hooks/mod.rs
+++ b/origa_ui/src/hooks/mod.rs
@@ -1,1 +1,2 @@
+pub mod keyboard_shortcuts;
 pub mod phrase_checker;


### PR DESCRIPTION
## Problem

On an Android tablet with a physical keyboard, pressing **Ctrl+R / Cmd+R / F5** opens the **system browser** (Chrome/Firefox) with a meaningless `tauri.localhost/...` URL instead of reloading inside the Tauri WebView.

## Root cause

No JS code intercepts the reload accelerator, and Android WebView's default URL policy opens top-level navigations to the WebView origin (`tauri.localhost`) in the system browser. With a hardware keyboard attached (the bug's precondition), Android WebView delivers the key events to the page's DOM, but nothing consumed them — so the WebView's default reload (a top-level navigation to the origin) was routed by the URL policy to the system browser.

## Fix

A global `keydown` listener intercepts reload accelerators (Ctrl+R, Cmd+R, F5) at the earliest JS interception point:

1. `preventDefault()` + `stopPropagation()` cancel the accelerator's default reload handling — this is what stops the system-browser leak.
2. A native Tauri WebView reload (`window.__TAURI__.webview.getCurrentWebview().reload()`) reloads inside the WebView, bypassing the URL navigation policy. Falls back to `window.location.reload()` if the native method is unavailable on the running Tauri version.
3. No-op outside a Tauri WebView (web dev via `trunk serve`) — the browser's native reload stays intact for the developer workflow.

### Files
- `hooks/keyboard_shortcuts.rs` (new): `is_reload_accelerator(code, ctrl, meta)` pure predicate (unit-tested truth table) + `install_reload_guard()` registering a `use_event_listener` on `window` keydown.
- `core/tauri.rs`: `reload_current_webview()` (public) + `try_native_webview_reload()` (private helper), following the module's existing `Reflect::get`/`dyn_into::<Function>()` pattern.
- `app.rs`: calls `install_reload_guard()` in `App()` init, right after OAuth listener setup.
- `hooks/mod.rs`: registers the new module.

## Verification

| Check | Status | Details |
|-------|--------|---------|
| `cargo fmt --check -p origa_ui` | ✅ | clean |
| `cargo clippy -p origa_ui --all-targets -- -D warnings` | ✅ | 0 warnings |
| `cargo test -p origa_ui` | ✅ | 241 unit + 6 build_config pass; 7 `keyboard_shortcuts` truth-table tests |
| `qlty check` (changed files) | ✅ | no issues |
| Code review (GATE 2) | ✅ | `approve` (2 iterations) |

## ⚠️ On-device verification (PR-level checkpoint, not code-blocking)

The code-level review passed (`approve`). The final confirmation that the bug is eliminated requires an **on-device smoke test** on an Android tablet with a physical keyboard:
- [ ] Ctrl+R does **not** open the system browser; WebView reloads
- [ ] Cmd+R does **not** open the system browser; WebView reloads
- [ ] F5 does **not** open the system browser; WebView reloads

This is outside the build/test environment and is tracked here as the bug-closure checkpoint. The fix is strictly additive (no-op in the browser; in Tauri it either fixes the bug or leaves it unchanged — no new failure mode is introduced), so merging is safe before the device test.