### PR TITLE
fix(ui): halve top safe-area padding, fix lesson card width, lock horizontal scroll (#1 #2 #7)

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -99,6 +99,7 @@ body {
     margin: 0;
     min-height: 100vh;
     min-height: 100dvh;
+    overflow-x: hidden;
     -webkit-user-select: none;
     user-select: none;
     -webkit-touch-callout: none;
@@ -128,7 +129,7 @@ textarea,
 html,
 body {
     overscroll-behavior: none;
-    touch-action: manipulation;
+    touch-action: pan-y;
     -webkit-tap-highlight-color: transparent;
 }
 
@@ -1542,6 +1543,7 @@ input[type="submit"],
     z-index: 40;
     display: flex;
     flex-direction: column;
+    padding-top: calc(env(safe-area-inset-top, 0px) / 2);
 }
 
 .sidebar-logo {

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -45,7 +45,7 @@ use leptos::prelude::*;
 pub fn Lesson() -> impl IntoView {
     view! {
         <div class="flex-1 flex flex-col py-4" data-testid="lesson-page">
-            <div class="max-w-6xl mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
+            <div class="max-w-4xl mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
                 <LessonContent />
             </div>
         </div>

--- a/origa_ui/src/routes.rs
+++ b/origa_ui/src/routes.rs
@@ -280,9 +280,9 @@ pub fn AppRoutes() -> impl IntoView {
     // (e.g., lesson card centering). See ADR-027; height + safe-area stay on the shell.
     let main_class = move || {
         if sidebar_visible.get() {
-            "paper-texture main-with-sidebar pt-safe-t pb-20 lg:pb-0".to_string()
+            "paper-texture main-with-sidebar pt-safe-t-half pb-20 lg:pb-0".to_string()
         } else {
-            "paper-texture pt-safe-t min-h-[100dvh] flex flex-col".to_string()
+            "paper-texture pt-safe-t-half min-h-[100dvh] flex flex-col".to_string()
         }
     };
 

--- a/origa_ui/tailwind.config.js
+++ b/origa_ui/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
 		extend: {
 			padding: {
 				"safe-t": "env(safe-area-inset-top, 0px)",
+				"safe-t-half": "calc(env(safe-area-inset-top, 0px) / 2)",
 				"safe-b": "env(safe-area-inset-bottom, 0px)",
 				"safe-l": "env(safe-area-inset-left, 0px)",
 				"safe-r": "env(safe-area-inset-right, 0px)",


### PR DESCRIPTION
Part of the rc1 feedback batch.

## Changes
- **#1 (top padding + sidebar):** Added `pt-safe-t-half` token (`calc(env(safe-area-inset-top,0px)/2)`); `<main>` uses it (type-neutral class-string swap). Added the same halved offset to `.sidebar` via CSS-only padding-top (no new class/attribute on `<aside>` → ADR-027-safe). Halves the oversized top gap on tablets and restores the sidebar top inset.
- **#2 (lesson card width):** Lesson card column `max-w-6xl` → `max-w-4xl` so the card keeps a stable width across quiz/writing/text card types.
- **#7 (horizontal scroll/rubber-band on touch):** `touch-action: manipulation` → `pan-y` on `html, body` (blocks horizontal pan gestures at the gesture level) + `overflow-x: hidden` on body. Drawing canvases already use `touch-action: none` so kanji/writing practice is unaffected. `100vw` usages verified safe (bounded `max-width: min(...)`).

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (0 warnings; type-checks the bin crate)
- `cargo check --bin origa_ui_bin` ✅
- `cargo test -p origa_ui --lib` ✅ (241 passed)
- Code review (code-quality-reviewer): **approve** (0 High, 1 Common advisory)

## Notes
- `overscroll-behavior: none` was already present; the actual culprit was `touch-action: manipulation` allowing horizontal pan.
- `max-w-6xl` removed everywhere (single source in `lesson/mod.rs`).
- Pre-existing Windows-only note: the `origa_ui_bin` crate does not fully LINK on Windows (`link.exe LNK1140`, over-monomorphization debug-info per ADR-027) — reproduces on clean master and is unrelated to these type-neutral changes. CI builds the bin on Linux.
- Advisory (non-blocking): halved safe-area inset is neutral in the dominant windowed-desktop runtime (inset=0); on notched devices in fullscreen a device smoke is recommended before RC1.