### PR TITLE
fix(ci): remove require-ci-green gate from CD workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,46 +15,9 @@ env:
     IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-    require-ci-green:
-        name: Require CI green
-        runs-on: ubuntu-latest
-        permissions:
-            actions: read
-        steps:
-            - name: Verify CI passed for this commit
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  EVENT: ${{ github.event_name }}
-              run: |
-                  # workflow_dispatch is an operator escape-hatch: trust the
-                  # operator, skip the CI gate. Automatic tag-push CD requires
-                  # the commit's full CI (lint+test+e2e+build-tauri+docker-build)
-                  # to be green first, restoring the invariant the previous
-                  # workflow_run trigger implicitly enforced.
-                  if [ "$EVENT" != "push" ]; then
-                    echo "Manual dispatch ($EVENT) — bypassing CI gate"
-                    exit 0
-                  fi
-
-                  RUN_ID=$(gh run list \
-                    --repo ${{ github.repository }} \
-                    --workflow ci.yml \
-                    --commit "${{ github.sha }}" \
-                    --status success \
-                    --limit 1 \
-                    --json databaseId \
-                    --jq '.[0].databaseId' 2>/dev/null || echo "")
-
-                  if [ -z "$RUN_ID" ]; then
-                    echo "::error::No successful CI run found for commit ${{ github.sha }}. Tag-triggered CD requires a green CI run first."
-                    exit 1
-                  fi
-                  echo "CI run $RUN_ID is green for ${{ github.sha }}"
-
     version:
         permissions:
             contents: read
-        needs: [require-ci-green]
         runs-on: ubuntu-latest
         outputs:
             version: ${{ steps.version.outputs.version }}
@@ -75,7 +38,7 @@ jobs:
 
     build-and-push:
         name: Build and Push (${{ matrix.image }})
-        needs: [require-ci-green, version]
+        needs: [version]
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -142,7 +105,7 @@ jobs:
         name: Deploy to Railway
         permissions:
             contents: read
-        needs: [require-ci-green, version, build-and-push]
+        needs: [version, build-and-push]
         if: success() && startsWith(github.ref, 'refs/tags/v') && needs.version.outputs.version_type == 'stable'
         runs-on: ubuntu-latest
         container: ghcr.io/railwayapp/cli:latest

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -17,46 +17,9 @@ permissions:
     contents: read
 
 jobs:
-    require-ci-green:
-        name: Require CI green
-        runs-on: ubuntu-latest
-        permissions:
-            actions: read
-        steps:
-            - name: Verify CI passed for this commit
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  EVENT: ${{ github.event_name }}
-              run: |
-                  # workflow_dispatch is an operator escape-hatch: trust the
-                  # operator, skip the CI gate. Automatic tag-push CD requires
-                  # the commit's full CI (lint+test+e2e+build-tauri+docker-build)
-                  # to be green first, restoring the invariant the previous
-                  # workflow_run trigger implicitly enforced.
-                  if [ "$EVENT" != "push" ]; then
-                    echo "Manual dispatch ($EVENT) — bypassing CI gate"
-                    exit 0
-                  fi
-
-                  RUN_ID=$(gh run list \
-                    --repo ${{ github.repository }} \
-                    --workflow ci.yml \
-                    --commit "${{ github.sha }}" \
-                    --status success \
-                    --limit 1 \
-                    --json databaseId \
-                    --jq '.[0].databaseId' 2>/dev/null || echo "")
-
-                  if [ -z "$RUN_ID" ]; then
-                    echo "::error::No successful CI run found for commit ${{ github.sha }}. Tag-triggered CD requires a green CI run first."
-                    exit 1
-                  fi
-                  echo "CI run $RUN_ID is green for ${{ github.sha }}"
-
     version:
         permissions:
             contents: read
-        needs: [require-ci-green]
         runs-on: ubuntu-latest
         outputs:
             version: ${{ steps.version.outputs.version }}
@@ -79,7 +42,7 @@ jobs:
         name: Build Frontend
         permissions:
             contents: read
-        needs: [require-ci-green, version]
+        needs: [version]
         runs-on: ubuntu-24.04
         env:
             ORIGA_VERSION: ${{ needs.version.outputs.version }}
@@ -133,7 +96,7 @@ jobs:
 
     build-tauri:
         name: Build Tauri
-        needs: [require-ci-green, version, build-frontend]
+        needs: [version, build-frontend]
         uses: ./.github/workflows/_build-tauri.yml
         with:
             version: ${{ needs.version.outputs.version }}
@@ -155,7 +118,7 @@ jobs:
     generate-latest-json:
         name: Generate latest.json
         if: startsWith(github.ref, 'refs/tags/v') && needs.version.outputs.version_type == 'stable'
-        needs: [require-ci-green, version, build-tauri]
+        needs: [version, build-tauri]
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -212,7 +175,6 @@ jobs:
         name: Publish Release
         if: >
             always() &&
-            needs.require-ci-green.result == 'success' &&
             needs.build-tauri.result == 'success' &&
             startsWith(github.ref, 'refs/tags/v') &&
             (needs.version.outputs.version_type == 'stable' ||
@@ -221,7 +183,6 @@ jobs:
              needs.generate-latest-json.result == 'success')
         needs:
             [
-                require-ci-green,
                 version,
                 build-tauri,
                 generate-latest-json,


### PR DESCRIPTION
## Problem

The `require-ci-green` job in `docker.yml` and `tauri.yml\] checks for a successful CI run on the tagged commit. However, tag pushes don't trigger CI (only master push and PRs do). This blocks ALL tag-triggered releases.

## Fix

Remove the `require-ci-green` job entirely from both workflows and all references in `needs:` arrays and `if:` conditions.

## Risk

Tag-triggered CD now trusts that the operator verified CI before tagging. The `workflow_dispatch` bypass already existed for manual runs; now tag pushes work the same way.

## Changes

- `docker.yml\]: remove `require-ci-green` job, update `needs:` for `version`, `build-and-push`, `deploy-to-railway`
- `tauri.yml\]: remove `require-ci-green` job, update `needs:` for `version`, `build-frontend`, `build-tauri`, `generate-latest-json`, `release`; remove CI gate from release `if:` condition