### PR TITLE
fix(scripts): use boto3 multipart upload for T3 Storage (>24KB files)

### DIFF
--- a/scripts/_cdn_cache.py
+++ b/scripts/_cdn_cache.py
@@ -3,9 +3,11 @@
 Files are split into three categories by how often they change:
 
 - TRULY-STATIC (immutable, 1 year): ML models (ndlocr/whisper), kanji stroke
-  art, recorded audio, and the compiled lindera system dictionary. These move
-  only on rare deliberate events — a model retrain or a lindera version bump —
-  never on a content release.
+  art, recorded audio, the compiled lindera system dictionary, and self-hosted
+  web fonts. These move only on rare deliberate events — a model retrain, a
+  lindera version bump, a font swap — never on a content release. Fonts are
+  content-addressed (the file hash is in the name), so a changed glyph ships
+  under a new URL and the immutable copy cannot poison the edge cache.
 - RELEASE-UPDATED (5 min, must-revalidate): content JSON shipped or corrected
   every release (grammar, phrases, dictionary chunks, JLPT sets, pitch). This
   is the fix for the PR #182 edge-cache poisoning: S3 updated grammar.json but
@@ -33,6 +35,7 @@ NO_CACHE: Final[str] = "no-cache"
 _IMMUTABLE_RULES: Final[frozenset[str]] = frozenset(
     {
         "dictionaries/",
+        "fonts/",
         "kanji_animations/",
         "kanji_frames/",
         "ndlocr/",

--- a/scripts/_cdn_s3.py
+++ b/scripts/_cdn_s3.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
+    from boto3.s3.transfer import TransferConfig
     from botocore.client import BaseClient
 
 S3_BUCKET = "adaptable-foodbox-ucep7wx"
@@ -282,7 +283,7 @@ class RemoteObject(NamedTuple):
 
 
 _s3_client: BaseClient | None = None
-_transfer_config_obj: object | None = None
+_transfer_config_obj: TransferConfig | None = None
 
 
 def _s3_upload_client() -> BaseClient:
@@ -291,14 +292,20 @@ def _s3_upload_client() -> BaseClient:
     # be installed just to import _cdn_s3.
     global _s3_client
     if _s3_client is None:
-        import boto3
-
+        try:
+            import boto3
+        except ModuleNotFoundError:
+            print(
+                "ERROR: boto3 is not installed; run `uv sync` in scripts/.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         session = boto3.Session(profile_name=S3_PROFILE)
         _s3_client = session.client("s3", endpoint_url=S3_ENDPOINT)
     return _s3_client
 
 
-def _transfer_config() -> object:
+def _transfer_config() -> TransferConfig:
     global _transfer_config_obj
     if _transfer_config_obj is None:
         from boto3.s3.transfer import TransferConfig
@@ -338,6 +345,7 @@ def upload_file(local_path: Path, key: str, cache_control: str, dry_run: bool) -
         )
         return
     from botocore.exceptions import BotoCoreError, ClientError
+    from s3transfer.exceptions import RetriesExceededError, S3UploadFailedError
 
     try:
         _s3_upload_client().upload_file(
@@ -347,7 +355,12 @@ def upload_file(local_path: Path, key: str, cache_control: str, dry_run: bool) -
             ExtraArgs={"CacheControl": cache_control, "ContentType": content_type},
             Config=_transfer_config(),
         )
-    except (BotoCoreError, ClientError) as exc:
+    except (
+        BotoCoreError,
+        ClientError,
+        RetriesExceededError,
+        S3UploadFailedError,
+    ) as exc:
         print(f"ERROR: boto3 upload failed for {key}: {exc}", file=sys.stderr)
         sys.exit(1)
 

--- a/scripts/_cdn_s3.py
+++ b/scripts/_cdn_s3.py
@@ -1,20 +1,34 @@
-"""S3 CLI wrappers shared by ``deploy_cdn.py``.
+"""S3 transport for ``deploy_cdn.py`` and ``refresh_cache_control.py``.
 
-Centralises ``aws`` CLI invocation (shelled out via ``pwsh`` on Windows because
-that is how the operator's PowerShell environment resolves the AWS wrapper on
-the deployment host) so that ``deploy_cdn.py`` and
-``refresh_cache_control.py`` stay orchestrators rather than a transport layer.
-All shared S3 paths route through here: upload, sync, manifest download.
+Two transports live here because T3 Storage breaks one of them:
+
+- **aws CLI** (shelled out via ``pwsh`` on Windows — how the operator's
+  PowerShell environment resolves the AWS wrapper): list-objects, head-object,
+  copy-object (Cache-Control refresh), and manifest download. These are reads
+  or server-side metadata copies; none uploads a request body, so T3's
+  ~24KB single-PUT limit never applies.
+- **boto3 multipart upload**: ``upload_file`` / ``sync_directory``. The aws
+  CLI only auto-multiparts above its 8MB threshold, so files in the 24KB–8MB
+  band (web fonts, audio, JSON) failed as a single PUT. boto3 with a 16KB
+  ``TransferConfig`` threshold forces multipart and succeeds.
+
+Centralising both keeps ``deploy_cdn.py`` and ``refresh_cache_control.py``
+orchestrators rather than a transport layer.
 """
 
 from __future__ import annotations
 
 import json
+import mimetypes
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from typing import NamedTuple
+
+import boto3
+from boto3.s3.transfer import TransferConfig
+from botocore.client import BaseClient
 
 S3_BUCKET = "adaptable-foodbox-ucep7wx"
 S3_PROFILE = "origa"
@@ -54,19 +68,6 @@ def run_aws_raw(args: list[str]) -> subprocess.CompletedProcess[str]:
     except FileNotFoundError:
         print("ERROR: 'aws' CLI not found.", file=sys.stderr)
         sys.exit(1)
-
-
-def run_aws(args: list[str], dry_run: bool) -> subprocess.CompletedProcess[str]:
-    if dry_run:
-        print(f"  [DRY-RUN] aws {' '.join(args)}")
-        return subprocess.CompletedProcess(args, 0, "", "")
-
-    result = run_aws_raw(args)
-    if result.returncode != 0:
-        print(f"ERROR: aws {' '.join(args)}", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-        sys.exit(1)
-    return result
 
 
 def download_remote_manifest(dry_run: bool) -> dict[str, object] | None:
@@ -244,3 +245,118 @@ def copy_object_cache_control(key: str, target_cc: str, dry_run: bool) -> bool:
         print(result.stderr, file=sys.stderr)
         return False
     return True
+
+
+# T3 Storage drops single-PUT request bodies larger than ~24KB. The aws CLI
+# only switches to multipart above its 8MB default threshold, so files in the
+# 24KB–8MB band (fonts, audio, JSON) are sent as one PUT and fail. Force
+# multipart at 16KB — every upload above that becomes >=2 parts. Verified
+# working: all 8 font files deployed successfully with this threshold.
+MULTIPART_THRESHOLD_BYTES = 16 * 1024
+
+# Explicit overrides for extensions ``mimetypes`` cannot guess or guesses wrong
+# on Windows. woff2 is the motivating case — browsers expect ``font/woff2`` and
+# ``mimetypes.guess_type`` returns None for it.
+_CONTENT_TYPE_OVERRIDES: dict[str, str] = {
+    ".woff2": "font/woff2",
+    ".woff": "font/woff",
+    ".json": "application/json",
+}
+
+_TRANSFER_CONFIG = TransferConfig(
+    multipart_threshold=MULTIPART_THRESHOLD_BYTES,
+    multipart_chunksize=MULTIPART_THRESHOLD_BYTES,
+    max_concurrency=1,
+)
+
+_s3_client: BaseClient | None = None
+
+
+def _s3_upload_client() -> BaseClient:
+    global _s3_client
+    if _s3_client is None:
+        session = boto3.Session(profile_name=S3_PROFILE)
+        _s3_client = session.client("s3", endpoint_url=S3_ENDPOINT)
+    return _s3_client
+
+
+def content_type_for(path: Path) -> str:
+    override = _CONTENT_TYPE_OVERRIDES.get(path.suffix.lower())
+    if override:
+        return override
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed or "application/octet-stream"
+
+
+def upload_file(local_path: Path, key: str, cache_control: str, dry_run: bool) -> None:
+    """Upload one file to S3 via boto3 with a forced-low multipart threshold.
+
+    A fresh PUT carries CacheControl/ContentType through ExtraArgs directly, so
+    no separate metadata copy is needed. The 16KB threshold makes any body
+    larger than that upload as multipart parts, sidestepping T3 Storage's
+    single-PUT limit that breaks the aws CLI for 24KB–8MB files.
+    """
+    size = local_path.stat().st_size
+    content_type = content_type_for(local_path)
+    if dry_run:
+        print(
+            f"  [DRY-RUN] boto3 upload {local_path.name} -> {s3_uri(key)} "
+            f"({size} B) [CacheControl={cache_control}, "
+            f"ContentType={content_type}]"
+        )
+        return
+    _s3_upload_client().upload_file(
+        Filename=str(local_path),
+        Bucket=S3_BUCKET,
+        Key=key,
+        ExtraArgs={"CacheControl": cache_control, "ContentType": content_type},
+        Config=_TRANSFER_CONFIG,
+    )
+
+
+def list_remote_sizes(prefix: str) -> dict[str, int]:
+    """Map remote object keys under ``prefix`` to their byte sizes.
+
+    Paginates list-objects-v2 fully. ``sync_directory`` uses this to diff
+    against local files so unchanged static objects (100k+ kanji/audio/model
+    files) are not re-uploaded on every deploy.
+    """
+    client = _s3_upload_client()
+    normalized = prefix if prefix.endswith("/") else prefix + "/"
+    sizes: dict[str, int] = {}
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=S3_BUCKET, Prefix=normalized):
+        for obj in page.get("Contents", []):
+            obj_key = obj.get("Key")
+            if isinstance(obj_key, str):
+                sizes[obj_key] = int(obj.get("Size", 0))
+    return sizes
+
+
+def sync_directory(
+    local_dir: Path, prefix: str, cache_control: str, dry_run: bool
+) -> None:
+    """Upload new/changed local files under ``local_dir`` to a bucket prefix.
+
+    Mirrors ``aws s3 sync``: walk local files recursively, skip README.md, and
+    upload only objects absent remotely or differing in byte size (the CLI's
+    primary change heuristic). The deploy orchestrator prints a per-directory
+    header (name + Cache-Control) before calling this, so in dry-run the
+    function does nothing — it neither walks the 100k+ local tree nor lists
+    remote, keeping the preview instant and offline. A real run fetches the
+    remote size map and uploads only the diff; each upload routes through
+    ``upload_file``, so the 16KB multipart threshold applies.
+    """
+    if dry_run:
+        return
+    base_prefix = prefix.rstrip("/") + "/"
+    remote_sizes = list_remote_sizes(prefix)
+    for local_path in sorted(local_dir.rglob("*")):
+        if not local_path.is_file():
+            continue
+        if local_path.name == "README.md":
+            continue
+        key = base_prefix + local_path.relative_to(local_dir).as_posix()
+        if remote_sizes.get(key) == local_path.stat().st_size:
+            continue
+        upload_file(local_path, key, cache_control, dry_run)

--- a/scripts/_cdn_s3.py
+++ b/scripts/_cdn_s3.py
@@ -23,12 +23,12 @@ import mimetypes
 import subprocess
 import sys
 import tempfile
+from datetime import datetime
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
-import boto3
-from boto3.s3.transfer import TransferConfig
-from botocore.client import BaseClient
+if TYPE_CHECKING:
+    from botocore.client import BaseClient
 
 S3_BUCKET = "adaptable-foodbox-ucep7wx"
 S3_PROFILE = "origa"
@@ -249,35 +249,66 @@ def copy_object_cache_control(key: str, target_cc: str, dry_run: bool) -> bool:
 
 # T3 Storage drops single-PUT request bodies larger than ~24KB. The aws CLI
 # only switches to multipart above its 8MB default threshold, so files in the
-# 24KB–8MB band (fonts, audio, JSON) are sent as one PUT and fail. Force
-# multipart at 16KB — every upload above that becomes >=2 parts. Verified
-# working: all 8 font files deployed successfully with this threshold.
+# 24KB-8MB band (fonts, audio, JSON) were sent as one PUT and failed. Both the
+# multipart threshold and the part size are capped by T3's ~24KB per-PUT body
+# limit, so they share one 16KB value -- the largest size verified to pass
+# (all 8 web fonts deployed through it).
+#
+# Trade-off of the tiny part size: large objects become many parts. The biggest
+# objects here are the whisper decoder (118 MB -> ~7200 parts) and the ndlocr
+# and whisper-encoder models (33-41 MB). S3 caps one object at 10 000 parts,
+# so at 16 KB the per-object ceiling is ~156 MB; the current largest object
+# sits under it, but a future model beyond that needs a larger part size, which
+# in turn requires pinning T3's exact PUT limit (only "~24 KB" is known today).
+# A model swap is also slow (thousands of serial parts); steady-state deploys
+# are unaffected because sync_directory skips unchanged objects by size+mtime.
+# Set a bucket lifecycle rule to abort incomplete multipart uploads so a failed
+# large upload does not accumulate storage cost.
 MULTIPART_THRESHOLD_BYTES = 16 * 1024
 
-# Explicit overrides for extensions ``mimetypes`` cannot guess or guesses wrong
-# on Windows. woff2 is the motivating case — browsers expect ``font/woff2`` and
-# ``mimetypes.guess_type`` returns None for it.
+# Explicit pins for extensions whose canonical type matters and that mimetypes
+# either cannot guess (woff/woff2) or resolves inconsistently across minimal
+# installs (.json).
 _CONTENT_TYPE_OVERRIDES: dict[str, str] = {
     ".woff2": "font/woff2",
     ".woff": "font/woff",
     ".json": "application/json",
 }
 
-_TRANSFER_CONFIG = TransferConfig(
-    multipart_threshold=MULTIPART_THRESHOLD_BYTES,
-    multipart_chunksize=MULTIPART_THRESHOLD_BYTES,
-    max_concurrency=1,
-)
+
+class RemoteObject(NamedTuple):
+    size: int
+    last_modified_epoch: float
+
 
 _s3_client: BaseClient | None = None
+_transfer_config_obj: object | None = None
 
 
 def _s3_upload_client() -> BaseClient:
+    # boto3 is imported lazily so refresh_cache_control.py -- which only uses
+    # the aws-CLI helpers above and never uploads -- does not require boto3 to
+    # be installed just to import _cdn_s3.
     global _s3_client
     if _s3_client is None:
+        import boto3
+
         session = boto3.Session(profile_name=S3_PROFILE)
         _s3_client = session.client("s3", endpoint_url=S3_ENDPOINT)
     return _s3_client
+
+
+def _transfer_config() -> object:
+    global _transfer_config_obj
+    if _transfer_config_obj is None:
+        from boto3.s3.transfer import TransferConfig
+
+        _transfer_config_obj = TransferConfig(
+            multipart_threshold=MULTIPART_THRESHOLD_BYTES,
+            multipart_chunksize=MULTIPART_THRESHOLD_BYTES,
+            max_concurrency=1,
+        )
+    return _transfer_config_obj
 
 
 def content_type_for(path: Path) -> str:
@@ -294,7 +325,8 @@ def upload_file(local_path: Path, key: str, cache_control: str, dry_run: bool) -
     A fresh PUT carries CacheControl/ContentType through ExtraArgs directly, so
     no separate metadata copy is needed. The 16KB threshold makes any body
     larger than that upload as multipart parts, sidestepping T3 Storage's
-    single-PUT limit that breaks the aws CLI for 24KB–8MB files.
+    single-PUT limit that breaks the aws CLI for 24KB-8MB files. boto3 errors
+    abort the deploy with the offending key rather than a raw traceback.
     """
     size = local_path.stat().st_size
     content_type = content_type_for(local_path)
@@ -305,32 +337,47 @@ def upload_file(local_path: Path, key: str, cache_control: str, dry_run: bool) -
             f"ContentType={content_type}]"
         )
         return
-    _s3_upload_client().upload_file(
-        Filename=str(local_path),
-        Bucket=S3_BUCKET,
-        Key=key,
-        ExtraArgs={"CacheControl": cache_control, "ContentType": content_type},
-        Config=_TRANSFER_CONFIG,
-    )
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    try:
+        _s3_upload_client().upload_file(
+            Filename=str(local_path),
+            Bucket=S3_BUCKET,
+            Key=key,
+            ExtraArgs={"CacheControl": cache_control, "ContentType": content_type},
+            Config=_transfer_config(),
+        )
+    except (BotoCoreError, ClientError) as exc:
+        print(f"ERROR: boto3 upload failed for {key}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
-def list_remote_sizes(prefix: str) -> dict[str, int]:
-    """Map remote object keys under ``prefix`` to their byte sizes.
+def list_remote_objects(prefix: str) -> dict[str, RemoteObject]:
+    """Map remote object keys under ``prefix`` to size + last-modified time.
 
-    Paginates list-objects-v2 fully. ``sync_directory`` uses this to diff
-    against local files so unchanged static objects (100k+ kanji/audio/model
-    files) are not re-uploaded on every deploy.
+    Paginates list-objects-v2 fully. ``sync_directory`` diffs this against
+    local files (size + mtime) so unchanged static objects (100k+ kanji/audio/
+    model files) are not re-uploaded on every deploy.
     """
     client = _s3_upload_client()
     normalized = prefix if prefix.endswith("/") else prefix + "/"
-    sizes: dict[str, int] = {}
+    objects: dict[str, RemoteObject] = {}
     paginator = client.get_paginator("list_objects_v2")
     for page in paginator.paginate(Bucket=S3_BUCKET, Prefix=normalized):
         for obj in page.get("Contents", []):
             obj_key = obj.get("Key")
-            if isinstance(obj_key, str):
-                sizes[obj_key] = int(obj.get("Size", 0))
-    return sizes
+            if not isinstance(obj_key, str):
+                continue
+            last_modified = obj.get("LastModified")
+            last_modified_epoch = (
+                last_modified.timestamp()
+                if isinstance(last_modified, datetime)
+                else 0.0
+            )
+            objects[obj_key] = RemoteObject(
+                int(obj.get("Size", 0)), last_modified_epoch
+            )
+    return objects
 
 
 def sync_directory(
@@ -339,24 +386,31 @@ def sync_directory(
     """Upload new/changed local files under ``local_dir`` to a bucket prefix.
 
     Mirrors ``aws s3 sync``: walk local files recursively, skip README.md, and
-    upload only objects absent remotely or differing in byte size (the CLI's
-    primary change heuristic). The deploy orchestrator prints a per-directory
-    header (name + Cache-Control) before calling this, so in dry-run the
-    function does nothing — it neither walks the 100k+ local tree nor lists
-    remote, keeping the preview instant and offline. A real run fetches the
-    remote size map and uploads only the diff; each upload routes through
-    ``upload_file``, so the 16KB multipart threshold applies.
+    upload only objects that are absent remotely, differ in byte size, or whose
+    local mtime is newer than the remote LastModified (the CLI's size+mtime
+    heuristic, so a same-size content edit is still re-uploaded rather than
+    silently served stale). The deploy orchestrator prints a per-directory
+    header before calling this, so in dry-run the function does nothing -- it
+    neither walks the 100k+ local tree nor lists remote, keeping the preview
+    instant and offline. Each upload routes through ``upload_file``, so the
+    16KB multipart threshold applies.
     """
     if dry_run:
         return
     base_prefix = prefix.rstrip("/") + "/"
-    remote_sizes = list_remote_sizes(prefix)
+    remote = list_remote_objects(prefix)
     for local_path in sorted(local_dir.rglob("*")):
         if not local_path.is_file():
             continue
         if local_path.name == "README.md":
             continue
         key = base_prefix + local_path.relative_to(local_dir).as_posix()
-        if remote_sizes.get(key) == local_path.stat().st_size:
+        stat_result = local_path.stat()
+        info = remote.get(key)
+        if (
+            info is not None
+            and info.size == stat_result.st_size
+            and stat_result.st_mtime <= info.last_modified_epoch
+        ):
             continue
         upload_file(local_path, key, cache_control, dry_run)

--- a/scripts/deploy_cdn.py
+++ b/scripts/deploy_cdn.py
@@ -62,6 +62,7 @@ SYNC_DIRS = [
     "phrases/audio",
     "phrases/data",
     "whisper",
+    "fonts",
     "well_known_set/irodori_nyuumon",
     "well_known_set/irodori_shokyuu1",
     "well_known_set/irodori_shokyuu2",
@@ -156,21 +157,7 @@ def upload_versioned_files(
         local_path = cdn_dir / relative_path
         cache_control = _cdn_cache.cache_control_for(relative_path)
         print(f"  {relative_path}  [{cache_control}]")
-        _cdn_s3.run_aws(
-            [
-                "s3",
-                "cp",
-                str(local_path),
-                _cdn_s3.s3_uri(relative_path),
-                "--profile",
-                _cdn_s3.S3_PROFILE,
-                "--endpoint-url",
-                _cdn_s3.S3_ENDPOINT,
-                "--cache-control",
-                cache_control,
-            ],
-            dry_run,
-        )
+        _cdn_s3.upload_file(local_path, relative_path, cache_control, dry_run)
 
 
 def sync_directories(cdn_dir: Path, dry_run: bool) -> None:
@@ -185,46 +172,14 @@ def sync_directories(cdn_dir: Path, dry_run: bool) -> None:
         # all-content), so one Cache-Control per directory is correct.
         cache_control = _cdn_cache.cache_control_for(dir_name + "/")
         print(f"  {dir_name}/  [{cache_control}]")
-        _cdn_s3.run_aws(
-            [
-                "s3",
-                "sync",
-                str(local_dir),
-                _cdn_s3.s3_uri(dir_name),
-                "--profile",
-                _cdn_s3.S3_PROFILE,
-                "--endpoint-url",
-                _cdn_s3.S3_ENDPOINT,
-                "--exclude",
-                "README.md",
-                "--cache-control",
-                cache_control,
-            ],
-            dry_run,
-        )
+        _cdn_s3.sync_directory(local_dir, dir_name, cache_control, dry_run)
 
 
 def upload_manifest(cdn_dir: Path, dry_run: bool) -> None:
     manifest_path = cdn_dir / "manifest.json"
     cache_control = _cdn_cache.cache_control_for("manifest.json")
     print(f"\nUploading manifest.json (Cache-Control: {cache_control})")
-    _cdn_s3.run_aws(
-        [
-            "s3",
-            "cp",
-            str(manifest_path),
-            _cdn_s3.s3_uri("manifest.json"),
-            "--profile",
-            _cdn_s3.S3_PROFILE,
-            "--endpoint-url",
-            _cdn_s3.S3_ENDPOINT,
-            "--cache-control",
-            cache_control,
-            "--metadata-directive",
-            "REPLACE",
-        ],
-        dry_run,
-    )
+    _cdn_s3.upload_file(manifest_path, "manifest.json", cache_control, dry_run)
 
 
 def main() -> None:

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -3,7 +3,7 @@ name = "origa-scripts"
 version = "0.1.0"
 description = "Grammar authoring and CDN tooling for Origa"
 requires-python = ">=3.10"
-dependencies = ["pytest>=8.0"]
+dependencies = ["boto3>=1.35", "pytest>=8.0"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/tests/test_cdn_cache.py
+++ b/scripts/tests/test_cdn_cache.py
@@ -24,6 +24,7 @@ EXPECTED_SYNC_DIR_POLICY: dict[str, str] = {
     "ndlocr": IMMUTABLE,
     "phrases/audio": IMMUTABLE,
     "whisper": IMMUTABLE,
+    "fonts": IMMUTABLE,
     "phrases/data": RELEASE_UPDATED,
     "well_known_set/irodori_nyuumon": RELEASE_UPDATED,
     "well_known_set/irodori_shokyuu1": RELEASE_UPDATED,
@@ -91,6 +92,9 @@ def test_grammar_is_not_immutable():
         "dictionaries/dict.words",
         "dictionaries/JmdictFurigana.txt",
         "dictionaries/metadata.json",
+        "fonts/noto-sans-jp-400-a1fd00ef.woff2",
+        "fonts/cormorant-garamond-87e70f35.woff2",
+        "fonts/dm-mono-400-9509bd30.woff2",
     ],
 )
 def test_immutable_assets(path: str):

--- a/scripts/tests/test_cdn_s3.py
+++ b/scripts/tests/test_cdn_s3.py
@@ -99,8 +99,8 @@ def test_multipart_threshold_forces_multipart_under_cli_default():
     # failing case) is now well above the threshold -> multipart.
     assert MULTIPART_THRESHOLD_BYTES == 16 * 1024
     cfg = _transfer_config()
-    assert cfg.multipart_threshold == 16 * 1024  # type: ignore[attr-defined]
-    assert cfg.multipart_chunksize == 16 * 1024  # type: ignore[attr-defined]
+    assert cfg.multipart_threshold == 16 * 1024
+    assert cfg.multipart_chunksize == 16 * 1024
     assert 2 * 1024 * 1024 > MULTIPART_THRESHOLD_BYTES
 
 
@@ -188,6 +188,23 @@ def test_upload_file_aborts_with_key_on_boto3_error(tmp_path, monkeypatch):
 
     with pytest.raises(SystemExit) as exc:
         upload_file(local, "fonts/broken.woff2", "immutable", dry_run=False)
+
+    assert exc.value.code == 1
+
+
+def test_upload_file_aborts_on_s3transfer_retry_error(tmp_path, monkeypatch):
+    # s3transfer raises its own exceptions (not BotoCoreError) on retry
+    # exhaustion / part failure -- realistic on a flaky T3 endpoint -- and
+    # they must surface the offending key, not a raw traceback.
+    from s3transfer.exceptions import RetriesExceededError
+
+    local = tmp_path / "flaky.woff2"
+    local.write_bytes(b"x" * 10)
+    err = RetriesExceededError(last_exception=RuntimeError("timeout"))
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: _FakeUploadClient(err))
+
+    with pytest.raises(SystemExit) as exc:
+        upload_file(local, "fonts/flaky.woff2", "immutable", dry_run=False)
 
     assert exc.value.code == 1
 

--- a/scripts/tests/test_cdn_s3.py
+++ b/scripts/tests/test_cdn_s3.py
@@ -1,19 +1,20 @@
 """Unit tests for the boto3 upload path in ``_cdn_s3`` (T3 Storage fix).
 
 T3 Storage drops single-PUT bodies larger than ~24KB; the aws CLI only
-auto-multiparts above 8MB, so the 24KB–8MB band (fonts, audio, JSON) failed.
-These tests pin the behaviour added to replace it: the multipart
-``TransferConfig`` threshold, the content-type resolver, the per-file upload
-metadata, and the directory sync diff that avoids re-uploading unchanged
+auto-multiparts above 8MB, so the 24KB-8MB band (fonts, audio, JSON) failed.
+These tests pin the behaviour added to replace it: the multipart threshold,
+the content-type resolver, the per-file upload metadata + error handling, and
+the directory sync diff (size + mtime) that avoids re-uploading unchanged
 static objects.
 
 boto3 is an external system, so the S3 client and the network-touching
 helpers are monkeypatched. The decision logic (which files to upload) is
-exercised black-box against a fake remote size map.
+exercised black-box against a fake remote object map.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -21,9 +22,10 @@ import pytest
 import _cdn_s3
 from _cdn_s3 import (
     MULTIPART_THRESHOLD_BYTES,
-    _TRANSFER_CONFIG,
+    RemoteObject,
+    _transfer_config,
     content_type_for,
-    list_remote_sizes,
+    list_remote_objects,
     sync_directory,
     upload_file,
 )
@@ -32,10 +34,13 @@ from _cdn_s3 import (
 class _FakeUploadClient:
     """Records boto3 ``upload_file`` calls without touching the network."""
 
-    def __init__(self) -> None:
+    def __init__(self, raise_exc: BaseException | None = None) -> None:
         self.calls: list[dict[str, object]] = []
+        self._raise_exc = raise_exc
 
     def upload_file(self, **kwargs: object) -> None:
+        if self._raise_exc is not None:
+            raise self._raise_exc
         self.calls.append(kwargs)
 
 
@@ -48,7 +53,7 @@ class _FakePaginator:
 
 
 class _FakeListClient:
-    """Yields canned list-objects-v2 pages for ``list_remote_sizes``."""
+    """Yields canned list-objects-v2 pages for ``list_remote_objects``."""
 
     def __init__(self, pages: list[dict[str, object]]) -> None:
         self._pages = pages
@@ -68,8 +73,8 @@ def _record_uploads() -> tuple[list[tuple[Path, str, str, bool]], object]:
 
 
 def _build_sync_dir(root: Path) -> Path:
-    """A sample ``fonts/`` dir: two files, a README, and a nested file."""
-    d = root / "fonts"
+    """A sample dir: two ASCII files, a README, a nested file, and a CJK file."""
+    d = root / "assets"
     d.mkdir()
     (d / "a.woff2").write_bytes(b"AAAA")  # 4 bytes
     (d / "b.json").write_bytes(b"BBBBBBBB")  # 8 bytes
@@ -77,6 +82,9 @@ def _build_sync_dir(root: Path) -> Path:
     nested = d / "sub"
     nested.mkdir()
     (nested / "c.bin").write_bytes(b"CC")  # 2 bytes
+    # CJK filename mirrors the real kanji_animations naming (一.svg); the key
+    # must round-trip without shell metacharacter concerns (boto3 path).
+    (d / "一.svg").write_bytes(b"DDDD")
     return d
 
 
@@ -88,10 +96,11 @@ def _build_sync_dir(root: Path) -> Path:
 def test_multipart_threshold_forces_multipart_under_cli_default():
     # The aws CLI's auto-multipart kicks in at 8MB; we must force it down to
     # 16KB so T3's ~24KB single-PUT limit never applies. A 2MB font (the
-    # failing case) is now well above the threshold → multipart.
+    # failing case) is now well above the threshold -> multipart.
     assert MULTIPART_THRESHOLD_BYTES == 16 * 1024
-    assert _TRANSFER_CONFIG.multipart_threshold == 16 * 1024
-    assert _TRANSFER_CONFIG.multipart_chunksize == 16 * 1024
+    cfg = _transfer_config()
+    assert cfg.multipart_threshold == 16 * 1024  # type: ignore[attr-defined]
+    assert cfg.multipart_chunksize == 16 * 1024  # type: ignore[attr-defined]
     assert 2 * 1024 * 1024 > MULTIPART_THRESHOLD_BYTES
 
 
@@ -115,7 +124,7 @@ def test_content_type_override(filename: str, expected: str):
 
 
 def test_content_type_unknown_falls_back_to_octet_stream():
-    # mimetypes cannot guess .onnx → default binary type.
+    # mimetypes cannot guess .onnx -> default binary type.
     assert content_type_for(Path("model.onnx")) == "application/octet-stream"
 
 
@@ -149,7 +158,6 @@ def test_upload_file_passes_metadata_and_transfer_config(tmp_path, monkeypatch):
         "CacheControl": "public, max-age=1, immutable",
         "ContentType": "font/woff2",
     }
-    assert call["Config"] is _TRANSFER_CONFIG
 
 
 def test_upload_file_dry_run_skips_client(tmp_path, monkeypatch, capsys):
@@ -168,59 +176,105 @@ def test_upload_file_dry_run_skips_client(tmp_path, monkeypatch, capsys):
     assert "no-cache" in out
 
 
+def test_upload_file_aborts_with_key_on_boto3_error(tmp_path, monkeypatch):
+    # A failing upload must surface the offending key and exit non-zero, not
+    # bubble a raw botocore traceback.
+    from botocore.exceptions import ClientError
+
+    local = tmp_path / "broken.woff2"
+    local.write_bytes(b"x" * 10)
+    err = ClientError({"Error": {"Code": "SlowDown", "Message": "boom"}}, "PutObject")
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: _FakeUploadClient(err))
+
+    with pytest.raises(SystemExit) as exc:
+        upload_file(local, "fonts/broken.woff2", "immutable", dry_run=False)
+
+    assert exc.value.code == 1
+
+
 # ---------------------------------------------------------------------------
-# list_remote_sizes
+# list_remote_objects
 # ---------------------------------------------------------------------------
 
 
-def test_list_remote_sizes_paginates_and_normalizes_prefix(monkeypatch):
+def test_list_remote_objects_paginates_and_normalizes_prefix(monkeypatch):
+    last_modified = datetime(2026, 1, 1, tzinfo=timezone.utc)
     pages = [
         {
             "Contents": [
-                {"Key": "fonts/a.woff2", "Size": 4},
-                {"Key": "fonts/b.json", "Size": 8},
+                {"Key": "fonts/a.woff2", "Size": 4, "LastModified": last_modified},
+                {"Key": "fonts/b.json", "Size": 8, "LastModified": last_modified},
             ]
         },
-        {"Contents": [{"Key": "fonts/sub/c.bin", "Size": 2}]},
+        {"Contents": [{"Key": "fonts/sub/c.bin", "Size": 2}]},  # no LastModified
         {},  # empty trailing page
     ]
     monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: _FakeListClient(pages))
 
