### PR TITLE
fix(ui): card width 1200->1152, tighter KanjiReadingQuiz spacing, larger CJK-safe heading

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -3218,10 +3218,9 @@ rt {
 .heading-h2 {
     font-family: var(--font-serif);
     font-weight: 300;
-    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    font-size: clamp(2rem, 4vw, 2.5rem);
     line-height: 1.2;
     word-break: break-words;
-    letter-spacing: -0.02em;
 }
 
 .heading-h3 {

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -52,7 +52,7 @@ pub(in crate::pages::lesson) const LESSON_CARD_CLASS: &str =
 pub fn Lesson() -> impl IntoView {
     view! {
         <div class="flex-1 flex flex-col py-4" data-testid="lesson-page">
-            <div class="min-w-[1200px] max-w-[1200px] mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
+            <div class="min-w-[1152px] max-w-[1152px] mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
                 <LessonContent />
             </div>
         </div>

--- a/origa_ui/src/pages/lesson/quiz_card.rs
+++ b/origa_ui/src/pages/lesson/quiz_card.rs
@@ -208,7 +208,7 @@ pub fn QuizCardView(
             />
 
             <div class="flex-1 flex flex-col justify-center">
-                <div class="text-center mb-3 sm:mb-6">
+                <div class="text-center mb-2 sm:mb-4">
                     <Show when=move || kanji_for_animation.get_value().is_none()>
                         <div class="mb-4">
                             <Heading level=HeadingLevel::H2>

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -132,7 +132,7 @@ fn MultiOptionButton(
                         return display.to_class();
                     }
                 }
-                let base = "p-2 sm:p-4 border text-left transition-all cursor-pointer relative flex flex-col justify-center min-h-[4rem]";
+                let base = "p-2 sm:p-3 border text-left transition-all cursor-pointer relative flex flex-col justify-center min-h-[3rem]";
                 let is_selected = selected_options.get_value().contains(&index);
                 if is_selected {
                     format!("{} border-[var(--accent-olive)] bg-[var(--bg-warm)]", base)
@@ -189,7 +189,7 @@ fn tag_class(tag: &str) -> &'static str {
 
 impl OptionDisplay {
     fn to_class(self) -> String {
-        let base = "p-2 sm:p-4 border text-left relative flex flex-col justify-center min-h-[4rem]";
+        let base = "p-2 sm:p-3 border text-left relative flex flex-col justify-center min-h-[3rem]";
         match self {
             OptionDisplay::Correct => {
                 format!(


### PR DESCRIPTION
## Operational tweaks per user request (no full review)

Three fixes after testing PRs #247-#250 in the built app.

### 1. Card width 1200 -> 1152
`mod.rs:55` — `min-w-[1200px] max-w-[1200px]` -> `min-w-[1152px] max-w-[1152px]`.

Previous 1200px caused horizontal scroll + right-edge clipping on viewports around 1200-1280px: the card was wider than the usable width after padding, and `mx-auto` could not center it (no slack for auto margins). 1152px gives enough headroom while staying close to the requested fixed width.

### 2. Tighter KanjiReadingQuiz vertical spacing
KanjiReadingQuiz with 6 options overflowed vertically on landscape. Reclaim ~50-60px:

- `quiz_options_multi.rs` (two call sites — live + result display): option `min-h-[4rem]` -> `min-h-[3rem]`, padding `sm:p-4` -> `sm:p-3`.
- `quiz_card.rs:211`: question container `mb-3 sm:mb-6` -> `mb-2 sm:mb-4`.

Scoped to QuizOptionsMulti (used only by KanjiReadingQuiz) + the shared question container; single-select QuizOptions and PhraseCardView untouched.

### 3. Larger CJK-safe word heading
`input.css .heading-h2` — user reported Japanese word text "пизда мелкий" in normal word cards while Russian text was fine, with inconsistent sizing across words (自由 normal, 家 / 下宿 small, 会計 larger).

- `font-size`: `clamp(1.75rem, 4vw, 2.25rem)` -> `clamp(2rem, 4vw, 2.5rem)` (+1 step).
- **Removed `letter-spacing: -0.02em`** — CJK glyphs do not benefit from negative letter-spacing the way Latin does; it was likely compressing the visual width of multi-kanji words (e.g. 下宿 looked tighter than 自由). Kept `line-height: 1.2` and `word-break: break-words`.

`font-weight: 300` kept to match the design system (Noto Serif JP ships only 400 in the subset; browser matches the requested 300 as best it can). The resize + letter-spacing removal is the conservative first lever — if the inconsistent-size bug persists, next step is investigating the Noto Serif JP subset coverage for specific kanji (家/宿 may be falling back to a system CJK serif with different glyph metrics).

`heading-h2` is used only in lesson card question/quiz views (verified via grep), so the change is scoped in practice.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p origa_ui --lib -- -D warnings` — clean
- Visual smoke recommended before release.

## Related

- PR #247 (ADR-031 stable min-h), #248 (wider card + 3-col quiz), #249 (fixed-width 1200 + larger heading-h2 — this PR reduces 1200->1152 and adjusts heading further), #250 (revert quiz to 2 cols).
