### PR TITLE
fix(ui): CJK heading weight 400 + kanji-hover sizing + tighter KanjiReadingQuiz

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1781,7 +1781,8 @@ rt {
     cursor: pointer;
     display: inline-block;
     position: relative;
-    vertical-align: baseline;
+    vertical-align: middle;
+    line-height: 1;
 }
 
 .kanji-char-hover:hover,
@@ -3217,8 +3218,8 @@ rt {
 
 .heading-h2 {
     font-family: var(--font-serif);
-    font-weight: 300;
-    font-size: clamp(2rem, 4vw, 2.5rem);
+    font-weight: 400;
+    font-size: clamp(2.25rem, 5vw, 2.75rem);
     line-height: 1.2;
     word-break: break-words;
 }

--- a/origa_ui/src/pages/lesson/quiz_card.rs
+++ b/origa_ui/src/pages/lesson/quiz_card.rs
@@ -208,7 +208,7 @@ pub fn QuizCardView(
             />
 
             <div class="flex-1 flex flex-col justify-center">
-                <div class="text-center mb-2 sm:mb-4">
+                <div class="text-center mb-1 sm:mb-2">
                     <Show when=move || kanji_for_animation.get_value().is_none()>
                         <div class="mb-4">
                             <Heading level=HeadingLevel::H2>

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -30,7 +30,7 @@ pub fn QuizOptionsMulti(
         .collect();
 
     view! {
-        <div class="grid grid-cols-2 gap-2 sm:gap-3">
+        <div class="grid grid-cols-2 gap-1 sm:gap-2">
             {options
                 .iter()
                 .enumerate()
@@ -132,7 +132,7 @@ fn MultiOptionButton(
                         return display.to_class();
                     }
                 }
-                let base = "p-2 sm:p-3 border text-left transition-all cursor-pointer relative flex flex-col justify-center min-h-[3rem]";
+                let base = "p-1.5 sm:p-2.5 border text-left transition-all cursor-pointer relative flex flex-col justify-center min-h-[2.5rem]";
                 let is_selected = selected_options.get_value().contains(&index);
                 if is_selected {
                     format!("{} border-[var(--accent-olive)] bg-[var(--bg-warm)]", base)
@@ -189,7 +189,8 @@ fn tag_class(tag: &str) -> &'static str {
 
 impl OptionDisplay {
     fn to_class(self) -> String {
-        let base = "p-2 sm:p-3 border text-left relative flex flex-col justify-center min-h-[3rem]";
+        let base =
+            "p-1.5 sm:p-2.5 border text-left relative flex flex-col justify-center min-h-[2.5rem]";
         match self {
             OptionDisplay::Correct => {
                 format!(


### PR DESCRIPTION
## Operational tweaks per user request (no full review)

Two issues reported after PR #251 (rc9): small Japanese text in normal word cards still broken, and KanjiReadingQuiz still slightly overflowing on landscape tablet.

### 1. CJK heading: font-weight 300 -> 400 (root cause of "small Japanese text")

`input.css .heading-h2` — `font-weight: 300` -> `font-weight: 400`.

**Root cause analysis:** Noto Serif JP subset ships only weight 400 (Regular). Requesting `font-weight: 300` forced the browser to **synthetic-thin** the CJK glyphs, which rendered inconsistently across kanji — exactly the symptom the user reported (自由 normal, 家/下宿 small, 会計 larger). Cormorant Garamond (Latin/Cyrillic) is a variable font and matched 300 fine, but `heading-h2` is used only for the Japanese word question (verified via grep — other Headings use H1/H3/H4), so 400 is safe and removes the synthetic-thin artifact.

This was the lever I missed in PR #251 — I removed letter-spacing and resized, but kept font-weight 300. The weight mismatch was the actual cause.

Also bumped `font-size`: `clamp(2rem, 4vw, 2.5rem)` -> `clamp(2.25rem, 5vw, 2.75rem)` (+1 step) for the word question — the primary value text for the user.

### 2. kanji-char-hover sizing normalisation

`input.css .kanji-char-hover` — `vertical-align: baseline` -> `vertical-align: middle`, added `line-height: 1`.

Each kanji in `render_segment_with_hover` (used by normal word cards with `with_kanji_tooltip=true`) is wrapped in an inline-block span. With baseline alignment, glyphs with different baseline metrics (ascent/descent) rendered at visually different sizes/positions even at the same font-size. `vertical-align: middle` + `line-height: 1` normalises the inline-block box so all kanji render at the same visual size.

### 3. KanjiReadingQuiz spacing tightened further

Still overflowing on landscape tablet after PR #251's trims. Reclaim another ~30-40px:

- `quiz_options_multi.rs`: grid `gap-2 sm:gap-3` -> `gap-1 sm:gap-2`; option `min-h-[3rem]` -> `min-h-[2.5rem]`; padding `p-2 sm:p-3` -> `p-1.5 sm:p-2.5` (two call sites: live + result display).
- `quiz_card.rs:211`: question container `mb-2 sm:mb-4` -> `mb-1 sm:mb-2`.

Scoped to QuizOptionsMulti (KanjiReadingQuiz only) + the shared question container; single-select QuizOptions and PhraseCardView untouched.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p origa_ui --lib -- -D warnings` — clean
- Visual smoke recommended before release.

## Related

- PR #251 (rc9: card width 1200->1152, first KanjiReadingQuiz trim, heading-h2 resize + letter-spacing removal — this PR adds the font-weight fix that was the actual root cause).