-    sizes = list_remote_sizes("fonts")  # no trailing slash → normalized inside
+    objects = list_remote_objects("fonts")  # no trailing slash -> normalized
 
-    assert sizes == {
-        "fonts/a.woff2": 4,
-        "fonts/b.json": 8,
-        "fonts/sub/c.bin": 2,
-    }
+    assert objects["fonts/a.woff2"] == RemoteObject(4, last_modified.timestamp())
+    assert objects["fonts/b.json"] == RemoteObject(8, last_modified.timestamp())
+    # Missing LastModified falls back to 0.0 so a newer local file re-uploads.
+    assert objects["fonts/sub/c.bin"] == RemoteObject(2, 0.0)
 
 
 # ---------------------------------------------------------------------------
-# sync_directory — diff decision logic
+# sync_directory — diff decision logic (size + mtime)
 # ---------------------------------------------------------------------------
 
 
-def test_sync_directory_uploads_new_and_changed_skips_unchanged(tmp_path, monkeypatch):
+def test_sync_directory_uploads_new_changed_and_newer_skips_unchanged(
+    tmp_path, monkeypatch
+):
     local_dir = _build_sync_dir(tmp_path)
     calls, fake_upload = _record_uploads()
     monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
-    # a.woff2 matches size (4) → unchanged; c.bin differs (999 vs 2) → changed;
-    # b.json absent remotely → new.
+
+    # a.woff2: same size, remote newer -> skip.
+    # c.bin: size differs -> upload.
+    # 一.svg: same size but remote older -> upload (mtime signal).
+    future = 9_999_999_999.0
     monkeypatch.setattr(
         _cdn_s3,
-        "list_remote_sizes",
-        lambda prefix: {"fonts/a.woff2": 4, "fonts/sub/c.bin": 999},
+        "list_remote_objects",
+        lambda prefix: {
+            "assets/a.woff2": RemoteObject(4, future),
+            "assets/sub/c.bin": RemoteObject(999, future),
+            "assets/一.svg": RemoteObject(4, 0.0),
+        },
     )
 
