### PR TITLE
fix(ui): fixed-width lesson card + larger Japanese word heading

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -3218,7 +3218,10 @@ rt {
 .heading-h2 {
     font-family: var(--font-serif);
     font-weight: 300;
-    font-size: 1.5rem;
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    line-height: 1.2;
+    word-break: break-words;
+    letter-spacing: -0.02em;
 }
 
 .heading-h3 {

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -52,7 +52,7 @@ pub(in crate::pages::lesson) const LESSON_CARD_CLASS: &str =
 pub fn Lesson() -> impl IntoView {
     view! {
         <div class="flex-1 flex flex-col py-4" data-testid="lesson-page">
-            <div class="max-w-7xl mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
+            <div class="min-w-[1200px] max-w-[1200px] mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
                 <LessonContent />
             </div>
         </div>


### PR DESCRIPTION
## Operational tweak per user request

Quick follow-up to PR #248 (no full code review per user''s "оперативно, без излишних вызовов").

## Changes (2 files)

### 1. Fixed-width lesson card
`origa_ui/src/pages/lesson/mod.rs:55` — `max-w-7xl` (1280px) -> `min-w-[1200px] max-w-[1200px]`.

- **min-width = max-width = 1200px** (per "минимальную приравняй к максимальной"). Card is now fixed-width 1200px.
- **max reduced slightly** from 1280 to 1200 (per "чуть чуть меньше").

Note: on viewports <1200px (mobile, small tablet) this forces horizontal scroll. Intentional per user directive. If mobile UX breaks, can be gated with `lg:` breakpoint in a follow-up.

### 2. Larger Japanese word heading
`origa_ui/input.css` `.heading-h2` — `font-size: 1.5rem` (24px) -> `clamp(1.75rem, 4vw, 2.25rem)` (28-36px adaptive).

- +1-2 step for the Japanese word heading — the question text in `LessonCardQuestion` and `QuizCardView`, which is the primary value text for the user ("особенно слова").
- Added `line-height: 1.2`, `word-break: break-words`, `letter-spacing: -0.02em` matching `.heading-h1` for consistency (previously `.heading-h2` had no line-height/word-break/letter-spacing, inherited defaults).
- `.heading-h2` is used only in lesson card question/quiz views (verified via grep — other Headings use H1/H3/H4), so the change is scoped in practice.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p origa_ui --lib -- -D warnings` — clean
- Full `cargo test --workspace --exclude origa_landing` not run (operational tweak, no Rust logic changed — only class-string + CSS).
- Visual smoke in Tauri recommended before merge.

## Related

- PR #247 (ADR-031 stable min-h)
- PR #248 (wider card max-w-7xl + 3-column quiz options — this PR adjusts the max-w further)
