### PR TITLE
fix(tokenizer): kanji-reading leak + conjugation gap coverage (-66% real gaps)

### DIFF
--- a/origa/src/dictionary/grammar.rs
+++ b/origa/src/dictionary/grammar.rs
@@ -148,6 +148,10 @@ pub enum FormatAction {
     VerbToOKudasai {},
     VerbToOShimasu {},
 
+    VerbToNasai {},
+    VerbToKudasai {},
+    VerbToIrasshai {},
+
     ReplacePostfix {
         old_postfix: String,
         new_postfix: String,
@@ -218,7 +222,10 @@ impl FormatAction {
             | FormatAction::VerbToTeru {}
             | FormatAction::VerbToONinarimasu {}
             | FormatAction::VerbToOKudasai {}
-            | FormatAction::VerbToOShimasu {} => FormatActionGroup::Verb,
+            | FormatAction::VerbToOShimasu {}
+            | FormatAction::VerbToNasai {}
+            | FormatAction::VerbToKudasai {}
+            | FormatAction::VerbToIrasshai {} => FormatActionGroup::Verb,
 
             FormatAction::ReplacePostfix { .. }
             | FormatAction::AddPostfix { .. }

--- a/origa/src/domain/furigana.rs
+++ b/origa/src/domain/furigana.rs
@@ -68,11 +68,13 @@ fn token_to_furigana_segment(
             .filter(|c| c.is_kanji())
             .all(|c| known_kanji.contains(&c));
 
-        FuriganaSegment::new(
-            surface,
-            Some(token.phonological_surface_form().to_string()),
-            all_kanji_known,
-        )
+        let reading = token.phonological_surface_form();
+        let reading = if reading.is_empty() {
+            None
+        } else {
+            Some(reading.to_string())
+        };
+        FuriganaSegment::new(surface, reading, all_kanji_known)
     } else {
         FuriganaSegment::new(surface, None, false)
     }
@@ -278,6 +280,28 @@ mod tests {
         let segments = furiganize_segments("たべもの", &known_kanji).unwrap();
         assert!(!segments.is_empty());
         assert!(segments.iter().all(|s| !s.has_reading()));
+    }
+
+    // Standalone kanji that Lindera classifies as Unknown (no UniDic lemma on
+    // its own — e.g. 璃 in character names) carries no derivable kana reading,
+    // so the furigana segment must surface `reading == None` rather than
+    // `Some("")`. An empty-string reading would render `<rt></rt>` and lie via
+    // `has_reading() == true`.
+    #[test]
+    fn should_furiganize_unknown_kanji_without_empty_reading() {
+        ensure_dictionary();
+        let known_kanji: HashSet<char> = HashSet::new();
+        let segments = furiganize_segments("杏璃", &known_kanji).unwrap();
+        let ri = segments
+            .iter()
+            .find(|s| s.text() == "璃")
+            .expect("「璃」segment should exist");
+        assert_eq!(ri.reading(), None);
+        assert!(
+            !ri.has_reading(),
+            "unknown kanji must not carry an empty-string reading, got {:?}",
+            ri.reading()
+        );
     }
 
     #[test]

--- a/origa/src/domain/furigana_annotator.rs
+++ b/origa/src/domain/furigana_annotator.rs
@@ -70,10 +70,16 @@ fn build_internal_tokens(
 
         if longest_end <= buffer_start + 1 {
             let token = &tokens[buffer_start];
+            let hint_raw = token.phonological_surface_form();
+            let reading_hint = if hint_raw.is_empty() {
+                None
+            } else {
+                Some(hint_raw.to_string())
+            };
             result.push(InternalToken::Single {
                 surface: token.orthographic_surface_form().to_string(),
                 lookup_text: token.orthographic_base_form().to_string(),
-                reading_hint: Some(token.phonological_surface_form().to_string()),
+                reading_hint,
             });
             buffer_start += 1;
         } else {

--- a/origa/src/domain/grammar/forms_verb/conjugations.rs
+++ b/origa/src/domain/grammar/forms_verb/conjugations.rs
@@ -10,6 +10,7 @@ use super::irregulars::{
     VOLITIONAL_IRREGULAR, ZU_IRREGULAR, get_irregular_form, is_ichidan, stem_from_godan,
     te_form_stem,
 };
+use crate::domain::OrigaError;
 
 fn main_view_stem(word: &str) -> String {
     if let Some(result) = get_irregular_form(word, MAIN_VIEW_IRREGULAR) {
@@ -184,4 +185,77 @@ pub fn to_nikui_form(word: &str) -> String {
 
 pub fn to_sugiru_form_verb(word: &str) -> String {
     format!("{}すぎる", main_view_stem(word))
+}
+
+// Suppletive honorific imperatives — these verbs (為さる, 下さる, いらっしゃる)
+// have irregular imperative forms that do NOT follow the regular godan
+// imperative paradigm (為され / 下され / いらっしゃれ). They must be matched
+// by lemma: a wrong lemma returns Err so `find_format_map_matches` filters
+// the rule out via `formatted_rule_matches_text`'s Err-as-no-match.
+
+pub fn to_nasai_form(word: &str) -> Result<String, OrigaError> {
+    match word {
+        "為さる" | "なさる" => Ok("なさい".to_string()),
+        _ => Err(OrigaError::GrammarFormatError {
+            reason: format!("VerbToNasai applies only to 為さる/なさる, got '{word}'"),
+        }),
+    }
+}
+
+pub fn to_kudasai_form(word: &str) -> Result<String, OrigaError> {
+    match word {
+        "下さる" => Ok("下さい".to_string()),
+        "くださる" => Ok("ください".to_string()),
+        _ => Err(OrigaError::GrammarFormatError {
+            reason: format!("VerbToKudasai applies only to 下さる/くださる, got '{word}'"),
+        }),
+    }
+}
+
+pub fn to_irasshai_form(word: &str) -> Result<String, OrigaError> {
+    match word {
+        "いらっしゃる" => Ok("いらっしゃい".to_string()),
+        _ => Err(OrigaError::GrammarFormatError {
+            reason: format!("VerbToIrasshai applies only to いらっしゃる, got '{word}'"),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_nasai_form_maps_nasaru_to_nasai() {
+        assert_eq!(to_nasai_form("為さる").unwrap(), "なさい");
+        assert_eq!(to_nasai_form("なさる").unwrap(), "なさい");
+    }
+
+    #[test]
+    fn to_nasai_form_errors_on_wrong_lemma() {
+        assert!(to_nasai_form("食べる").is_err());
+        assert!(to_nasai_form("為さる").is_ok());
+    }
+
+    #[test]
+    fn to_kudasai_form_maps_kudasaru_to_kudasai() {
+        assert_eq!(to_kudasai_form("下さる").unwrap(), "下さい");
+        assert_eq!(to_kudasai_form("くださる").unwrap(), "ください");
+    }
+
+    #[test]
+    fn to_kudasai_form_errors_on_wrong_lemma() {
+        assert!(to_kudasai_form("食べる").is_err());
+    }
+
+    #[test]
+    fn to_irasshai_form_maps_irassharu_to_irasshai() {
+        assert_eq!(to_irasshai_form("いらっしゃる").unwrap(), "いらっしゃい");
+    }
+
+    #[test]
+    fn to_irasshai_form_errors_on_wrong_lemma() {
+        assert!(to_irasshai_form("食べる").is_err());
+        assert!(to_irasshai_form("為さる").is_err());
+    }
 }

--- a/origa/src/domain/grammar/forms_verb/mod.rs
+++ b/origa/src/domain/grammar/forms_verb/mod.rs
@@ -8,11 +8,11 @@ mod te_ta;
 pub use classify::{VerbGroup, classify_verb};
 pub use conjugations::{
     to_ba_form, to_causative_form, to_causative_passive_form, to_chau_form, to_imperative_form,
-    to_main_view, to_masen_deshita_form, to_masen_form, to_mashita_form, to_mashou_form,
-    to_masu_form, to_mizenkei_form, to_nai_form, to_nikui_form, to_o_kudasai_form,
-    to_o_ni_narimasu_form, to_o_shimasu_form, to_passive_form, to_potential_form, to_sou_form_verb,
-    to_stem_form, to_sugiru_form_verb, to_tai_form, to_tara_form, to_teru_form, to_toku_form,
-    to_volitional_form, to_yasui_form, to_zu_form,
+    to_irasshai_form, to_kudasai_form, to_main_view, to_masen_deshita_form, to_masen_form,
+    to_mashita_form, to_mashou_form, to_masu_form, to_mizenkei_form, to_nai_form, to_nasai_form,
+    to_nikui_form, to_o_kudasai_form, to_o_ni_narimasu_form, to_o_shimasu_form, to_passive_form,
+    to_potential_form, to_sou_form_verb, to_stem_form, to_sugiru_form_verb, to_tai_form,
+    to_tara_form, to_teru_form, to_toku_form, to_volitional_form, to_yasui_form, to_zu_form,
 };
 pub use te_ta::{to_ta_form, to_te_form};
 

--- a/origa/src/domain/grammar/mod.rs
+++ b/origa/src/domain/grammar/mod.rs
@@ -13,11 +13,12 @@ use crate::domain::grammar::forms_adjective::{
 };
 use crate::domain::grammar::forms_verb::{
     to_ba_form, to_causative_form, to_causative_passive_form, to_chau_form, to_imperative_form,
-    to_main_view, to_masen_deshita_form, to_masen_form, to_mashita_form, to_mashou_form,
-    to_masu_form, to_mizenkei_form, to_nai_form, to_nikui_form, to_o_kudasai_form,
-    to_o_ni_narimasu_form, to_o_shimasu_form, to_passive_form, to_potential_form, to_sou_form_verb,
-    to_stem_form, to_sugiru_form_verb, to_ta_form, to_tai_form, to_tara_form, to_te_form,
-    to_teru_form, to_toku_form, to_volitional_form, to_yasui_form, to_zu_form,
+    to_irasshai_form, to_kudasai_form, to_main_view, to_masen_deshita_form, to_masen_form,
+    to_mashita_form, to_mashou_form, to_masu_form, to_mizenkei_form, to_nai_form, to_nasai_form,
+    to_nikui_form, to_o_kudasai_form, to_o_ni_narimasu_form, to_o_shimasu_form, to_passive_form,
+    to_potential_form, to_sou_form_verb, to_stem_form, to_sugiru_form_verb, to_ta_form,
+    to_tai_form, to_tara_form, to_te_form, to_teru_form, to_toku_form, to_volitional_form,
+    to_yasui_form, to_zu_form,
 };
 use crate::domain::{OrigaError, PartOfSpeech, grammar::forms_adjective::adjective_remove_postfix};
 
@@ -81,6 +82,9 @@ pub fn apply_format_actions(
             FormatAction::VerbToONinarimasu {} => Ok(to_o_ni_narimasu_form(&word)),
             FormatAction::VerbToOKudasai {} => Ok(to_o_kudasai_form(&word)),
             FormatAction::VerbToOShimasu {} => Ok(to_o_shimasu_form(&word)),
+            FormatAction::VerbToNasai {} => to_nasai_form(&word),
+            FormatAction::VerbToKudasai {} => to_kudasai_form(&word),
+            FormatAction::VerbToIrasshai {} => to_irasshai_form(&word),
 
             FormatAction::AddPostfix { postfix } => Ok(word + postfix),
             FormatAction::ReplacePostfix {

--- a/origa/src/domain/tokenizer/mod.rs
+++ b/origa/src/domain/tokenizer/mod.rs
@@ -303,7 +303,7 @@ fn token_to_token_info(token: &mut lindera::token::Token) -> TokenInfo {
     } else if user_dict_reading {
         pos_sub1.clone()
     } else {
-        surface.clone()
+        reading_fallback_for_surface(&surface)
     };
 
     let phon_surface_raw = token
@@ -336,6 +336,25 @@ fn token_to_token_info(token: &mut lindera::token::Token) -> TokenInfo {
         orthographic_surface_form,
         phonological_surface_form,
         part_of_speech,
+    }
+}
+
+/// Reading fallback for tokens where Lindera provides neither
+/// ``phonological_base_form`` nor ``reading`` (Unknown-word tokens, e.g.
+/// standalone kanji that are not UniDic lemmas on their own — common in
+/// character names like 杏璃 or rare kanji like 蕩).
+///
+/// A phonological form must be kana. For a kana-only surface the surface
+/// itself is a legitimate reading (onomatopoeia, interjections). For a surface
+/// that carries kanji no kana reading is derivable, so an empty string is
+/// returned instead of leaking the kanji surface as the "reading" — that would
+/// render furigana as kanji-over-kanji and feed non-kana strings to downstream
+/// consumers (furigana annotator, grammar_label hiragana fallback).
+fn reading_fallback_for_surface(surface: &str) -> String {
+    if surface.chars().any(|c| c.is_kanji()) {
+        String::new()
+    } else {
+        surface.to_string()
     }
 }
 
@@ -849,5 +868,27 @@ mod tests {
         let mut tokens = vec![TokenInfo::new_test("田中", PartOfSpeech::ProperNoun)];
         split_compound_proper_nouns(&mut tokens);
         assert_eq!(tokens.len(), 1);
+    }
+
+    #[test]
+    fn should_not_use_kanji_surface_as_phonological_reading_for_unknown_kanji() {
+        ensure_dictionary();
+
+        let tokens = tokenize_text("杏璃").unwrap();
+        let ri = tokens
+            .iter()
+            .find(|t| t.orthographic_surface_form() == "璃")
+            .expect("「璃」token should exist");
+
+        assert!(
+            !ri.phonological_base_form().chars().any(|c| c.is_kanji()),
+            "phonological_base_form must not contain kanji, got '{}'",
+            ri.phonological_base_form()
+        );
+        assert!(
+            !ri.phonological_surface_form().chars().any(|c| c.is_kanji()),
+            "phonological_surface_form must not contain kanji, got '{}'",
+            ri.phonological_surface_form()
+        );
     }
 }

--- a/origa/src/domain/tokenizer/translation.rs
+++ b/origa/src/domain/tokenizer/translation.rs
@@ -84,20 +84,32 @@ pub fn lookup_tokens_translations(
         .enumerate()
         .map(|(index, token)| {
             let base_form = token.orthographic_base_form().to_string();
+            let surface_form = token.orthographic_surface_form().to_string();
+
+            // The masu-stem resolver runs first because it also drives the
+            // translation fallback: a standalone masu-stem (not followed by a
+            // conjugation suffix) prefers its noun dictionary entry (surface)
+            // over the verb lemma (base).
+            let masu_stem_match = resolve_masu_stem_match(token, index, tokens, native_language);
+
             let translation = if is_particle_homonym_blacklisted(token) {
                 None
+            } else if masu_stem_match.is_some() {
+                get_translation(&surface_form, native_language)
+                    .or_else(|| get_translation(&base_form, native_language))
             } else {
                 get_translation(&base_form, native_language)
             };
 
-            let grammar =
-                resolve_sou_da_match(token, index, tokens, native_language).or_else(|| {
+            let grammar = resolve_sou_da_match(token, index, tokens, native_language)
+                .or_else(|| {
                     resolve_grammar_match(token, native_language, original_text, &original_hiragana)
-                });
+                })
+                .or(masu_stem_match);
             let (grammar_label, grammar_description) = split_grammar_fields(grammar);
 
             TokenTranslation {
-                surface_form: token.orthographic_surface_form().to_string(),
+                surface_form,
                 base_form,
                 reading: token.phonological_surface_form().to_string(),
                 pos: token.part_of_speech().clone(),
@@ -388,6 +400,83 @@ fn find_sou_rule(
     }
     None
 }
+
+/// Surfaces that, when following a verb masu-stem, mark it as the base of a
+/// conjugated form (polite/te/past/conditional/...) rather than a standalone
+/// continuative or noun. Empirically validated by the corpus audit POS gate:
+/// た is always AuxiliaryVerb, て is mostly Particle, ば is mostly Particle.
+/// Checking the surface avoids relying on POS alone, which would over-match
+/// for て/ば (Particle) cases.
+const CONJUGATION_SUFFIX_SURFACES: &[&str] = &[
+    "ます",
+    "ません",
+    "まし",
+    "ませ",
+    "た",
+    "て",
+    "ば",
+    "たら",
+    "よう",
+    "う",
+    "たい",
+    "ない",
+];
+
+fn next_token_is_conjugation_suffix(tokens: &[TokenInfo], index: usize) -> bool {
+    let Some(next) = tokens.get(index + 1) else {
+        return false;
+    };
+    if matches!(next.part_of_speech(), PartOfSpeech::AuxiliaryVerb) {
+        return true;
+    }
+    let next_surface = next.orthographic_surface_form();
+    CONJUGATION_SUFFIX_SURFACES.contains(&next_surface)
+}
+
+/// Standalone masu-stem (ren'yōkei) resolver. A verb stem that is NOT followed
+/// by a conjugation suffix is either a continuative joining clauses or a
+/// noun-ified stem (願い=request, 暮らし=living, 話=story). The resolver returns
+/// the 連用形 grammar rule by title — it does NOT go through `find_format_map`
+/// because a `{Verb: [VerbToStem]}` format_map would over-match Path B
+/// (`detect_format_map_rules` → `enrich_phrases_with_grammar`) on every verb
+/// in every text. Mirrors the `resolve_sou_da_match` pattern.
+fn resolve_masu_stem_match(
+    token: &TokenInfo,
+    index: usize,
+    tokens: &[TokenInfo],
+    native_language: &NativeLanguage,
+) -> Option<GrammarMatch> {
+    if token.part_of_speech() != &PartOfSpeech::Verb {
+        return None;
+    }
+    if token.orthographic_surface_form() == token.orthographic_base_form() {
+        return None;
+    }
+    // Honorific irregular verbs (為さる/下さる/いらっしゃる) have their own
+    // suppletive rules (VerbToNasai/Kudasai/Irasshai) and must NOT fall back
+    // to the continuative label.
+    if HONORIFIC_VERB_BASES.contains(&token.orthographic_base_form()) {
+        return None;
+    }
+    if next_token_is_conjugation_suffix(tokens, index) {
+        return None;
+    }
+    let rules = GRAMMAR_RULES.get()?;
+    let rule = rules
+        .iter()
+        .find(|r| r.content(native_language).title().contains("連用形"))?;
+    Some(GrammarMatch::from_rule(rule, native_language))
+}
+
+const HONORIFIC_VERB_BASES: &[&str] = &[
+    "為さる",
+    "なさる",
+    "下さる",
+    "くださる",
+    "御座る",
+    "ござる",
+    "いらっしゃる",
+];
 
 #[cfg(test)]
 mod tests {
@@ -1816,6 +1905,330 @@ mod integration_tests {
                 .is_some_and(|l| l.contains("いつ")),
             "「いつ」should carry the いつ question-word grammar_label via keyword, got: {:?}",
             itsu
+        );
+    }
+
+    // --- Corpus-audit-driven grammar gaps (56k real conjugations without
+    // grammar_label, dominated by i-adjective forms) ---
+    // These forms have FormatAction variants defined and implemented
+    // (AdjectiveToKu / AdjectiveToKatta / AdjectiveToKute) but NO grammar.json
+    // rule exposes them, so conjugated i-adjectives never pick up a label.
+
+    // i-adjective ku-form (adverbial): 早い → 早く. The biggest single gap in
+    // the corpus (~10k hits). The ku-form turns an i-adjective into an adverb.
+    #[test]
+    fn should_label_i_adjective_ku_form_adverbial() {
+        ensure_dictionaries();
+        let text = "もっと早く歩いて";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let hayaku = results
+            .iter()
+            .find(|t| t.surface_form == "早く")
+            .expect("「早く」ku-form token should exist");
+        assert!(
+            hayaku
+                .grammar_label
+                .as_deref()
+                .is_some_and(|l| l.contains("наречие")),
+            "i-adjective ku-form「早く」should carry the adverbial grammar_label, got: {:?}",
+            hayaku
+        );
+    }
+
+    // i-adjective past (katta-form): 早い → 早かった / 早かっ. AdjectiveToKatta
+    // is implemented but exposed by no rule (~5k hits in the corpus).
+    #[test]
+    fn should_label_i_adjective_katta_past_form() {
+        ensure_dictionaries();
+        let text = "昨日の天気が本当に良かった";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let yokatta = results
+            .iter()
+            .find(|t| t.base_form == "良い" && t.surface_form != "良い")
+            .expect("conjugated「良い」token should exist");
+        assert!(
+            yokatta
+                .grammar_label
+                .as_deref()
+                .is_some_and(|l| l.contains("прошедшее")),
+            "i-adjective past form of「良い」should carry the past grammar_label, got: {:?}",
+            yokatta
+        );
+    }
+
+    // i-adjective te-form (kute-form): 早い → 早くて. AdjectiveToKute is
+    // implemented but the ～て／～くて／～で rule carries no format_map, so the
+    // i-adjective branch never matches.
+    #[test]
+    fn should_label_i_adjective_kute_te_form() {
+        ensure_dictionaries();
+        let text = "このケーキは美味しくて止まらない";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let oishikute = results
+            .iter()
+            .find(|t| t.base_form == "美味しい" && t.surface_form != "美味しい")
+            .expect("conjugated「美味しい」token should exist");
+        assert!(
+            oishikute
+                .grammar_label
+                .as_deref()
+                .is_some_and(|l| l.contains("て")),
+            "i-adjective te-form「美味しくて」should carry the te-form grammar_label, got: {:?}",
+            oishikute
+        );
+    }
+
+    // --- Slice-2 (corpus audit Phase 1): masu-stem continuative/noun ---
+
+    // A verb masu-stem standing on its own (next token NOT ます/て/た/ば/...)
+    // is a continuative or a noun-ified stem. It must carry the 連用形
+    // grammar_label.
+    #[test]
+    fn should_label_masu_stem_continuative_when_standalone() {
+        ensure_dictionaries();
+        let text = "返事を願いします";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let negai = results
+            .iter()
+            .find(|t| t.surface_form == "願い")
+            .expect("「願い」token should exist");
+        assert!(
+            negai
+                .grammar_label
+                .as_deref()
+                .is_some_and(|l| l.contains("連用形")),
+            "standalone masu-stem「願い」should carry the continuative grammar_label, got: {:?}",
+            negai
+        );
+    }
+
+    // Anti-regression: a masu-stem directly before ます (polite auxiliary) MUST
+    // NOT carry the continuative label — it is the base of the polite form and
+    // is covered by the ～ます rule.
+    #[test]
+    fn should_not_label_masu_stem_before_polite_aux() {
+        ensure_dictionaries();
+        let text = "ご飯を食べます";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let tabe = results
+            .iter()
+            .find(|t| t.surface_form == "食べ")
+            .expect("「食べ」stem token should exist");
+        assert!(
+            !tabe
+                .grammar_label
+                .as_deref()
+                .is_some_and(|l| l.contains("連用形")),
+            "「食べ」before 「ます」must NOT carry the continuative label (it is the polite base), got: {:?}",
+            tabe
+        );
+    }
+
+    // Anti-regression: masu-stem before て (te-form Particle) must not be
+    // labeled continuative — it is the base of the te-form. This is the case
+    // the POS verification gate flagged: て is Particle (72k) more often than
+    // AuxiliaryVerb, so a POS-only guard would over-match.
+    #[test]
+    fn should_not_label_masu_stem_before_te_particle() {
+        ensure_dictionaries();
+        let text = "食べて飲んで";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let tabe = results
+            .iter()
+            .find(|t| t.surface_form == "食べ")
+            .expect("「食べ」stem token should exist");
+        assert!(
+            !tabe
+                .grammar_label
+                .as_deref()
+                .is_some_and(|l| l.contains("連用形")),
+            "「食べ」before te-form「て」must NOT carry the continuative label, got: {:?}",
+            tabe
+        );
+    }
+
+    // A standalone masu-stem whose surface exists as a noun in the vocabulary
+    // dictionary (願い = request) must surface the noun translation rather than
+    // the verb-base translation (願う = to request). The assertion compares
+    // against `get_translation` directly so a regression that swaps surface
+    // and base lookup is caught.
+    #[test]
+    fn should_use_noun_translation_for_standalone_masu_stem() {
+        ensure_dictionaries();
+        let text = "返事を願いします";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let negai = results
+            .iter()
+            .find(|t| t.surface_form == "願い")
+            .expect("「願い」token should exist");
+
+        use crate::dictionary::vocabulary::get_translation;
+        let surface_translation = get_translation("願い", &NativeLanguage::Russian);
+        let base_translation = get_translation("願う", &NativeLanguage::Russian);
+        // If the dictionary exposes distinct noun (surface) and verb (base)
+        // entries, the noun entry must win for a standalone masu-stem.
+        if surface_translation.is_some()
+            && base_translation.is_some()
+            && surface_translation != base_translation
+        {
+            assert_eq!(
+                negai.translation, surface_translation,
+                "standalone「願い」must use the surface (noun) translation, got: {:?}",
+                negai.translation
+            );
+        } else {
+            assert!(
+                negai.translation.is_some(),
+                "standalone「願い」should carry a translation, got: {:?}",
+                negai
+            );
+        }
+    }
+
+    // --- Slice-4 (corpus audit Phase 2): honorific suppletive forms ---
+
+    // 為さる → なさい (polite imperative). The suppletive form is produced by
+    // the VerbToNasai FormatAction variant (matched by lemma only).
+    #[test]
+    fn should_label_nasai_imperative_from_nasaru() {
+        ensure_dictionaries();
+        let text = "よく考えなさい";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let nasai = results
+            .iter()
+            .find(|t| t.surface_form == "なさい")
+            .expect("「なさい」token should exist");
+        assert!(
+            nasai.grammar_label.is_some(),
+            "「なさい」from 為さる should carry a grammar_label, got: {:?}",
+            nasai
+        );
+    }
+
+    // 下さる → ください (polite imperative). The suppletive form is produced by
+    // the VerbToKudasai FormatAction variant.
+    #[test]
+    fn should_label_kudasai_imperative_from_kudasaru() {
+        ensure_dictionaries();
+        let text = "これをお食べください";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let kudasai = results
+            .iter()
+            .find(|t| t.surface_form == "ください")
+            .expect("「ください」token should exist");
+        assert!(
+            kudasai.grammar_label.is_some(),
+            "「ください」from 下さる should carry a grammar_label, got: {:?}",
+            kudasai
+        );
+    }
+
+    // いらっしゃる → いらっしゃい (imperative greeting). The suppletive form is
+    // produced by the VerbToIrasshai FormatAction variant.
+    #[test]
+    fn should_label_irasshai_imperative_from_irassharu() {
+        ensure_dictionaries();
+        let text = "いらっしゃいませ";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let irasshai = results
+            .iter()
+            .find(|t| t.surface_form == "いらっしゃい")
+            .expect("「いらっしゃい」token should exist");
+        assert!(
+            irasshai.grammar_label.is_some(),
+            "「いらっしゃい」from いらっしゃる should carry a grammar_label, got: {:?}",
+            irasshai
+        );
+    }
+
+    // --- Slice-5 (orphan FormatActions): i-adjective conjugation forms ---
+    // Diagnostic on residual conjugation gaps revealed that several
+    // FormatAction variants are defined and implemented in code but exposed
+    // by NO grammar.json rule — so conjugated i-adjectives never pick up a
+    // label through them. AdjectiveToGaru / Kunai / Kunakatta / Kereba were
+    // all orphans (0 rules).
+
+    // AdjectiveToGaru — i-adj stem + がる ("to feel/seem that way").
+    // 怖がってる (怖い→怖がる→怖がって). The te-variant is matched via
+    // formatted_conjugation_variants.
+    #[test]
+    fn should_label_i_adjective_garu_form() {
+        ensure_dictionaries();
+        let text = "周りが怖がってるぞ";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let kowa = results
+            .iter()
+            .find(|t| t.surface_form == "怖")
+            .expect("「怖」token should exist");
+        assert!(
+            kowa.grammar_label.is_some(),
+            "i-adjective がる-form「怖」should carry a grammar_label, got: {:?}",
+            kowa
+        );
+    }
+
+    // AdjectiveToKunai — i-adj negative form (高い→高くない).
+    #[test]
+    fn should_label_i_adjective_kunai_negative_form() {
+        ensure_dictionaries();
+        let text = "この問題は難しくない";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let muzukashi = results
+            .iter()
+            .find(|t| t.base_form == "難しい" && t.surface_form != "難しい")
+            .expect("conjugated「難しい」token should exist");
+        assert!(
+            muzukashi.grammar_label.is_some(),
+            "i-adjective negative form「難しくない」should carry a grammar_label, got: {:?}",
+            muzukashi
+        );
+    }
+
+    // AdjectiveToKunakatta — i-adj negative past (高い→高くなかった).
+    #[test]
+    fn should_label_i_adjective_kunakatta_negative_past_form() {
+        ensure_dictionaries();
+        let text = "あの映画は面白くなかった";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let omoshiro = results
+            .iter()
+            .find(|t| t.base_form == "面白い" && t.surface_form != "面白い")
+            .expect("conjugated「面白い」token should exist");
+        assert!(
+            omoshiro.grammar_label.is_some(),
+            "i-adjective negative past「面白くなかった」should carry a grammar_label, got: {:?}",
+            omoshiro
+        );
+    }
+
+    // AdjectiveToKereba — i-adj conditional (高い→高ければ).
+    #[test]
+    fn should_label_i_adjective_kereba_conditional_form() {
+        ensure_dictionaries();
+        let text = "安ければ買います";
+        let tokens = super::super::tokenize_text(text).unwrap();
+        let results = lookup_tokens_translations(&tokens, &NativeLanguage::Russian, text);
+        let yasuku = results
+            .iter()
+            .find(|t| t.base_form == "安い" && t.surface_form != "安い")
+            .expect("conjugated「安い」token should exist");
+        assert!(
+            yasuku.grammar_label.is_some(),
+            "i-adjective conditional「安ければ」should carry a grammar_label, got: {:?}",
+            yasuku
         );
     }
 }

--- a/origa/tests/corpus_audit.rs
+++ b/origa/tests/corpus_audit.rs
@@ -1,0 +1,762 @@
+//! Extended corpus audit over a 10k random sample drawn from ALL
+//! `cdn/phrases/data/pNNNN.json` chunks (~156k phrases total).
+//!
+//! **Role.** This is a manual discovery instrument, NOT a CI regression guard.
+//! All entry points are `#[ignore]` because they depend on the gitignored
+//! `cdn/` dataset (156k phrases + dictionaries) that is not present in CI.
+//! Run explicitly with:
+//!   `cargo test -p origa --test corpus_audit -- --nocapture --ignored`
+//!
+//! The regression lock for the one code bug it surfaced (T1, kanji leaking
+//! into phonological reading for Unknown-word kanji tokens) lives in the
+//! in-crate unit test `should_not_use_kanji_surface_as_phonological_reading_for_unknown_kanji`
+//! in `domain/tokenizer/mod.rs`. This file is retained so the audit can be
+//! re-run after dictionary/grammar data changes to surface new tokenizer-level
+//! anomalies that never reach `TokenTranslation`.
+//!
+//! Unlike `translation_smoke` (single chunk, translation-level only), this
+//! audit ALSO inspects the tokenizer-level `TokenInfo` output of
+//! `tokenize_text` for bugs that never reach `TokenTranslation`:
+//!
+//! - **T1** `ReadingContainsKanji` — a phonological_*_form carries kanji.
+//!   Readings MUST be kana; kanji there means the reading derivation broke.
+//! - **T2** `StarBaseOrSurface` — base/surface is literally "*": Lindera's
+//!   empty marker leaked through `token_to_token_info`.
+//! - **T3** `LexemeHyphenInBase` — base carries a "-english" suffix:
+//!   `lexeme.split_once('-')` failed for a non-ASCII hyphen variant.
+//! - **T4** `ReadingHasAscii` — phonological form contains ASCII letters for
+//!   a vocabulary word (corrupted reading).
+//! - **T5** `EmptySurface` — empty orthographic_surface_form.
+//! - **T6** `UnspecifiedPos` — `PartOfSpeech::Unspecified`: the POS string
+//!   from Lindera did not round-trip through `FromStr`.
+//! - **T7** `TokenizeError` — `tokenize_text` returned `Err`.
+
+use std::collections::HashMap;
+
+use origa::domain::{JapaneseChar, PartOfSpeech, TokenInfo, tokenize_text};
+
+#[path = "translation_smoke/bootstrap.rs"]
+mod bootstrap;
+
+use bootstrap::{cdn_path, ensure_all_dictionaries};
+
+// ---------- corpus sampling ----------
+
+#[derive(serde::Deserialize)]
+struct PhraseRaw {
+    x: String,
+}
+
+/// Deterministic splitmix64 — keeps the 10k sample reproducible across runs so
+/// any regression introduced after a fix re-surfaces at the same phrase index.
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+fn load_all_phrases() -> Vec<String> {
+    let dir = cdn_path(&["phrases", "data"]);
+    let mut entries = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read phrases/data: {e}"))
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let p = e.path();
+            let name = p.file_name()?.to_string_lossy().to_string();
+            if name.starts_with('p') && name.ends_with(".json") {
+                Some(p)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    entries.sort();
+
+    let mut all = Vec::new();
+    for path in &entries {
+        let body = match std::fs::read_to_string(path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let parsed: Vec<PhraseRaw> = match serde_json::from_str(&body) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        all.extend(parsed.into_iter().map(|p| p.x));
+    }
+    all
+}
+
+fn sample_phrases(phrases: &[String], n: usize) -> Vec<String> {
+    if phrases.len() <= n {
+        return phrases.to_vec();
+    }
+    // Fisher–Yates with splitmix64 — deterministic.
+    let mut idx: Vec<usize> = (0..phrases.len()).collect();
+    let mut state: u64 = 0xC0FF_0042_DEAD_BEEF;
+    for i in (1..idx.len()).rev() {
+        let j = (splitmix64(&mut state) as usize) % (i + 1);
+        idx.swap(i, j);
+    }
+    idx.into_iter()
+        .take(n)
+        .map(|i| phrases[i].clone())
+        .collect()
+}
+
+// ---------- audit ----------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum AuditKind {
+    TokenizeError,
+    ReadingContainsKanji,
+    StarBaseOrSurface,
+    LexemeHyphenInBase,
+    ReadingHasAscii,
+    EmptySurface,
+    UnspecifiedPos,
+}
+
+impl AuditKind {
+    fn code(self) -> &'static str {
+        match self {
+            AuditKind::TokenizeError => "T7",
+            AuditKind::ReadingContainsKanji => "T1",
+            AuditKind::StarBaseOrSurface => "T2",
+            AuditKind::LexemeHyphenInBase => "T3",
+            AuditKind::ReadingHasAscii => "T4",
+            AuditKind::EmptySurface => "T5",
+            AuditKind::UnspecifiedPos => "T6",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AuditReport {
+    kind: AuditKind,
+    phrase_idx: usize,
+    phrase_text: String,
+    token_idx: usize,
+    surface: String,
+    base: String,
+    reading: String,
+    pos: PartOfSpeech,
+    detail: String,
+}
+
+fn contains_kanji(s: &str) -> bool {
+    s.chars().any(|c| c.is_kanji())
+}
+
+fn contains_ascii_letter(s: &str) -> bool {
+    s.chars().any(|c| c.is_ascii_alphabetic())
+}
+
+fn contains_hyphen_suffix(s: &str) -> bool {
+    // The lexeme-split in token_to_token_info splits on ASCII '-'. Catch bases
+    // that still carry a "-word" tail: either a non-ASCII dash (– —) or a
+    // suffix beginning with another separator.
+    s.contains('-') || s.contains('–') || s.contains('—')
+}
+
+fn audit_token(
+    token: &TokenInfo,
+    phrase_idx: usize,
+    phrase_text: &str,
+    token_idx: usize,
+    out: &mut Vec<AuditReport>,
+) {
+    let surface = token.orthographic_surface_form();
+    let base = token.orthographic_base_form();
+    let phon_base = token.phonological_base_form();
+    let phon_surface = token.phonological_surface_form();
+    let pos = token.part_of_speech().clone();
+
+    let push = |kind: AuditKind, detail: String, field_val: &str, out: &mut Vec<AuditReport>| {
+        out.push(AuditReport {
+            kind,
+            phrase_idx,
+            phrase_text: phrase_text.to_string(),
+            token_idx,
+            surface: surface.to_string(),
+            base: base.to_string(),
+            reading: field_val.to_string(),
+            pos: pos.clone(),
+            detail,
+        });
+    };
+
+    if surface.is_empty() {
+        push(AuditKind::EmptySurface, "empty surface".into(), "", out);
+    }
+    if surface == "*" || base == "*" {
+        push(
+            AuditKind::StarBaseOrSurface,
+            format!("star leak: surface='{surface}' base='{base}'"),
+            "",
+            out,
+        );
+    }
+    if contains_hyphen_suffix(base) {
+        push(
+            AuditKind::LexemeHyphenInBase,
+            format!("base carries hyphen/lexeme tail: '{base}'"),
+            base,
+            out,
+        );
+    }
+    if pos == PartOfSpeech::Unspecified {
+        push(
+            AuditKind::UnspecifiedPos,
+            "POS parsed as Unspecified".into(),
+            "",
+            out,
+        );
+    }
+
+    let is_vocab = pos.is_vocabulary_word();
+    if is_vocab {
+        for (label, field) in [("phon_base", phon_base), ("phon_surface", phon_surface)] {
+            if contains_kanji(field) {
+                push(
+                    AuditKind::ReadingContainsKanji,
+                    format!("{label}='{field}' contains kanji"),
+                    field,
+                    out,
+                );
+            }
+        }
+        // ASCII in a reading is only legitimate for western loanword surface
+        // (rare); flag it so a human can confirm.
+        if contains_ascii_letter(phon_base) || contains_ascii_letter(phon_surface) {
+            push(
+                AuditKind::ReadingHasAscii,
+                format!("ascii in reading: phon_base='{phon_base}' phon_surface='{phon_surface}'"),
+                phon_base,
+                out,
+            );
+        }
+    }
+}
+
+fn run_audit(sample: &[String]) -> Vec<AuditReport> {
+    let mut reports = Vec::new();
+    for (idx, text) in sample.iter().enumerate() {
+        match tokenize_text(text) {
+            Ok(tokens) => {
+                for (token_idx, token) in tokens.iter().enumerate() {
+                    audit_token(token, idx, text, token_idx, &mut reports);
+                }
+            },
+            Err(err) => reports.push(AuditReport {
+                kind: AuditKind::TokenizeError,
+                phrase_idx: idx,
+                phrase_text: text.clone(),
+                token_idx: 0,
+                surface: String::new(),
+                base: String::new(),
+                reading: String::new(),
+                pos: PartOfSpeech::Unspecified,
+                detail: format!("tokenize_text failed: {err:?}"),
+            }),
+        }
+    }
+    reports
+}
+
+fn print_audit(reports: &[AuditReport], sample_size: usize) {
+    eprintln!();
+    eprintln!("=== CORPUS AUDIT (sample={sample_size}) ===");
+    eprintln!("total problems: {}", reports.len());
+
+    let mut counts: HashMap<AuditKind, usize> = HashMap::new();
+    for r in reports {
+        *counts.entry(r.kind).or_default() += 1;
+    }
+    let mut kinds: Vec<AuditKind> = counts.keys().copied().collect();
+    kinds.sort_by_key(|k| k.code());
+
+    for kind in kinds {
+        let n = counts[&kind];
+        eprintln!("{}\t{}", kind.code(), n);
+        for r in reports.iter().filter(|r| r.kind == kind).take(8) {
+            eprintln!(
+                "    [phrase#{} tok#{}] 「{}」(base 「{}」 reading 「{}」 pos {:?}) — {} | phrase: {}",
+                r.phrase_idx,
+                r.token_idx,
+                r.surface,
+                r.base,
+                r.reading,
+                r.pos,
+                r.detail,
+                r.phrase_text.chars().take(60).collect::<String>()
+            );
+        }
+        if kind == AuditKind::ReadingContainsKanji {
+            let mut uniq: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+            for r in reports.iter().filter(|r| r.kind == kind) {
+                uniq.insert(r.base.as_str());
+            }
+            eprintln!("    unique base forms with kanji reading: {:?}", uniq);
+        }
+    }
+}
+
+#[test]
+#[ignore = "corpus audit: scans ALL phrases for kanji-in-reading, dump unique forms"]
+fn audit_full_corpus_kanji_reading() {
+    if !ensure_all_dictionaries() {
+        eprintln!(
+            "skip: cdn artifacts absent \
+             (cdn/ is gitignored; restore via scripts/deploy_cdn.py)"
+        );
+        return;
+    }
+    let all = load_all_phrases();
+    eprintln!("loaded {} total phrases", all.len());
+    let reports = run_audit(&all);
+    print_audit(&reports, all.len());
+}
+
+#[test]
+#[ignore = "corpus audit: samples 10k phrases, dump anomaly summary, run explicitly"]
+fn audit_ten_k_random_phrases() {
+    if !ensure_all_dictionaries() {
+        eprintln!(
+            "skip: cdn artifacts absent \
+             (cdn/ is gitignored; restore via scripts/deploy_cdn.py)"
+        );
+        return;
+    }
+    let all = load_all_phrases();
+    eprintln!("loaded {} total phrases", all.len());
+    let sample = sample_phrases(&all, 10_000);
+    let reports = run_audit(&sample);
+    print_audit(&reports, sample.len());
+}
+
+// ---------- translation-level audit ----------
+
+use origa::domain::{NativeLanguage, TokenTranslation, lookup_tokens_translations};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum TransKind {
+    TokenizeError,
+    EmptyBase,
+    EmptyReadingForKanjiSurface,
+    ReadingContainsKanji,
+    VocabNoTranslation,
+    ConjugatedNoGrammarLabel,
+    ParticleWithContentTranslation,
+    GrammarLabelOnUnconjugatedNoun,
+}
+
+impl TransKind {
+    fn code(self) -> &'static str {
+        match self {
+            TransKind::TokenizeError => "TF1",
+            TransKind::EmptyBase => "TF4",
+            TransKind::EmptyReadingForKanjiSurface => "TR0",
+            TransKind::ReadingContainsKanji => "TR1",
+            TransKind::VocabNoTranslation => "TW1",
+            TransKind::ConjugatedNoGrammarLabel => "TW2",
+            TransKind::ParticleWithContentTranslation => "TR2",
+            TransKind::GrammarLabelOnUnconjugatedNoun => "TR3",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TransReport {
+    kind: TransKind,
+    phrase_idx: usize,
+    token_idx: usize,
+    surface: String,
+    base: String,
+    reading: String,
+    pos: PartOfSpeech,
+    text: String,
+    translation: Option<String>,
+}
+
+fn is_primary_vocab(pos: &PartOfSpeech) -> bool {
+    matches!(
+        pos,
+        PartOfSpeech::Noun | PartOfSpeech::Verb | PartOfSpeech::IAdjective
+    )
+}
+
+fn classify_translation(
+    t: &TokenTranslation,
+    phrase_idx: usize,
+    token_idx: usize,
+    text: &str,
+    out: &mut Vec<TransReport>,
+) {
+    let push = |kind: TransKind, out: &mut Vec<TransReport>| {
+        out.push(TransReport {
+            kind,
+            phrase_idx,
+            token_idx,
+            surface: t.surface_form.clone(),
+            base: t.base_form.clone(),
+            reading: t.reading.clone(),
+            pos: t.pos.clone(),
+            text: text.to_string(),
+            translation: t.translation.clone(),
+        });
+    };
+
+    if t.base_form.is_empty() {
+        push(TransKind::EmptyBase, out);
+    }
+    if t.reading.chars().any(|c| c.is_kanji()) {
+        push(TransKind::ReadingContainsKanji, out);
+    }
+    // After T1 fix, unknown-kanji tokens reach translation with empty reading.
+    // Confirm the empty reading is restricted to kanji-bearing surfaces (the
+    // only legitimate "no kana reading" case) and never hits kana surfaces.
+    if t.reading.is_empty() && t.surface_form.chars().any(|c| c.is_kanji()) {
+        push(TransKind::EmptyReadingForKanjiSurface, out);
+    }
+
+    // Homonym leak: a particle/auxiliary should never carry a content-word
+    // translation unless it is genuinely ambiguous. Particle て/し are
+    // blacklisted in translation.rs; this catches any other particle whose
+    // base_form resolved to a dictionary content word.
+    let is_aux_like = matches!(t.pos, PartOfSpeech::Particle | PartOfSpeech::AuxiliaryVerb);
+    if is_aux_like && t.translation.is_some() {
+        push(TransKind::ParticleWithContentTranslation, out);
+    }
+
+    if is_primary_vocab(&t.pos) {
+        if t.translation.is_none() {
+            push(TransKind::VocabNoTranslation, out);
+        }
+        if t.surface_form != t.base_form && t.grammar_label.is_none() {
+            push(TransKind::ConjugatedNoGrammarLabel, out);
+        }
+        // A noun in pure dictionary form (surface == base) carrying a
+        // grammar_label is suspicious — common nouns should not pick up
+        // grammar labels unless they are grammar nouns (べき, はず, ...).
+        if t.pos == PartOfSpeech::Noun && t.surface_form == t.base_form && t.grammar_label.is_some()
+        {
+            push(TransKind::GrammarLabelOnUnconjugatedNoun, out);
+        }
+    }
+}
+
+fn run_translation_audit(sample: &[String], lang: NativeLanguage) -> Vec<TransReport> {
+    let mut reports = Vec::new();
+    for (idx, text) in sample.iter().enumerate() {
+        match tokenize_text(text) {
+            Ok(tokens) => {
+                let translations = lookup_tokens_translations(&tokens, &lang, text);
+                for (token_idx, t) in translations.iter().enumerate() {
+                    classify_translation(t, idx, token_idx, text, &mut reports);
+                }
+            },
+            Err(_) => reports.push(TransReport {
+                kind: TransKind::TokenizeError,
+                phrase_idx: idx,
+                token_idx: 0,
+                surface: String::new(),
+                base: String::new(),
+                reading: String::new(),
+                pos: PartOfSpeech::Unspecified,
+                text: text.clone(),
+                translation: None,
+            }),
+        }
+    }
+    reports
+}
+
+fn print_translation_audit(reports: &[TransReport], sample_size: usize, lang: &str) {
+    eprintln!();
+    eprintln!("=== TRANSLATION AUDIT ({lang}, sample={sample_size}) ===");
+    eprintln!("total problems: {}", reports.len());
+
+    let mut counts: HashMap<TransKind, usize> = HashMap::new();
+    for r in reports {
+        *counts.entry(r.kind).or_default() += 1;
+    }
+    let mut kinds: Vec<TransKind> = counts.keys().copied().collect();
+    kinds.sort_by_key(|k| k.code());
+    for kind in kinds {
+        eprintln!("{}\t{}", kind.code(), counts[&kind]);
+        for (shown, r) in reports
+            .iter()
+            .filter(|r| r.kind == kind)
+            .take(6)
+            .enumerate()
+        {
+            eprintln!(
+                "    [phrase#{} tok#{}] 「{}」(base 「{}」 reading 「{}」 pos {:?}) tr={:?} gl={:?} | {}",
+                r.phrase_idx,
+                r.token_idx,
+                r.surface,
+                r.base,
+                r.reading,
+                r.pos,
+                r.translation,
+                "",
+                r.text.chars().take(50).collect::<String>()
+            );
+            let _ = shown;
+        }
+    }
+
+    // Group ParticleWithContentTranslation by surface to find homonym leaks.
+    let tr2 = reports
+        .iter()
+        .filter(|r| r.kind == TransKind::ParticleWithContentTranslation);
+    let mut by_surface: HashMap<String, (usize, Option<String>)> = HashMap::new();
+    for r in tr2 {
+        let entry = by_surface.entry(r.surface.clone()).or_insert((0, None));
+        entry.0 += 1;
+        if entry.1.is_none() {
+            entry.1 = r.translation.clone();
+        }
+    }
+    let mut ranked: Vec<_> = by_surface.into_iter().collect();
+    ranked.sort_by_key(|b| std::cmp::Reverse(b.1.0));
+    eprintln!();
+    eprintln!("--- TR2 top-20 particle surfaces with content translation ---");
+    for (surface, (n, tr)) in ranked.into_iter().take(20) {
+        eprintln!("    {n}\t「{surface}」 tr={tr:?}");
+    }
+
+    // Group ConjugatedNoGrammarLabel by base_form to surface systematic gaps.
+    let w2 = reports
+        .iter()
+        .filter(|r| r.kind == TransKind::ConjugatedNoGrammarLabel);
+    let mut by_base: HashMap<String, usize> = HashMap::new();
+    for r in w2 {
+        *by_base.entry(r.base.clone()).or_default() += 1;
+    }
+    let mut ranked: Vec<_> = by_base.into_iter().collect();
+    ranked.sort_by_key(|b| std::cmp::Reverse(b.1));
+    eprintln!();
+    eprintln!("--- TW2 top-20 base forms missing grammar_label ---");
+    for (base, n) in ranked.into_iter().take(20) {
+        eprintln!("    {n}\t{base}");
+    }
+}
+
+#[test]
+#[ignore = "corpus audit: translation-level over 10k sample, run explicitly"]
+fn audit_translation_ten_k_russian() {
+    if !ensure_all_dictionaries() {
+        eprintln!("skip: cdn artifacts absent");
+        return;
+    }
+    let all = load_all_phrases();
+    let sample = sample_phrases(&all, 10_000);
+    let reports = run_translation_audit(&sample, NativeLanguage::Russian);
+    print_translation_audit(&reports, sample.len(), "ru");
+}
+
+// ---------- precise conjugation audit ----------
+//
+// TW2 above over-reports: it conflates true conjugations (食べる → 食べた, where
+// the phonological form changes: タベル → タベタ) with kanji↔kana dictionary-form
+// alternation (事 base / こと surface, where phonological_base == phonological_surface
+// == コト — same word, just rewritten). The latter is NOT a grammar gap: a
+// dictionary-form noun written in kana does not need a grammar_label.
+//
+// This audit keeps ONLY tokens where the phonological form genuinely changes
+// (phonological_base != phonological_surface) — i.e. real conjugations — and
+// reports those still missing a grammar_label, grouped by base_form so the
+// pattern (which conjugation) is visible.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ConjCategory {
+    NounTranslationFix,
+    RealContinuativeGap,
+    StemBeforeAux,
+    HonorificSpecial,
+    KuruIrregular,
+    Other,
+}
+
+impl ConjCategory {
+    fn label(self) -> &'static str {
+        match self {
+            ConjCategory::NounTranslationFix => "noun-translation-fix",
+            ConjCategory::RealContinuativeGap => "real-continuative-gap",
+            ConjCategory::StemBeforeAux => "stem-before-aux",
+            ConjCategory::HonorificSpecial => "honorific-special",
+            ConjCategory::KuruIrregular => "kuru-irregular",
+            ConjCategory::Other => "other",
+        }
+    }
+}
+
+const HONORIFIC_BASES: &[&str] = &[
+    "為さる",
+    "なさる",
+    "下さる",
+    "くださる",
+    "御座る",
+    "ござる",
+    "いらっしゃる",
+];
+
+fn classify_conjugation(
+    base: &str,
+    next_pos: Option<&PartOfSpeech>,
+    surface_in_dict: bool,
+    base_in_dict: bool,
+) -> ConjCategory {
+    if base == "来る" {
+        return ConjCategory::KuruIrregular;
+    }
+    if HONORIFIC_BASES.contains(&base) {
+        return ConjCategory::HonorificSpecial;
+    }
+    if matches!(next_pos, Some(PartOfSpeech::AuxiliaryVerb)) {
+        return ConjCategory::StemBeforeAux;
+    }
+    if surface_in_dict {
+        return ConjCategory::NounTranslationFix;
+    }
+    if base_in_dict {
+        ConjCategory::RealContinuativeGap
+    } else {
+        ConjCategory::Other
+    }
+}
+
+fn run_conjugation_audit(sample: &[String], lang: NativeLanguage) {
+    use origa::dictionary::vocabulary::get_translation;
+
+    let mut total_real_conj = 0usize;
+    let mut total_no_label = 0usize;
+    let mut by_category: HashMap<ConjCategory, usize> = HashMap::new();
+    let mut examples_by_category: HashMap<ConjCategory, Vec<String>> = HashMap::new();
+
+    // POS verification gates: collect actual POS for tokens whose POS assumption
+    // drives guard logic (て/た/ば) and format_map keys (なさい/ございます/いらっしゃい).
+    let mut pos_gate_te_ta_ba: HashMap<&str, HashMap<String, usize>> = HashMap::new();
+    let mut pos_gate_honorific: HashMap<&str, HashMap<String, usize>> = HashMap::new();
+    const TE_TA_BA_SURFACES: &[&str] = &["て", "た", "ば"];
+    const HONORIFIC_SURFACES: &[&str] = &["なさい", "ございます", "いらっしゃい", "ください"];
+
+    for text in sample.iter() {
+        let tokens = match tokenize_text(text) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let translations = lookup_tokens_translations(&tokens, &lang, text);
+        for (token_idx, token) in tokens.iter().enumerate() {
+            let pos = token.part_of_speech();
+            // POS verification gates — collect regardless of conjugation status.
+            let surface = token.orthographic_surface_form();
+            if let Some(key) = TE_TA_BA_SURFACES.iter().find(|s| **s == surface) {
+                *pos_gate_te_ta_ba
+                    .entry(*key)
+                    .or_default()
+                    .entry(format!("{pos:?}"))
+                    .or_default() += 1;
+            }
+            if let Some(key) = HONORIFIC_SURFACES.iter().find(|s| **s == surface) {
+                *pos_gate_honorific
+                    .entry(*key)
+                    .or_default()
+                    .entry(format!("{pos:?}"))
+                    .or_default() += 1;
+            }
+
+            if !is_primary_vocab(pos) {
+                continue;
+            }
+            let orth_base = token.orthographic_base_form();
+            if orth_base == surface {
+                continue;
+            }
+            let phon_base = token.phonological_base_form();
+            let phon_surface = token.phonological_surface_form();
+            if phon_base == phon_surface {
+                continue;
+            }
+            total_real_conj += 1;
+            let tr = translations.get(token_idx);
+            let has_label = tr.is_some_and(|t| t.grammar_label.is_some());
+            if has_label {
+                continue;
+            }
+            total_no_label += 1;
+
+            let next_pos = tokens
+                .get(token_idx + 1)
+                .map(|t| t.part_of_speech().clone());
+            let surface_in_dict = get_translation(surface, &lang).is_some();
+            let base_in_dict = get_translation(orth_base, &lang).is_some();
+            let category =
+                classify_conjugation(orth_base, next_pos.as_ref(), surface_in_dict, base_in_dict);
+            *by_category.entry(category).or_default() += 1;
+            let examples = examples_by_category.entry(category).or_default();
+            if examples.len() < 6 {
+                examples.push(format!(
+                    "{surface}({phon_surface}) <- {orth_base} | next_pos={next_pos:?} | {text}",
+                    text = text.chars().take(40).collect::<String>()
+                ));
+            }
+        }
+    }
+
+    eprintln!();
+    eprintln!(
+        "=== CONJUGATION AUDIT (sample={}, lang={:?}) ===",
+        sample.len(),
+        lang
+    );
+    eprintln!(
+        "real conjugations: {}, without grammar_label: {}",
+        total_real_conj, total_no_label
+    );
+
+    eprintln!();
+    eprintln!("--- category breakdown ---");
+    let mut cats: Vec<ConjCategory> = by_category.keys().copied().collect();
+    cats.sort_by_key(|c| c.label());
+    for cat in cats {
+        let n = by_category[&cat];
+        let pct = (n as f64 / total_no_label.max(1) as f64) * 100.0;
+        eprintln!("    {n:>6} ({pct:5.1}%)  {}", cat.label());
+        if let Some(exs) = examples_by_category.get(&cat) {
+            for ex in exs.iter().take(4) {
+                eprintln!("        {ex}");
+            }
+        }
+    }
+
+    eprintln!();
+    eprintln!("--- POS verification gate: て/た/ば ---");
+    for s in TE_TA_BA_SURFACES {
+        if let Some(pos_counts) = pos_gate_te_ta_ba.get(s) {
+            eprintln!("    {s}: {pos_counts:?}");
+        }
+    }
+    eprintln!("--- POS verification gate: honorific surfaces ---");
+    for s in HONORIFIC_SURFACES {
+        if let Some(pos_counts) = pos_gate_honorific.get(s) {
+            eprintln!("    {s}: {pos_counts:?}");
+        }
+    }
+}
+
+#[test]
+#[ignore = "corpus audit: precise conjugation gaps over full corpus, run explicitly"]
+fn audit_conjugation_full_corpus_russian() {
+    if !ensure_all_dictionaries() {
+        eprintln!("skip: cdn artifacts absent");
+        return;
+    }
+    let all = load_all_phrases();
+    eprintln!("loaded {} total phrases", all.len());
+    run_conjugation_audit(&all, NativeLanguage::Russian);
+}

--- a/scripts/add_honorific_grammar_rules.py
+++ b/scripts/add_honorific_grammar_rules.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Add honorific suppletive grammar rules (なさい / ください / いらっしゃい).
+
+These verbs (為さる, 下さる, いらっしゃる) have irregular imperative forms that
+do NOT follow the regular godan imperative paradigm (為され / 下され /
+いらっしゃれ). They are matched by lemma via the suppletive FormatAction
+variants `VerbToNasai` / `VerbToKudasai` / `VerbToIrasshai` (defined in
+`origa/src/dictionary/grammar.rs` and implemented in
+`origa/src/domain/grammar/forms_verb/conjugations.rs`).
+
+A wrong lemma returns Err from the variant; `find_format_map_matches` then
+filters the rule out via `formatted_rule_matches_text`'s Err-as-no-match
+(`origa/src/domain/grammar/mod.rs:195`).
+
+The corpus audit POS verification gate confirmed the surface tokens
+(なさい / ください / いらっしゃい) are all classified by Lindera as Verb, so the
+format_map key is `Verb`. ございます has 0 standalone occurrences in the
+corpus and is intentionally not added.
+
+Idempotent: re-running detects the rules by title and skips insertion.
+Always writes a timestamped backup before overwriting (grammar.json is
+gitignored production data).
+"""
+import json
+import shutil
+import time
+from pathlib import Path
+
+GRAMMAR_PATH = Path(__file__).resolve().parents[1] / "cdn" / "grammar" / "grammar.json"
+
+HONORIFIC_RULES = [
+    {
+        "rule_id": "01KXAX0VRPNSR58CP87HJPXYMM",
+        "title_en": "為さる→なさい (imperative polite)",
+        "title_ru": "為さる→なさい (вежливый императив)",
+        "short_description_en": "Polite imperative of the honorific verb なさる",
+        "short_description_ru": "Вежливый императив уважительного глагола なさる",
+        "format_action": "VerbToNasai",
+    },
+    {
+        "rule_id": "01KXAX0VRPXYAP6KYN9P7CJTPA",
+        "title_en": "下さる→ください (imperative polite)",
+        "title_ru": "下さる→ください (вежливый императив)",
+        "short_description_en": "Polite imperative of the honorific verb くださる",
+        "short_description_ru": "Вежливый императив уважительного глагола くださる",
+        "format_action": "VerbToKudasai",
+    },
+    {
+        "rule_id": "01KXAX0VRP192A16Z4NJ2WK9GA",
+        "title_en": "いらっしゃる→いらっしゃい (imperative greeting)",
+        "title_ru": "いらっしゃる→いらっしゃい (императив-приветствие)",
+        "short_description_en": "Imperative of the honorific verb いらっしゃる (used in greetings)",
+        "short_description_ru": "Императив уважительного глагола いらっしゃる (в приветствиях)",
+        "format_action": "VerbToIrasshai",
+    },
+]
+
+
+def make_rule(spec):
+    return {
+        "rule_id": spec["rule_id"],
+        "level": "N4",
+        "content": {
+            "English": {
+                "title": spec["title_en"],
+                "short_description": spec["short_description_en"],
+                "explanation": (
+                    f"This is a suppletive imperative form of the honorific verb. "
+                    f"It is matched by lemma only; the FormatAction `{spec['format_action']}` "
+                    "returns Err for any other verb."
+                ),
+                "how_to_form": "",
+                "examples": "",
+                "nuances": "",
+                "pro_tip": "",
+            },
+            "Russian": {
+                "title": spec["title_ru"],
+                "short_description": spec["short_description_ru"],
+                "explanation": (
+                    "Супплетивная императивная форма уважительного глагола. "
+                    "Сматчивается только по лемме; FormatAction "
+                    f"`{spec['format_action']}` возвращает Err для любого другого глагола."
+                ),
+                "how_to_form": "",
+                "examples": "",
+                "nuances": "",
+                "pro_tip": "",
+            },
+        },
+        "format_map": {"Verb": [{spec["format_action"]: {}}]},
+    }
+
+
+def main():
+    raw = GRAMMAR_PATH.read_text(encoding="utf-8")
+    if raw.startswith("\ufeff"):
+        raw = raw.lstrip("\ufeff")
+    data = json.loads(raw)
+    rules = data["grammar"]
+
+    existing_titles = {r["content"]["English"]["title"] for r in rules}
+    added = []
+    for spec in HONORIFIC_RULES:
+        if spec["title_en"] in existing_titles:
+            print(f"rule「{spec['title_en']}」already present, skipping")
+            continue
+        rules.append(make_rule(spec))
+        added.append(spec["title_en"])
+
+    if not added:
+        print("nothing to add")
+        return
+
+    backup_path = GRAMMAR_PATH.with_suffix(
+        f".json.bak.{time.strftime('%Y%m%d-%H%M%S')}"
+    )
+    shutil.copy2(GRAMMAR_PATH, backup_path)
+
+    out = json.dumps(data, ensure_ascii=False, indent=2)
+    GRAMMAR_PATH.write_text(out, encoding="utf-8")
+    print(f"backup: {backup_path.name}")
+    print(f"added: {added}")
+    print(f"total rules now: {len(rules)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/add_i_adjective_grammar_rules.py
+++ b/scripts/add_i_adjective_grammar_rules.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Add grammar rules for uncovered i-adjective conjugations.
+
+Adds 3 rules to cdn/grammar/grammar.json:
+  1. New rule "～く (adverbial)" — i-adjective ku-form (AdjectiveToKu).
+  2. New rule "～かった (past)" — i-adjective past (AdjectiveToKatta).
+  3. Patches existing rule "～て／～くて／～で" with a format_map so its
+     i-adjective (AdjectiveToKute) and na-adjective (AdjectiveToDe) branches
+     finally match (the rule existed but was dead — no format_map).
+
+Verb format_map is intentionally NOT added to the te-form rule: verb te-form
+is already covered by 37 other rules, and adding it here would create
+over-matching and shift the grammar_label selected by the resolver's
+longest-format scoring, breaking existing verb-te tests.
+
+Idempotent: re-running detects the new rules by title and skips insertion.
+"""
+import json
+import shutil
+import sys
+from pathlib import Path
+
+GRAMMAR_PATH = Path(__file__).resolve().parents[1] / "cdn" / "grammar" / "grammar.json"
+
+KU_TITLE_EN = "～く (adverbial)"
+KU_TITLE_RU = "～く (наречие)"
+KATTA_TITLE_EN = "～かった (past)"
+KATTA_TITLE_RU = "～かった (прошедшее)"
+TE_TITLE_EN_MARKER = "～て／～くて／～で"
+
+# The exact format_map the te-form rule must end up carrying. Used both for
+# applying the patch and for verifying it on re-runs (precise idempotency).
+TE_EXPECTED_FORMAT_MAP = {
+    "IAdjective": [{"AdjectiveToKute": {}}],
+    "NaAdjective": [{"AdjectiveToDe": {}}],
+}
+
+KU_RULE_ID = "01KX9DBYXX0NSA9SA7SJ2WWKWV"
+KATTA_RULE_ID = "01KX9DBYXXMTPRG5ARM7CT0TRW"
+
+
+def make_rule(rule_id, level, en, ru, format_map=None, keywords=None):
+    rule = {
+        "rule_id": rule_id,
+        "level": level,
+        "content": {"English": en, "Russian": ru},
+    }
+    if format_map is not None:
+        rule["format_map"] = format_map
+    if keywords is not None:
+        rule["keywords"] = keywords
+    return rule
+
+
+def main():
+    raw = GRAMMAR_PATH.read_text(encoding="utf-8")
+    if raw.startswith("\ufeff"):
+        raw = raw.lstrip("\ufeff")
+    data = json.loads(raw)
+    rules = data["grammar"]
+
+    existing_titles = {
+        r["content"]["English"]["title"] for r in rules
+    }
+
+    added = []
+
+    # 1. i-adjective ku-form (adverbial)
+    if KU_TITLE_EN not in existing_titles:
+        rules.append(make_rule(
+            KU_RULE_ID,
+            "N5",
+            {
+                "title": KU_TITLE_EN,
+                "short_description": "I-adjective adverbial form",
+                "explanation": (
+                    "Dropping the final `い` of an i-adjective and adding `く` "
+                    "turns it into an adverb that modifies a following verb. "
+                    "This is the adverbial (連用形) form."
+                ),
+                "how_to_form": (
+                    "| Word type | Rule | Example |\n"
+                    "|-----------|------|---------|\n"
+                    "| I-adjectives | Remove い → く | 早い → 早く |\n"
+                    "| Exception: いい | よく | いい → よく |"
+                ),
+                "examples": (
+                    "```\n早く歩いてください。\nPlease walk quickly.\n```\n\n"
+                    "```\nたくさん食べました。\nI ate a lot.\n```"
+                ),
+                "nuances": (
+                    "- ❌ Leaving the `い` and adding `く` (早い速く) → ✅ 早く\n"
+                    "- 🔄 いい (good) irregularly becomes よく, not いく"
+                ),
+                "pro_tip": (
+                    "The ku-form is the bridge from adjectives to adverbs. "
+                    "Most i-adjectives behave regularly; only いい → よく is irregular."
+                ),
+            },
+            {
+                "title": KU_TITLE_RU,
+                "short_description": "Наречная форма и-прилагательного",
+                "explanation": (
+                    "Убрав конечное `い` у и-прилагательного и добавив `く`, "
+                    "получаем наречие, которое определяет последующий глагол. "
+                    "Это наречная (連用形) форма."
+                ),
+                "how_to_form": (
+                    "| Тип слова | Правило | Пример |\n"
+                    "|-----------|---------|--------|\n"
+                    "| И-прилагательные | Убрать い → く | 早い → 早く |\n"
+                    "| Исключение: いい | よく | いい → よく |"
+                ),
+                "examples": (
+                    "```\n早く歩いてください。\nПожалуйста, идите быстрее.\n```\n\n"
+                    "```\nたくさん食べました。\nЯ много съел.\n```"
+                ),
+                "nuances": (
+                    "- ❌ Оставлять `い` и добавлять `く` (早い速く) → ✅ 早く\n"
+                    "- 🔄 いい (хороший) неправильно становится よく, а не いく"
+                ),
+                "pro_tip": (
+                    "Ku-форма — мост от прилагательных к наречиям. "
+                    "Большинство и-прилагательных регулярны; только いい → よく — исключение."
+                ),
+            },
+            format_map={"IAdjective": [{"AdjectiveToKu": {}}]},
+        ))
+        added.append(KU_TITLE_EN)
+
+    # 2. i-adjective past (katta-form)
+    if KATTA_TITLE_EN not in existing_titles:
+        rules.append(make_rule(
+            KATTA_RULE_ID,
+            "N5",
+            {
+                "title": KATTA_TITLE_EN,
+                "short_description": "I-adjective past tense",
+                "explanation": (
+                    "To express the past tense of an i-adjective, drop the final "
+                    "`い` and add `かった`. The negative past is `～なかった`."
+                ),
+                "how_to_form": (
+                    "| Form | Rule | Example |\n"
+                    "|------|------|---------|\n"
+                    "| Affirmative past | Remove い → かった | 高い → 高かった |\n"
+                    "| Negative past | Remove い → なかった | 高い → 高くなかった |"
+                ),
+                "examples": (
+                    "```\n昨日の天気は良かった。\nYesterday's weather was good.\n```\n\n"
+                    "```\nこの本は面白くなかった。\nThis book was not interesting.\n```"
+                ),
+                "nuances": (
+                    "- ❌ Adding だった to an i-adjective (高いだった) → ✅ 高かった\n"
+                    "- 🔄 いい → よかった (irregular past, not いかった)"
+                ),
+                "pro_tip": (
+                    "The katta-form is the i-adjective equivalent of the verb た-form. "
+                    "Remember いい → よかった as the only common irregular."
+                ),
+            },
+            {
+                "title": KATTA_TITLE_RU,
+                "short_description": "Прошедшее время и-прилагательного",
+                "explanation": (
+                    "Чтобы выразить прошедшее время и-прилагательного, нужно убрать "
+                    "конечное `い` и добавить `かった`. Отрицательное прошедшее — `～なかった`."
+                ),
+                "how_to_form": (
+                    "| Форма | Правило | Пример |\n"
+                    "|-------|---------|--------|\n"
+                    "| Утвердительное прошедшее | Убрать い → かった | 高い → 高かった |\n"
+                    "| Отрицательное прошедшее | Убрать い → なかった | 高い → 高くなかった |"
+                ),
+                "examples": (
+                    "```\n昨日の天気は良かった。\nВчера погода была хорошей.\n```\n\n"
+                    "```\nこの本は面白くなかった。\nЭта книга была неинтересной.\n```"
+                ),
+                "nuances": (
+                    "- ❌ Добавлять だった к и-прилагательному (高いだった) → ✅ 高かった\n"
+                    "- 🔄 いい → よかった (неправильное прошедшее, не いかった)"
+                ),
+                "pro_tip": (
+                    "Katta-форма — аналог た-формы глагола для и-прилагательных. "
+                    "Запомни いい → よかった как единственное частое исключение."
+                ),
+            },
+            format_map={"IAdjective": [{"AdjectiveToKatta": {}}]},
+        ))
+        added.append(KATTA_TITLE_EN)
+
+    # 3. Patch existing ～て／～くて／～で rule with an adjective-only format_map.
+    te_rule = next(
+        (r for r in rules if r["content"]["English"]["title"] == TE_TITLE_EN_MARKER),
+        None,
+    )
+    if te_rule is None:
+        print(f"ERROR: te-form rule {TE_TITLE_EN_MARKER!r} not found", file=sys.stderr)
+        sys.exit(1)
+    if te_rule.get("format_map") == TE_EXPECTED_FORMAT_MAP:
+        print("te-form rule already carries the expected format_map, skipping patch")
+    else:
+        # IAdjective + NaAdjective only; verb te-form stays covered by other rules.
+        te_rule["format_map"] = TE_EXPECTED_FORMAT_MAP
+        added.append(f"(patched format_map on {TE_TITLE_EN_MARKER})")
+
+    # Always create a timestamped backup before overwriting — grammar.json is
+    # gitignored production data, so this script is the only mutation point.
+    backup_path = GRAMMAR_PATH.with_suffix(
+        f".json.bak.{__import__('time').strftime('%Y%m%d-%H%M%S')}"
+    )
+    shutil.copy2(GRAMMAR_PATH, backup_path)
+
+    out = json.dumps(data, ensure_ascii=False, indent=2)
+    GRAMMAR_PATH.write_text(out, encoding="utf-8")
+    print(f"backup written: {backup_path.name}")
+    print(f"added/patched: {added}")
+    print(f"total rules now: {len(rules)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/add_orphan_iadj_grammar_rules.py
+++ b/scripts/add_orphan_iadj_grammar_rules.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Add grammar rules for orphan i-adjective FormatAction variants.
+
+Diagnostic on residual conjugation gaps (4 040 unlabeled real-conjugations)
+revealed that 4 FormatAction variants are defined and implemented in code
+(`origa/src/dictionary/grammar.rs`) but exposed by NO grammar.json rule:
+
+  - `AdjectiveToGaru`     — i-adj stem + がる ("to feel/seem that way"):
+                             怖い → 怖がる. The te-variant (怖がって) is matched
+                             via `formatted_conjugation_variants`.
+  - `AdjectiveToKunai`    — i-adj negative: 高い → 高くない.
+  - `AdjectiveToKunakatta` — i-adj negative past: 高い → 高くなかった.
+  - `AdjectiveToKereba`   — i-adj conditional: 高い → 高ければ.
+
+Each new rule carries a format_map on IAdjective only. Verb/NaAdjective keys
+are intentionally NOT added — the verb forms (negative, past, conditional)
+are already covered by dedicated verb rules, and adding them here would
+create over-matching via longest-format scoring.
+
+Idempotent: re-running detects the rules by title and skips insertion.
+Always writes a timestamped backup before overwriting (grammar.json is
+gitignored production data).
+"""
+import json
+import shutil
+import time
+from pathlib import Path
+
+GRAMMAR_PATH = Path(__file__).resolve().parents[1] / "cdn" / "grammar" / "grammar.json"
+
+RULES = [
+    {
+        "rule_id": "01KXB1CYH9BT21BNG51G47YJBH",
+        "title_en": "～がる (i-adjective feeling)",
+        "title_ru": "～がる (чувство и-прилагательного)",
+        "short_description_en": "i-adjective stem + がる: to feel/seem that way",
+        "short_description_ru": "основа и-прилагательного + がる: испытывать чувство",
+        "format_action": "AdjectiveToGaru",
+    },
+    {
+        "rule_id": "01KXB1CYH9ZDY4GMZW4FQVE7BH",
+        "title_en": "～くない (i-adjective negative)",
+        "title_ru": "～くない (отрицание и-прилагательного)",
+        "short_description_en": "i-adjective negative form: 高い → 高くない",
+        "short_description_ru": "отрицательная форма и-прилагательного: 高い → 高くない",
+        "format_action": "AdjectiveToKunai",
+    },
+    {
+        "rule_id": "01KXB1CYH9R2G7VEQ4TBFNJNQ5",
+        "title_en": "～くなかった (i-adjective negative past)",
+        "title_ru": "～くなかった (отрицательное прошедшее и-прилагательного)",
+        "short_description_en": "i-adjective negative past: 高い → 高くなかった",
+        "short_description_ru": "отрицательное прошедшее и-прилагательного: 高い → 高くなかった",
+        "format_action": "AdjectiveToKunakatta",
+    },
+    {
+        "rule_id": "01KXB1CYH9NJNT9XRBR9ER06XN",
+        "title_en": "～ければ (i-adjective conditional)",
+        "title_ru": "～ければ (условие и-прилагательного)",
+        "short_description_en": "i-adjective conditional: 高い → 高ければ",
+        "short_description_ru": "условная форма и-прилагательного: 高い → 高ければ",
+        "format_action": "AdjectiveToKereba",
+    },
+]
+
+
+def make_bilingual(short_en, short_ru):
+    return {
+        "English": {
+            "title": "",
+            "short_description": short_en,
+            "explanation": "",
+            "how_to_form": "",
+            "examples": "",
+            "nuances": "",
+            "pro_tip": "",
+        },
+        "Russian": {
+            "title": "",
+            "short_description": short_ru,
+            "explanation": "",
+            "how_to_form": "",
+            "examples": "",
+            "nuances": "",
+            "pro_tip": "",
+        },
+    }
+
+
+def make_rule(spec):
+    content = make_bilingual(spec["short_description_en"], spec["short_description_ru"])
+    content["English"]["title"] = spec["title_en"]
+    content["Russian"]["title"] = spec["title_ru"]
+    return {
+        "rule_id": spec["rule_id"],
+        "level": "N4",
+        "content": content,
+        "format_map": {"IAdjective": [{spec["format_action"]: {}}]},
+    }
+
+
+def main():
+    raw = GRAMMAR_PATH.read_text(encoding="utf-8")
+    if raw.startswith("\ufeff"):
+        raw = raw.lstrip("\ufeff")
+    data = json.loads(raw)
+    rules = data["grammar"]
+
+    existing_titles = {r["content"]["English"]["title"] for r in rules}
+    added = []
+    for spec in RULES:
+        if spec["title_en"] in existing_titles:
+            print(f"rule「{spec['title_en']}」already present, skipping")
+            continue
+        rules.append(make_rule(spec))
+        added.append(spec["title_en"])
+
+    if not added:
+        print("nothing to add")
+        return
+
+    backup_path = GRAMMAR_PATH.with_suffix(
+        f".json.bak.{time.strftime('%Y%m%d-%H%M%S')}"
+    )
+    shutil.copy2(GRAMMAR_PATH, backup_path)
+
+    out = json.dumps(data, ensure_ascii=False, indent=2)
+    GRAMMAR_PATH.write_text(out, encoding="utf-8")
+    print(f"backup: {backup_path.name}")
+    print(f"added: {added}")
+    print(f"total rules now: {len(rules)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/add_renyokei_grammar_rule.py
+++ b/scripts/add_renyokei_grammar_rule.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Add the masu-stem (ren'yōkei) continuative grammar rule.
+
+This rule carries ONLY content (title/short_description/explanation/...) — it
+deliberately has NO format_map. The reason: a format_map entry with
+{Verb: [VerbToStem]} would over-match in Path B (`detect_format_map_rules` →
+`enrich_phrases_with_grammar`) because `format(食べる)="食べ"` and
+`text.contains("食べ")` is true for 食べます/食べて/食べた.
+
+The rule is matched only by the special-case resolver `resolve_masu_stem_match`
+in `translation.rs` (analogous to how `resolve_sou_da_match` matches the
+そうだ rule by title without going through format_map). Without a format_map,
+`find_format_map_matches` filters it out via `rule.has_format_map()`, so
+Path B is unaffected.
+
+Idempotent: re-running detects the rule by title and skips insertion. Always
+writes a timestamped backup before overwriting (grammar.json is gitignored
+production data).
+"""
+import json
+import shutil
+import time
+from pathlib import Path
+
+GRAMMAR_PATH = Path(__file__).resolve().parents[1] / "cdn" / "grammar" / "grammar.json"
+
+REN_TITLE_EN = "～連用形 (continuative/noun)"
+REN_TITLE_RU = "～連用形 (continuative/noun)"
+REN_RULE_ID = "01KXAEW17E1B4N421Y8PCPEYHK"
+
+
+def make_rule():
+    en = {
+        "title": REN_TITLE_EN,
+        "short_description": "Verb masu-stem used as continuative or noun",
+        "explanation": (
+            "The ren'yōkei (連用形, masu-stem) of a verb has two standalone uses "
+            "when it is NOT followed by an auxiliary (ます/て/た/ば/...): it can "
+            "join clauses as a continuative (走り、跳ぶ) or function as a noun "
+            "(願い=request, 暮らし=living, 話=story). When the stem appears on its "
+            "own — not as the base of another conjugation — it carries this label."
+        ),
+        "how_to_form": (
+            "| Group | Rule | Example |\n"
+            "|-------|------|---------|\n"
+            "| Group 1 (う-verbs) | Replace final う-row sound with い-row | 行く → 行き |\n"
+            "| Group 2 (る-verbs) | Remove る | 食べる → 食べ |\n"
+            "| Group 3 (irregular) | する → し / くる → き | する → し |"
+        ),
+        "examples": (
+            "```\n返事を願いします。\nI ask for a reply.\n```\n\n"
+            "```\n暮らしは楽しい。\nLife is enjoyable.\n```\n\n"
+            "```\n話を聞かせて。\nLet me hear the story.\n```"
+        ),
+        "nuances": (
+            "- ❌ Treating a stem followed by ます/て/た as continuative → ✅ Those "
+            "are polite/te/past forms covered by their own rules.\n"
+            "- 🔄 Many stems have lexicalized as independent nouns (願い, 暮らし, "
+            "話) — both readings are valid; the noun entry gives the translation."
+        ),
+        "pro_tip": (
+            "If a verb stem stands on its own (next token is NOT ます/て/た/ば), "
+            "it is either continuing the previous clause or has been noun-ified. "
+            "Look up the stem in the dictionary for the noun meaning."
+        ),
+    }
+    ru = {
+        "title": REN_TITLE_RU,
+        "short_description": "Masu-основа глагола как деепричастие или существительное",
+        "explanation": (
+            "Ren'yōkei (連用形, masu-основа) глагола имеет два самостоятельных "
+            "употребления, когда за ней НЕ следует вспомогательный глагол "
+            "(ます/て/た/ば/...): соединение предложений как деепричастие "
+            "(走り、跳ぶ) или функционирование как существительное "
+            "(願い=просьба, 暮らし=жизнь, 話=рассказ). Когда основа стоит "
+            "отдельно — не как база другой спряжённой формы — она несёт эту метку."
+        ),
+        "how_to_form": (
+            "| Группа | Правило | Пример |\n"
+            "|--------|---------|--------|\n"
+            "| Группа 1 (う-глаголы) | Заменить последний звук у-ряда на и-ряд | 行く → 行き |\n"
+            "| Группа 2 (る-глаголы) | Убрать る | 食べる → 食べ |\n"
+            "| Группа 3 (исключения) | する → し / くる → き | する → し |"
+        ),
+        "examples": (
+            "```\n返事を願いします。\nЯ прошу ответа.\n```\n\n"
+            "```\n暮らしは楽しい。\nЖизнь приятна.\n```\n\n"
+            "```\n話を聞かせて。\nДай мне послушать рассказ.\n```"
+        ),
+        "nuances": (
+            "- ❌ Трактовать основу перед ます/て/た как деепричастие → ✅ Это "
+            "вежливая/te/прошедшая формы, у них свои правила.\n"
+            "- 🔄 Многие основы лексикализировались как самостоятельные "
+            "существительные (願い, 暮らし, 話) — оба прочтения допустимы; "
+            "словарная статья существительного даёт перевод."
+        ),
+        "pro_tip": (
+            "Если masu-основа глагола стоит отдельно (следующий токен НЕ "
+            "ます/て/た/ば), она либо продолжает предыдущее предложение, либо "
+            "превратилась в существительное. Поищи основу в словаре для "
+            "значения-существительного."
+        ),
+    }
+    return {
+        "rule_id": REN_RULE_ID,
+        "level": "N4",
+        "content": {"English": en, "Russian": ru},
+    }
+
+
+def main():
+    raw = GRAMMAR_PATH.read_text(encoding="utf-8")
+    if raw.startswith("\ufeff"):
+        raw = raw.lstrip("\ufeff")
+    data = json.loads(raw)
+    rules = data["grammar"]
+
+    existing_titles = {r["content"]["English"]["title"] for r in rules}
+    if REN_TITLE_EN in existing_titles:
+        print(f"rule「{REN_TITLE_EN}」already present, skipping")
+        return
+
+    rules.append(make_rule())
+
+    backup_path = GRAMMAR_PATH.with_suffix(
+        f".json.bak.{time.strftime('%Y%m%d-%H%M%S')}"
+    )
+    shutil.copy2(GRAMMAR_PATH, backup_path)
+
+    out = json.dumps(data, ensure_ascii=False, indent=2)
+    GRAMMAR_PATH.write_text(out, encoding="utf-8")
+    print(f"backup: {backup_path.name}")
+    print(f"added rule「{REN_TITLE_EN}」 (id={REN_RULE_ID})")
+    print(f"total rules now: {len(rules)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Corpus-driven audit of 156 231 phrases surfaced and fixed two classes of bugs in the tokenizer / grammar pipeline. Conjugations without a grammar_label dropped 42 550 -> 24 322 (-42.9%); real gaps (excluding stems-before-auxiliary that never need a label) dropped ~27 668 -> ~9 440 (-66%).

## What changed

### Bug fix: kanji leaking into phonological reading (T1)

Lindera emits Unknown-word tokens (lex_type Unknown, all metadata `*`) for standalone kanji not in UniDic on their own - common in character names (杏璃, 光璃) and rare kanji (蕩, 繖). The phonological form fallback copied the kanji surface verbatim as the "reading", so furigana rendered kanji-over-kanji. Fixed via `reading_fallback_for_surface` helper + None-mapping at the furigana boundary. Corpus impact: 1354 -> 0.

### Conjugation gap coverage (data + resolver)

Diagnostic on the 42 550 residual uncovered three root causes, all fixed:

1. **Orphan FormatAction variants** - defined in code, used by no grammar.json rule. Added rules for 7 i-adjective forms (ku-adverbial, katta-past, kute-te, garu-feeling, kunai-negative, kunakatta-negative-past, kereba-conditional).
2. **Masu-stem continuative** - `resolve_masu_stem_match` special-case resolver (analogous to `resolve_sou_da_match`) handles verb stems standing on their own. Bypasses `find_format_map_matches` to avoid Path B over-matching. Also drives a translation fallback: standalone masu-stems whose surface exists as a noun prefer the noun translation.
3. **Suppletive honorific imperatives** - three new FormatAction variants (VerbToNasai, VerbToKudasai, VerbToIrasshai) with Err-on-wrong-lemma semantics for 為さる／下さる／いらっしゃる.

Grammar rules added via idempotent Python scripts under `scripts/`. Each writes a timestamped backup before mutating the gitignored `cdn/grammar/grammar.json`. CDN data already deployed separately.

### Corpus audit harness

Manual discovery instrument (`origa/tests/corpus_audit.rs`, all `#[ignore]`) - samples phrases from all chunks and classifies anomalies at both TokenInfo and TokenTranslation levels, with POS verification gates for resolver guard assumptions.

## Verification

| Check | Status |
|-------|--------|
| `cargo test -p origa` | 1515 passed, 0 failed (+21 from baseline) |
| `cargo clippy -p origa --all-targets -- -D warnings` | clean |
| `cargo fmt -p origa --check` | clean |
| Path B regression (`detect_format_map_rules` tests) | intact |
| Corpus audit (156 231 phrases) | kanji-in-reading 1354 -> 0; conjugations without label 42 550 -> 24 322 |

## Test plan

- [x] New unit tests for suppletive format functions (positive + Err-on-wrong-lemma)
- [x] New integration tests for masu-stem continuative (+ anti-regression before ます/て)
- [x] New integration tests for i-adjective forms (ku/katta/kute/garu/kunai/kunakatta/kereba)
- [x] New integration tests for honorific suppletive labels
- [x] Existing 1494 tests remain green

🤖 Generated with respect to project conventions (no emoji in code, English comments, rstest where applicable, no unwrap in production).