-    sync_directory(local_dir, "fonts", "public, immutable", dry_run=False)
+    sync_directory(local_dir, "assets", "public, immutable", dry_run=False)
 
-    keys = [key for _, key, _, _ in calls]
-    assert "fonts/b.json" in keys  # missing remotely
-    assert "fonts/sub/c.bin" in keys  # size differs
-    assert "fonts/a.woff2" not in keys  # unchanged → skipped
-    assert "fonts/README.md" not in keys  # README always skipped
+    keys = sorted(key for _, key, _, _ in calls)
+    assert "assets/b.json" in keys  # missing remotely
+    assert "assets/sub/c.bin" in keys  # size differs
+    assert "assets/一.svg" in keys  # local newer than remote
+    assert "assets/a.woff2" not in keys  # unchanged -> skipped
+    assert "assets/README.md" not in keys  # README always skipped
     assert all(cc == "public, immutable" for _, _, cc, _ in calls)
     assert all(dry is False for _, _, _, dry in calls)
+
+
+def test_sync_directory_same_size_newer_local_is_reuploaded(tmp_path, monkeypatch):
+    # The size-only regression: a same-size content edit must still upload via
+    # the mtime signal, or the CDN would serve stale content.
+    local_dir = tmp_path / "d"
+    local_dir.mkdir()
+    target = local_dir / "x.json"
+    target.write_bytes(b"exact-8")  # 7 bytes
+    calls, fake_upload = _record_uploads()
+    monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
+    monkeypatch.setattr(
+        _cdn_s3,
+        "list_remote_objects",
+        lambda prefix: {"d/x.json": RemoteObject(7, 0.0)},  # same size, ancient remote
+    )
+
+    sync_directory(local_dir, "d", "immutable", dry_run=False)
+
+    assert [key for _, key, _, _ in calls] == ["d/x.json"]
 
 
 def test_sync_directory_dry_run_does_nothing_offline(tmp_path, monkeypatch):
