### PR TITLE
fix(ui): wider lesson card + 3-column quiz options on wide viewports

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -317,6 +317,7 @@ scripts/subset_fonts.py` (подробности в `cdn/README.md`).
   - `card-layout-small`: max-width 480px
   - `card-layout-medium`: max-width 768px
   - `card-layout-large`: max-width 1024px
+  - `card-layout-lesson`: max-width 1280px — интерактивные карточки вопроса/ответа в `/lesson`. Шире `card-layout-large`, потому что карточка заполняет viewport по вертикали (ADR-031 stable min-h через svh) и при прежнем `max-w-4xl` (896px) на десктопе оставляла слишком много пустого места по краям. Quiz options внутри используют 3-колоночный grid на ≥768px (`md:grid-cols-3`).
   - `card-layout-adaptive`: width 100%
 
 ### Responsive Breakpoints

--- a/origa_ui/src/pages/grammar/grammar_practice_session.rs
+++ b/origa_ui/src/pages/grammar/grammar_practice_session.rs
@@ -355,7 +355,7 @@ pub fn GrammarPracticeSession(
                     }}
                 </div>
 
-                <div class="grid grid-cols-2 gap-2">
+                <div class="grid grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
                     <button
                         class=move || option_class(0)
                         data-testid="grammar-practice-option-0"

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -52,7 +52,7 @@ pub(in crate::pages::lesson) const LESSON_CARD_CLASS: &str =
 pub fn Lesson() -> impl IntoView {
     view! {
         <div class="flex-1 flex flex-col py-4" data-testid="lesson-page">
-            <div class="max-w-4xl mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
+            <div class="max-w-7xl mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
                 <LessonContent />
             </div>
         </div>

--- a/origa_ui/src/pages/lesson/phrase_card.rs
+++ b/origa_ui/src/pages/lesson/phrase_card.rs
@@ -77,7 +77,7 @@ pub fn PhraseCardView(
                     </Text>
                 </div>
 
-                <div class="grid grid-cols-2 gap-2 sm:gap-3">
+                <div class="grid grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
                     {move || {
                         options_stored
                             .get_value()

--- a/origa_ui/src/pages/lesson/quiz_options.rs
+++ b/origa_ui/src/pages/lesson/quiz_options.rs
@@ -20,7 +20,7 @@ pub fn QuizOptions(
     let i18n = use_i18n();
 
     view! {
-        <div class="grid grid-cols-2 gap-2 sm:gap-3">
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
             {move || {
                 options
                     .iter()

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -30,7 +30,7 @@ pub fn QuizOptionsMulti(
         .collect();
 
     view! {
-        <div class="grid grid-cols-2 gap-2 sm:gap-3">
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
             {options
                 .iter()
                 .enumerate()


### PR DESCRIPTION
## Problem

Follow-up to PR #247 (ADR-031 stable min-h). After merge, user reported two remaining issues on wide/landscape viewports:

1. **Narrow card on desktop/landscape** — `max-w-4xl` (896px) wrapper left too much empty space around the centered card on wide screens. Confirmed: "много места по краям остается".
2. **2-column quiz options did not fit on landscape**, especially KanjiReadingQuiz with 4-6 options stacked vertically.

User clarifications:
1. max-w → `max-w-7xl` (1280px), not "remove entirely" (kept for readability of long text).
2. 3 columns → for **all quiz cards** (including grammar practice).
3. Switching logic → by **viewport width** (Tailwind breakpoint, not orientation).

## Changes (6 total)

### 1. Wider card wrapper
`origa_ui/src/pages/lesson/mod.rs:55` — `max-w-4xl` (896px) -> `max-w-7xl` (1280px). On viewports <1280px the cap is not reached (full width); on >=1280px the card is centered at 1280px. Cap kept (instead of removing) for readability of long grammar explanations.

### 2. 3-column quiz options (4 grid files)
`grid-cols-2 gap-2 sm:gap-3` -> `grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3` in 4 files:

- `origa_ui/src/pages/lesson/quiz_options.rs:23` (single-select)
- `origa_ui/src/pages/lesson/quiz_options_multi.rs:33` (multi-select, KanjiReadingQuiz)
- `origa_ui/src/pages/lesson/phrase_card.rs:80` (phrase quiz)
- `origa_ui/src/pages/grammar/grammar_practice_session.rs:358` (grammar practice, also got `sm:gap-3` for consistency with /lesson)

On <768px (mobile) — 2 columns (unchanged). On >=768px (tablet landscape, desktop) — 3 columns.

**Breakpoint math** (why `md:` 768px, not `sm:` 640px):
- /lesson at 768px: 768 - px-4[32] - lesson-content p-6[48] - Card p-6[48] = 640px; (640 - gap-3[24]) / 3 = ~205px per option.
- /grammar at 768px: 768 - .grammar-detail-container[32] = 736px; (736 - sm:gap-3[24]) / 3 = ~237px per option.
- Both >=200px with margin. At 640px (`sm:`), /lesson would give ~162px — too tight.

### 3. DESIGN.md token
Added `card-layout-lesson: max-width 1280px` to Layout and Spacing -> Containers. Wider than `card-layout-large` (1024px) because the lesson card fills the viewport vertically (ADR-031) and at the previous `max-w-4xl` (896px) left too much empty space on the sides of the desktop.

## Intentionally NOT changed (4 `grid grid-cols-2` sites)

- `yesno_card_view.rs:226` — Yes/No (2 options). 3 columns = empty orphan cell.
- `rating_buttons.rs:14` — FSRS rating Again/Good (2 options).
- `phrase_rating_buttons.rs:16` — did-not-understand/understood (2 options).
- `onboarding/scoring_step.rs:286` — radio for scoring level, not a quiz.

`kanji_card_details.rs:132` already uses `sm:grid-cols-3`, untouched.

## Tradeoffs

- **4-option quizzes on 3 columns produce 3+1 layout** (orphan button bottom-left). Accepted per user directive "for all quiz cards" — the win for 6-option KanjiReadingQuiz (3+3 instead of 2+2+2) outweighs the orphan.
- **No durable E2E guard on column count** — CSS class-string tweaks are flaky for column/width assertions, and the user explicitly asked not to test sizes in E2E. Regression protection is via code review.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --exclude origa_landing` (CI command from `ci.yml:164`) — all suites green: 1493 lib + 241 origa_ui + 16 tauri + 6 build_config + others, 0 failed. bin crate `origa_ui_bin` compiles (type-neutral class-string changes only, recursion_limit landmine ADR-027 section B3 not triggered).
- `npx tsc --noEmit` (end2end) — clean

### Not verified (and why)

- Playwright E2E suite not executed (requires TrailBase + CDN infrastructure). TypeScript typecheck covers static errors. Existing `lesson.spec.ts` uses only data-testid selectors + height-chain guard, does not assert columns/width, so expected to pass.
- Visual smoke in Tauri recommended before merge (`cargo tauri dev`, exercise quiz cards on mobile 375 / tablet 768 / desktop 1920).

## Related

- PR #247 (ADR-031 — stable min-h via svh, the predecessor this builds on).
- ADR-027 section B3 (recursion_limit landmine — class-string changes are type-neutral, safe).
