### PR TITLE
fix(ui): relative card width min(90vw,1280px), tighter KanjiReadingQuiz

### DIFF
--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -52,7 +52,7 @@ pub(in crate::pages::lesson) const LESSON_CARD_CLASS: &str =
 pub fn Lesson() -> impl IntoView {
     view! {
         <div class="flex-1 flex flex-col py-4" data-testid="lesson-page">
-            <div class="min-w-[1152px] max-w-[1152px] mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
+            <div class="min-w-[min(90vw,1280px)] max-w-[min(90vw,1280px)] mx-auto px-2 sm:px-4 flex-1 flex flex-col min-h-0" data-testid="lesson-card">
                 <LessonContent />
             </div>
         </div>

--- a/origa_ui/src/pages/lesson/quiz_card.rs
+++ b/origa_ui/src/pages/lesson/quiz_card.rs
@@ -208,7 +208,7 @@ pub fn QuizCardView(
             />
 
             <div class="flex-1 flex flex-col justify-center">
-                <div class="text-center mb-1 sm:mb-2">
+                <div class="text-center mb-0.5 sm:mb-1">
                     <Show when=move || kanji_for_animation.get_value().is_none()>
                         <div class="mb-4">
                             <Heading level=HeadingLevel::H2>

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -132,7 +132,7 @@ fn MultiOptionButton(
                         return display.to_class();
                     }
                 }
-                let base = "p-1.5 sm:p-2.5 border text-left transition-all cursor-pointer relative flex flex-col justify-center min-h-[2.5rem]";
+                let base = "p-1.5 sm:p-2 border text-left transition-all cursor-pointer relative flex flex-col justify-center min-h-[2.25rem]";
                 let is_selected = selected_options.get_value().contains(&index);
                 if is_selected {
                     format!("{} border-[var(--accent-olive)] bg-[var(--bg-warm)]", base)
@@ -190,7 +190,7 @@ fn tag_class(tag: &str) -> &'static str {
 impl OptionDisplay {
     fn to_class(self) -> String {
         let base =
-            "p-1.5 sm:p-2.5 border text-left relative flex flex-col justify-center min-h-[2.5rem]";
+            "p-1.5 sm:p-2 border text-left relative flex flex-col justify-center min-h-[2.25rem]";
         match self {
             OptionDisplay::Correct => {
                 format!(


### PR DESCRIPTION
## Operational tweaks per user request (no full review)

Two issues after PR #252: KanjiReadingQuiz still slight scroll on landscape, and fixed 1152px card was clipping on portrait (1152 > mobile portrait width) while looking too wide on desktop.

### 1. Relative card width with cap

`mod.rs:55` — `min-w-[1152px] max-w-[1152px]` -> `min-w-[min(90vw,1280px)] max-w-[min(90vw,1280px)]`.

- **min = max** (per "мин=макс чтобы не скакала") — card never resizes between cards.
- **Relative** (per "сделать относительной может?") — scales with viewport.
- **Cap 1280px** — on wide desktop 90vw of 1920 = 1728px would be too wide ("ахуенная"); the `min()` caps it at 1280px.
- On portrait mobile/tablet the card now scales down to 90vw instead of being clipped at fixed 1152px.
- The CSS `min()` function transitions continuously through the threshold (~1422px viewport), so no jump at any breakpoint.

| Viewport | Card width (before) | Card width (after) |
|----------|---------------------|--------------------|
| 375px (mobile portrait) | 1152px (clipped, scroll) | 337px (fits) |
| 768px (tablet portrait) | 1152px (clipped, scroll) | 691px (fits) |
| 1024px (tablet landscape) | 1152px (slight scroll) | 921px (fits) |
| 1920px (desktop) | 1152px (60% viewport) | 1280px (cap, 67% viewport) |

### 2. KanjiReadingQuiz spacing trimmed further

Still slight scroll on landscape after PR #252's trims. Reclaim another ~15-20px:

- `quiz_options_multi.rs` (two call sites): option `min-h-[2.5rem]` -> `min-h-[2.25rem]`, padding `sm:p-2.5` -> `sm:p-2`.
- `quiz_card.rs:211`: question container `mb-1 sm:mb-2` -> `mb-0.5 sm:mb-1`.

Scoped to QuizOptionsMulti (KanjiReadingQuiz) + shared question container; single-select QuizOptions and PhraseCardView untouched.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p origa_ui --lib -- -D warnings` — clean
- Visual smoke recommended before release.

## Related

- PR #251 (card 1200->1152, first KanjiReadingQuiz trim), #252 (CJK weight 400 + kanji-hover sizing + more KanjiReadingQuiz trim).