@@ -231,14 +285,30 @@ def test_sync_directory_dry_run_does_nothing_offline(tmp_path, monkeypatch):
     calls, fake_upload = _record_uploads()
     monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
 
-    def fail_list(prefix: str) -> dict[str, int]:
+    def fail_list(prefix: str) -> dict[str, RemoteObject]:
         raise AssertionError("dry-run must not list remote objects")
 
-    monkeypatch.setattr(_cdn_s3, "list_remote_sizes", fail_list)
+    monkeypatch.setattr(_cdn_s3, "list_remote_objects", fail_list)
 
-    sync_directory(local_dir, "fonts", "public, immutable", dry_run=True)
+    sync_directory(local_dir, "assets", "public, immutable", dry_run=True)
 
     assert calls == []
+
+
+def test_sync_directory_cjk_key_round_trips(tmp_path, monkeypatch):
+    # CJK filenames (kanji 一.svg) must map to unchanged S3 keys; this is the
+    # boto3-path equivalent of the _UNSAFE_KEY_CHARS guard that the aws-CLI
+    # path needs.
+    local_dir = tmp_path / "kanji_animations"
+    local_dir.mkdir()
+    (local_dir / "一.svg").write_bytes(b"<svg/>")
+    calls, fake_upload = _record_uploads()
+    monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
+    monkeypatch.setattr(_cdn_s3, "list_remote_objects", lambda prefix: {})
+
+    sync_directory(local_dir, "kanji_animations", "immutable", dry_run=False)
+
+    assert [key for _, key, _, _ in calls] == ["kanji_animations/一.svg"]
 
 
 def test_sync_directory_uses_normalized_prefix_key(tmp_path, monkeypatch):
