### PR TITLE
fix(csp): allow cdn.pyke.io for ort-rs WASM (OCR)

### DIFF
--- a/tauri/build_config.rs
+++ b/tauri/build_config.rs
@@ -31,15 +31,15 @@ pub(crate) const DEFAULT_LANDING: &str = "https://origa.uwuwu.net";
 /// Build the Content-Security-Policy directive by substituting env-controlled
 /// hosts into the static template. The CDN host is referenced from `font-src`
 /// because all fonts are self-hosted there (ADR-028). Other third-party hosts
-/// (huggingface, OAuth providers) remain hardcoded — they are not
-/// environment-dependent.
+/// (huggingface, cdn.pyke.io for ort-rs WASM, OAuth providers) remain
+/// hardcoded — they are not environment-dependent.
 ///
 /// The literal is kept on a single line because `rustfmt` does not reflow
 /// string-literal contents, and byte-equality with `tauri.conf.json` must hold
 /// (verified by `build_csp_with_production_defaults_matches_committed_tauri_conf`).
 pub(crate) fn build_csp(cdn: &str, landing: &str, trailbase: &str) -> String {
     format!(
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co https://cdn.pyke.io; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
     )
 }
 

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -21,7 +21,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://cdn.pyke.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
         }
     },
     "bundle": {

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -97,6 +97,7 @@ fn build_csp_substitutes_staging_hosts() {
 
     // Other third-party hosts must survive any host substitution.
     assert!(csp.contains("https://huggingface.co"));
+    assert!(csp.contains("https://cdn.pyke.io"));
     assert!(csp.contains("https://accounts.google.com"));
     assert!(csp.contains("https://oauth.yandex.ru"));
 


### PR DESCRIPTION
## Problem

ONNX Runtime Web (ort-rs) loads WASM files from `cdn.pyke.io`. The Tauri CSP blocked both:

- **connect-src** — WASM binary fetch
- **script-src** — mjs/js module loading

## Fix

Added `https://cdn.pyke.io` to both `connect-src` and `script-src` CSP directives in:

- `tauri/build_config.rs` — CSP template (single source of truth for env-parameterized builds)
- `tauri/tauri.conf.json` — committed CSP (production defaults, byte-matched by drift-detection test)
- `tauri/tests/build_config.rs` — added `cdn.pyke.io` assertion to staging substitution test

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p origa-app --all-targets -- -D warnings` — clean
- `cargo test -p origa-app --test build_config` — **14/14 passed** (including byte-match drift detection)