### PR TITLE
fix(ui): revert quiz options to 2 columns (orphan button on non-multiple-of-3)

### DIFF
--- a/origa_ui/src/pages/grammar/grammar_practice_session.rs
+++ b/origa_ui/src/pages/grammar/grammar_practice_session.rs
@@ -355,7 +355,7 @@ pub fn GrammarPracticeSession(
                     }}
                 </div>
 
-                <div class="grid grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
+                <div class="grid grid-cols-2 gap-2 sm:gap-3">
                     <button
                         class=move || option_class(0)
                         data-testid="grammar-practice-option-0"

--- a/origa_ui/src/pages/lesson/phrase_card.rs
+++ b/origa_ui/src/pages/lesson/phrase_card.rs
@@ -77,7 +77,7 @@ pub fn PhraseCardView(
                     </Text>
                 </div>
 
-                <div class="grid grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
+                <div class="grid grid-cols-2 gap-2 sm:gap-3">
                     {move || {
                         options_stored
                             .get_value()

--- a/origa_ui/src/pages/lesson/quiz_options.rs
+++ b/origa_ui/src/pages/lesson/quiz_options.rs
@@ -20,7 +20,7 @@ pub fn QuizOptions(
     let i18n = use_i18n();
 
     view! {
-        <div class="grid grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
+        <div class="grid grid-cols-2 gap-2 sm:gap-3">
             {move || {
                 options
                     .iter()

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -30,7 +30,7 @@ pub fn QuizOptionsMulti(
         .collect();
 
     view! {
-        <div class="grid grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
+        <div class="grid grid-cols-2 gap-2 sm:gap-3">
             {options
                 .iter()
                 .enumerate()


### PR DESCRIPTION
## Revert

PR #248 introduced `md:grid-cols-3` for quiz options. In practice most quizzes have 4 options (single-select QuizOptions, PhraseCardView, grammar practice) or 4-5 (KanjiReadingQuiz multi) — not multiples of 3. On 3 columns this produces a 3+1 layout with an orphan button bottom-left, which looks unbalanced.

Per user request, revert to 2 columns in all 4 quiz-grid files.

## Changes

4 files, `grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3` -> `grid-cols-2 gap-2 sm:gap-3`:

- `origa_ui/src/pages/lesson/quiz_options.rs:23`
- `origa_ui/src/pages/lesson/quiz_options_multi.rs:33`
- `origa_ui/src/pages/lesson/phrase_card.rs:80`
- `origa_ui/src/pages/grammar/grammar_practice_session.rs:358` (keeps the `sm:gap-3` consistency introduced in PR #248, which is orthogonal to column count)

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p origa_ui --lib -- -D warnings` — clean

Operational revert, no full review.