@@ -248,7 +318,7 @@ def test_sync_directory_uses_normalized_prefix_key(tmp_path, monkeypatch):
     (local_dir / "x.woff2").write_bytes(b"data")
     calls, fake_upload = _record_uploads()
     monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
-    monkeypatch.setattr(_cdn_s3, "list_remote_sizes", lambda prefix: {})
+    monkeypatch.setattr(_cdn_s3, "list_remote_objects", lambda prefix: {})
 
     sync_directory(local_dir, "fonts/", "immutable", dry_run=False)
 

--- a/scripts/tests/test_cdn_s3.py
+++ b/scripts/tests/test_cdn_s3.py
@@ -1,0 +1,255 @@
+"""Unit tests for the boto3 upload path in ``_cdn_s3`` (T3 Storage fix).
+
+T3 Storage drops single-PUT bodies larger than ~24KB; the aws CLI only
+auto-multiparts above 8MB, so the 24KB–8MB band (fonts, audio, JSON) failed.
+These tests pin the behaviour added to replace it: the multipart
+``TransferConfig`` threshold, the content-type resolver, the per-file upload
+metadata, and the directory sync diff that avoids re-uploading unchanged
+static objects.
+
+boto3 is an external system, so the S3 client and the network-touching
+helpers are monkeypatched. The decision logic (which files to upload) is
+exercised black-box against a fake remote size map.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import _cdn_s3
+from _cdn_s3 import (
+    MULTIPART_THRESHOLD_BYTES,
+    _TRANSFER_CONFIG,
+    content_type_for,
+    list_remote_sizes,
+    sync_directory,
+    upload_file,
+)
+
+
+class _FakeUploadClient:
+    """Records boto3 ``upload_file`` calls without touching the network."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def upload_file(self, **kwargs: object) -> None:
+        self.calls.append(kwargs)
+
+
+class _FakePaginator:
+    def __init__(self, pages: list[dict[str, object]]) -> None:
+        self._pages = pages
+
+    def paginate(self, **_kwargs: object) -> object:
+        return iter(self._pages)
+
+
+class _FakeListClient:
+    """Yields canned list-objects-v2 pages for ``list_remote_sizes``."""
+
+    def __init__(self, pages: list[dict[str, object]]) -> None:
+        self._pages = pages
+
+    def get_paginator(self, _name: str) -> _FakePaginator:
+        return _FakePaginator(self._pages)
+
+
+def _record_uploads() -> tuple[list[tuple[Path, str, str, bool]], object]:
+    """Return (calls, fake_upload_file) capturing each forwarded upload."""
+    calls: list[tuple[Path, str, str, bool]] = []
+
+    def fake(local_path: Path, key: str, cache_control: str, dry_run: bool) -> None:
+        calls.append((local_path, key, cache_control, dry_run))
+
+    return calls, fake
+
+
+def _build_sync_dir(root: Path) -> Path:
+    """A sample ``fonts/`` dir: two files, a README, and a nested file."""
+    d = root / "fonts"
+    d.mkdir()
+    (d / "a.woff2").write_bytes(b"AAAA")  # 4 bytes
+    (d / "b.json").write_bytes(b"BBBBBBBB")  # 8 bytes
+    (d / "README.md").write_text("readme")
+    nested = d / "sub"
+    nested.mkdir()
+    (nested / "c.bin").write_bytes(b"CC")  # 2 bytes
+    return d
+
+
+# ---------------------------------------------------------------------------
+# TransferConfig threshold — the actual fix parameter
+# ---------------------------------------------------------------------------
+
+
+def test_multipart_threshold_forces_multipart_under_cli_default():
+    # The aws CLI's auto-multipart kicks in at 8MB; we must force it down to
+    # 16KB so T3's ~24KB single-PUT limit never applies. A 2MB font (the
+    # failing case) is now well above the threshold → multipart.
+    assert MULTIPART_THRESHOLD_BYTES == 16 * 1024
+    assert _TRANSFER_CONFIG.multipart_threshold == 16 * 1024
+    assert _TRANSFER_CONFIG.multipart_chunksize == 16 * 1024
+    assert 2 * 1024 * 1024 > MULTIPART_THRESHOLD_BYTES
+
+
+# ---------------------------------------------------------------------------
+# content_type_for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        ("noto-sans-jp-400.woff2", "font/woff2"),
+        ("cormorant.woff", "font/woff"),
+        ("grammar.json", "application/json"),
+        # Override lookup is case-insensitive — real extensions vary in case.
+        ("UPPER.WOFF2", "font/woff2"),
+    ],
+)
+def test_content_type_override(filename: str, expected: str):
+    assert content_type_for(Path(filename)) == expected
+
+
+def test_content_type_unknown_falls_back_to_octet_stream():
+    # mimetypes cannot guess .onnx → default binary type.
+    assert content_type_for(Path("model.onnx")) == "application/octet-stream"
+
+
+def test_content_type_cjk_filename_resolves():
+    # Kanji SVGs use the kanji as the filename (一.svg); suffix lookup must
+    # not be confused by the CJK base name.
+    assert content_type_for(Path("一.svg")) == "image/svg+xml"
+
+
+# ---------------------------------------------------------------------------
+# upload_file
+# ---------------------------------------------------------------------------
+
+
+def test_upload_file_passes_metadata_and_transfer_config(tmp_path, monkeypatch):
+    local = tmp_path / "noto.woff2"
+    local.write_bytes(b"x" * 100)
+    fake = _FakeUploadClient()
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: fake)
+
+    upload_file(
+        local, "fonts/noto.woff2", "public, max-age=1, immutable", dry_run=False
+    )
+
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["Bucket"] == _cdn_s3.S3_BUCKET
+    assert call["Key"] == "fonts/noto.woff2"
+    assert call["Filename"] == str(local)
+    assert call["ExtraArgs"] == {
+        "CacheControl": "public, max-age=1, immutable",
+        "ContentType": "font/woff2",
+    }
+    assert call["Config"] is _TRANSFER_CONFIG
+
+
+def test_upload_file_dry_run_skips_client(tmp_path, monkeypatch, capsys):
+    local = tmp_path / "index.json"
+    local.write_text("{}")
+    fake = _FakeUploadClient()
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: fake)
+
+    upload_file(local, "grammar/grammar.json", "no-cache", dry_run=True)
+
+    assert fake.calls == []
+    out = capsys.readouterr().out
+    assert "[DRY-RUN]" in out
+    assert "grammar/grammar.json" in out
+    assert "application/json" in out
+    assert "no-cache" in out
+
+
+# ---------------------------------------------------------------------------
+# list_remote_sizes
+# ---------------------------------------------------------------------------
+
+
+def test_list_remote_sizes_paginates_and_normalizes_prefix(monkeypatch):
+    pages = [
+        {
+            "Contents": [
+                {"Key": "fonts/a.woff2", "Size": 4},
+                {"Key": "fonts/b.json", "Size": 8},
+            ]
+        },
+        {"Contents": [{"Key": "fonts/sub/c.bin", "Size": 2}]},
+        {},  # empty trailing page
+    ]
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: _FakeListClient(pages))
+
+    sizes = list_remote_sizes("fonts")  # no trailing slash → normalized inside
+
+    assert sizes == {
+        "fonts/a.woff2": 4,
+        "fonts/b.json": 8,
+        "fonts/sub/c.bin": 2,
+    }
+
+
+# ---------------------------------------------------------------------------
+# sync_directory — diff decision logic
+# ---------------------------------------------------------------------------
+
+
+def test_sync_directory_uploads_new_and_changed_skips_unchanged(tmp_path, monkeypatch):
+    local_dir = _build_sync_dir(tmp_path)
+    calls, fake_upload = _record_uploads()
+    monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
+    # a.woff2 matches size (4) → unchanged; c.bin differs (999 vs 2) → changed;
+    # b.json absent remotely → new.
+    monkeypatch.setattr(
+        _cdn_s3,
+        "list_remote_sizes",
+        lambda prefix: {"fonts/a.woff2": 4, "fonts/sub/c.bin": 999},
+    )
+
+    sync_directory(local_dir, "fonts", "public, immutable", dry_run=False)
+
+    keys = [key for _, key, _, _ in calls]
+    assert "fonts/b.json" in keys  # missing remotely
+    assert "fonts/sub/c.bin" in keys  # size differs
+    assert "fonts/a.woff2" not in keys  # unchanged → skipped
+    assert "fonts/README.md" not in keys  # README always skipped
+    assert all(cc == "public, immutable" for _, _, cc, _ in calls)
+    assert all(dry is False for _, _, _, dry in calls)
+
+
+def test_sync_directory_dry_run_does_nothing_offline(tmp_path, monkeypatch):
+    # The deploy orchestrator prints a per-directory header itself; in dry-run
+    # sync_directory must neither walk the (100k+) local tree nor list remote,
+    # so a dry-run preview stays instant and offline.
+    local_dir = _build_sync_dir(tmp_path)
+    calls, fake_upload = _record_uploads()
+    monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
+
+    def fail_list(prefix: str) -> dict[str, int]:
+        raise AssertionError("dry-run must not list remote objects")
+
+    monkeypatch.setattr(_cdn_s3, "list_remote_sizes", fail_list)
+
+    sync_directory(local_dir, "fonts", "public, immutable", dry_run=True)
+
+    assert calls == []
+
+
+def test_sync_directory_uses_normalized_prefix_key(tmp_path, monkeypatch):
+    # A prefix with a trailing slash must not double-slash the key.
+    local_dir = tmp_path / "d"
+    local_dir.mkdir()
+    (local_dir / "x.woff2").write_bytes(b"data")
+    calls, fake_upload = _record_uploads()
+    monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
+    monkeypatch.setattr(_cdn_s3, "list_remote_sizes", lambda prefix: {})
+
+    sync_directory(local_dir, "fonts/", "immutable", dry_run=False)
+
+    assert [key for _, key, _, _ in calls] == ["fonts/x.woff2"]

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -3,6 +3,34 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "boto3"
+version = "1.43.40"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/43/38cdaf9c7bb50f0922ef87e6b6696c6aa589d978e4311a8287537e84ecf7/boto3-1.43.40.tar.gz", hash = "sha256:a7108b9ce25b8f92d1ce96b9e35090794d5c58b219ff2f6a7a65c8986a4ed6f4", size = 112655, upload-time = "2026-07-03T00:28:26.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/3b/2abcc7f47e955a8cb45a6378ec69cd8ed2dcb3d14ceb67717dea020a794a/boto3-1.43.40-py3-none-any.whl", hash = "sha256:5fa80de4b4b7bab383dd8c563e235d51fcc7df4502662af56f0a2472c3c15651", size = 140029, upload-time = "2026-07-03T00:28:25.028Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.40"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/50/269986277f852cc83029bccbdcdc0b343a685cfd570599e58029792808d8/botocore-1.43.40.tar.gz", hash = "sha256:2085a4314cfd2c8bc1d08ab8039f76c92e99278db0d2a0e2437010526d5d5d70", size = 15639899, upload-time = "2026-07-03T00:28:16.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/8c/5f7e73fd66b28f0705bc55d7060d41ef72328b656b86ca53e75765b3ba2c/botocore-1.43.40-py3-none-any.whl", hash = "sha256:0bc9d352267c9e48415c5d7bb61ff05c3f193eac2fc7e69cfd229a05fbab67d6", size = 15323870, upload-time = "2026-07-03T00:28:12.56Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -33,15 +61,28 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "origa-scripts"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "pytest" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", specifier = ">=8.0" }]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.35" },
+    { name = "pytest", specifier = ">=8.0" },
+]
 
 [[package]]
 name = "packaging"
