### PR TITLE
fix(ui): collapse kanji answer details by default (#3)

### DIFF
--- a/origa_ui/src/pages/lesson/kanji_card_details.rs
+++ b/origa_ui/src/pages/lesson/kanji_card_details.rs
@@ -20,7 +20,6 @@ pub fn KanjiCardDetails(
     name: String,
     radicals: Option<Vec<RadicalDisplay>>,
     example_words: Option<Vec<(String, String)>>,
-    #[prop(into)] show_details: Signal<bool>,
     on_readings: Option<Vec<String>>,
     kun_readings: Option<Vec<String>>,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
@@ -34,25 +33,48 @@ pub fn KanjiCardDetails(
     let on_readings_stored = StoredValue::new(on_readings);
     let kun_readings_stored = StoredValue::new(kun_readings);
 
+    let details_expanded = RwSignal::new(false);
+    let more_text =
+        Signal::derive(move || i18n.get_keys().common().more_details().inner().to_string());
+    let collapse_text =
+        Signal::derive(move || i18n.get_keys().common().collapse().inner().to_string());
+
     view! {
-        <Show when=move || show_details.get()>
-            <div class="my-6 space-y-4 max-w-max mx-auto">
-                <ReadingGroup label=Signal::derive(move || i18n.get_keys().lesson().on_yomi().inner().to_string()) readings=on_readings_stored />
-                <ReadingGroup label=Signal::derive(move || i18n.get_keys().lesson().kun_yomi().inner().to_string()) readings=kun_readings_stored />
+        <div class="my-6 space-y-4 max-w-max mx-auto">
+            <ReadingGroup
+                label=Signal::derive(move || i18n.get_keys().lesson().on_yomi().inner().to_string())
+                readings=on_readings_stored
+            />
+            <ReadingGroup
+                label=Signal::derive(move || i18n.get_keys().lesson().kun_yomi().inner().to_string())
+                readings=kun_readings_stored
+            />
 
-                <div class="flex gap-4 items-start text-left">
-                    <div class="w-16 shrink-0">
-                        <Text size=TextSize::Default variant=TypographyVariant::Muted>
-                            {t!(i18n, lesson.meaning)}
-                        </Text>
-                    </div>
-                    <div class="flex px-2 py-1">
-                        <Text size=TextSize::Large class="text-primary">
-                            {name_stored.get_value()}
-                        </Text>
-                    </div>
+            <div class="flex gap-4 items-start text-left">
+                <div class="w-16 shrink-0">
+                    <Text size=TextSize::Default variant=TypographyVariant::Muted>
+                        {t!(i18n, lesson.meaning)}
+                    </Text>
                 </div>
+                <div class="flex px-2 py-1">
+                    <Text size=TextSize::Large class="text-primary">
+                        {name_stored.get_value()}
+                    </Text>
+                </div>
+            </div>
+        </div>
 
+        <div class="mt-3">
+            <button
+                class="font-mono text-sm text-[var(--fg-muted)] cursor-pointer hover:text-[var(--fg-black)] underline underline-offset-4 decoration-[var(--border-light)]"
+                on:click=move |_| details_expanded.update(|v| *v = !*v)
+            >
+                {move || if details_expanded.get() { collapse_text.get() } else { more_text.get() }}
+            </button>
+        </div>
+
+        <Show when=move || details_expanded.get()>
+            <div class="my-6 space-y-4 max-w-max mx-auto">
                 <Show when=move || radicals_stored.get_value().is_some()>
                     <div class="flex gap-4 items-start text-left">
                         <div class="w-16 shrink-0">

--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -219,6 +219,7 @@ pub fn LessonCard(
 
     Effect::new(move |_| {
         if show_answer.get()
+            && card_type != CardType::Kanji
             && let Some(el) = content_ref.get()
         {
             let is_overflow = el.scroll_height() > el.client_height();

--- a/origa_ui/src/pages/lesson/lesson_card_answer.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_answer.rs
@@ -159,7 +159,6 @@ pub fn LessonCardAnswer(
                             name=answer.get_value()
                             radicals=radicals_stored.get_value()
                             example_words=examples_stored.get_value()
-                            show_details=is_expanded
                             on_readings=on_readings_stored.get_value()
                             kun_readings=kun_readings_stored.get_value()
                             known_kanji=known_kanji

--- a/origa_ui/src/pages/lesson/writing_card.rs
+++ b/origa_ui/src/pages/lesson/writing_card.rs
@@ -134,7 +134,6 @@ pub fn WritingCard(
         };
 
     let show_details = RwSignal::new(false);
-    let is_expanded = RwSignal::new(true);
 
     let symbol_sv = StoredValue::new(symbol_char);
     let display_text_sv = StoredValue::new(display_text);
@@ -182,7 +181,6 @@ pub fn WritingCard(
                         name=display_text_sv.get_value()
                         radicals=radicals_sv.get_value()
                         example_words=examples_sv.get_value()
-                        show_details=is_expanded
                         on_readings=on_readings_sv.get_value()
                         kun_readings=kun_readings_sv.get_value()
                         known_kanji=known_kanji


### PR DESCRIPTION
Part of the rc1 feedback batch.

## Problem
Kanji answer cards rendered every section at once (on/kun readings, meaning, radicals, stroke order, example vocabulary) — too content-dense. User wants all details collapsed by default EXCEPT the main meaning and the readings, mirroring the grammar answer card.

## Changes
- `KanjiCardDetails` (`kanji_card_details.rs`): dropped the `show_details` prop. on/kun readings and the main meaning now render unconditionally; radicals, the writing/stroke section, and example vocabulary collapse behind a local `RwSignal(false)` toggled by a "More details"/"Collapse" button (same visual pattern + i18n keys as `grammar_details_expand.rs`).
- Removed the now-unused `show_details` prop from both call sites (`lesson_card_answer.rs`, `writing_card.rs`) and the dead `is_expanded` in `writing_card.rs` (it was used only for that prop). The writing card's own `show_details` (canvas-vs-result) flow is untouched.
- `lesson_card.rs`: the `needs_collapse` Effect now skips kanji (`&& card_type != CardType::Kanji`) so the coarse line-clamp collapse never appears for kanji — the per-section toggle is the only collapse mechanism (no double-collapse UX).

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (0 warnings; bin type-checks → ADR-027 recursion gate)
- `cargo test -p origa_ui --lib` ✅ (241 passed)
- Code review (code-quality-reviewer): **approve** (0 High / 0 Common / 2 Low cosmetic, optional)

## Notes
- Pre-existing Windows-only: `origa_ui_bin` does not LINK on Windows (LNK1140 / ADR-027 over-monomorphization); reproduces on master, unrelated. CI builds the bin on Linux.