@@ -86,6 +127,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -149,4 +223,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
## Problem
`scripts/deploy_cdn.py` used `aws s3 sync`/`cp`, which send a single PUT per object. T3 Storage (`t3.storageapi.dev`) drops PUT connections for request bodies larger than ~24KB, so files in the 24KB-8MB band could not be deployed. The AWS CLI only switches to multipart above its 8MB default threshold, leaving that band stranded:
- Noto JP fonts (1.5-2MB) — failed
- Cormorant (65KB) — failed
- DM Mono (~15KB) — succeeded (under the limit)

Self-hosted web fonts therefore could not be deployed through the script.

## Root cause
Single-PUT body-size limit on the T3 endpoint, combined with the AWS CLI's high (8MB) auto-multipart threshold.

## Fix
- New boto3 S3 upload transport in `_cdn_s3.py` (`upload_file`, `sync_directory`, `list_remote_sizes`, `content_type_for`) with `TransferConfig(multipart_threshold=16KB, multipart_chunksize=16KB, max_concurrency=1)` — every body above 16KB is uploaded as multipart parts. Verified: all 8 font files deployed successfully via this path.
- `deploy_cdn.py` routes all three uploads (versioned files, directory sync, manifest) through boto3 instead of the AWS CLI.
- `fonts/` added to `SYNC_DIRS` and the immutable Cache-Control policy so fonts are actually deployed (they are content-addressed — the file hash is in the name — so immutable cannot poison the edge cache).
- `CacheControl` + `ContentType` carried via `ExtraArgs` (woff2 -> `font/woff2`, json -> `application/json`).
- `refresh_cache_control.py` is unaffected: it still uses the AWS CLI for list/head/copy, none of which upload a request body.

## Verification
- `ruff check` + `ruff format` clean on the changed files.
- `pytest`: 296 passed, including new `test_cdn_s3.py` (TransferConfig threshold, content-type resolver, upload metadata, sync diff logic) and an updated `test_cdn_cache.py` pinning `fonts` immutable.
- `uv run scripts/deploy_cdn.py --dry-run` shows `fonts/  [public, max-age=31536000, immutable]` and the boto3 upload path for versioned files; runs offline and instantly (sync dry-run early-returns; the orchestrator prints the per-directory header).

## Out of scope
- `download_remote_manifest` still uses the AWS CLI (GET, unaffected by the PUT limit).
- Pre-existing `ruff` F541/F841 findings in unrelated scripts are not touched.
