### PR TITLE
fix(updater+ci+csp): working auto-update, dedup release assets, telemetry CSP

### DIFF
--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -145,12 +145,15 @@ jobs:
                   VERSION: ${{ inputs.version }}
               run: |
                   # Tauri emits Origa_<version>_x64-setup.exe (+ .exe.sig updater
-                  # signature). Mirror to a fixed-name alias so the landing
-                  # page's /releases/latest/download/Origa_x64-setup.exe link
-                  # resolves on every release — GitHub's "latest" download URL
-                  # requires a filename that does not change between releases.
-                  cp "Origa_${VERSION}_x64-setup.exe" "Origa_x64-setup.exe"
-                  [ -f "Origa_${VERSION}_x64-setup.exe.sig" ] && cp "Origa_${VERSION}_x64-setup.exe.sig" "Origa_x64-setup.exe.sig" || true
+                  # signature). Rename to a fixed name so the landing page's
+                  # /releases/latest/download/Origa_x64-setup.exe link resolves on
+                  # every release — GitHub's "latest" download URL requires a
+                  # filename that does not change between releases. Single-name
+                  # (no versioned copy) per ADR-025 addendum: the release tag
+                  # already identifies the version, and duplicate assets clutter
+                  # the release UI.
+                  mv "Origa_${VERSION}_x64-setup.exe" "Origa_x64-setup.exe"
+                  [ -f "Origa_${VERSION}_x64-setup.exe.sig" ] && mv "Origa_${VERSION}_x64-setup.exe.sig" "Origa_x64-setup.exe.sig" || true
 
             - name: Extract signature
               id: signature
@@ -241,11 +244,12 @@ jobs:
                   VERSION: ${{ inputs.version }}
               run: |
                   # Tauri emits Origa_<version>_amd64.AppImage/.deb (+ .AppImage.sig
-                  # updater signature). Mirror each to a fixed-name alias for the
+                  # updater signature). Rename each to a fixed name for the
                   # landing page's /releases/latest/download/<fixed> links.
-                  cp "appimage/Origa_${VERSION}_amd64.AppImage" "appimage/Origa_amd64.AppImage"
-                  [ -f "appimage/Origa_${VERSION}_amd64.AppImage.sig" ] && cp "appimage/Origa_${VERSION}_amd64.AppImage.sig" "appimage/Origa_amd64.AppImage.sig" || true
-                  cp "deb/Origa_${VERSION}_amd64.deb" "deb/Origa_amd64.deb"
+                  # Single-name (no versioned copy) per ADR-025 addendum.
+                  mv "appimage/Origa_${VERSION}_amd64.AppImage" "appimage/Origa_amd64.AppImage"
+                  [ -f "appimage/Origa_${VERSION}_amd64.AppImage.sig" ] && mv "appimage/Origa_${VERSION}_amd64.AppImage.sig" "appimage/Origa_amd64.AppImage.sig" || true
+                  mv "deb/Origa_${VERSION}_amd64.deb" "deb/Origa_amd64.deb"
 
             - name: Extract signature
               id: signature
@@ -337,8 +341,6 @@ jobs:
               run: echo "signature=" >> $GITHUB_OUTPUT
 
             - name: Create macOS app bundle
-              env:
-                  VERSION: ${{ inputs.version }}
               run: |
                   mkdir -p Origa.app/Contents/MacOS
                   mkdir -p Origa.app/Contents/Resources
@@ -366,17 +368,17 @@ jobs:
                   </plist>
                   EOF
                   chmod +x Origa.app/Contents/MacOS/origa
-                  # Versioned archive for release history, plus a fixed-name alias
-                  # for the landing page's /releases/latest/download/Origa_macos-arm64.zip.
-                  zip -r "Origa_${VERSION}_macos-arm64.zip" Origa.app
-                  cp "Origa_${VERSION}_macos-arm64.zip" "Origa_macos-arm64.zip"
+                  # Single fixed-name archive for the landing page's
+                  # /releases/latest/download/Origa_macos-arm64.zip link, and as
+                  # the only macOS asset in the release (no versioned duplicate)
+                  # per ADR-025 addendum.
+                  zip -r "Origa_macos-arm64.zip" Origa.app
 
             - name: Upload macOS artifacts
               uses: actions/upload-artifact@v4
               with:
                   name: macos-build
                   path: |
-                      Origa_${{ inputs.version }}_macos-arm64.zip
                       Origa_macos-arm64.zip
                   retention-days: 7
 

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -135,18 +135,21 @@ jobs:
                   # auto-updated to an rc build. The URL tag segment is the git
                   # tag (v-prefixed, e.g. v1.0.0) — it MUST match the release's
                   # tag_name (github.ref_name), not the stripped version. The
-                  # asset filename segment keeps the stripped version because
-                  # Tauri stamps bundle names from tauri.conf.json:version (no v).
-                  # The manifest's `version` field is the bare version (1.0.0)
-                  # the updater compares against.
+                  # asset filename segment is the fixed-name alias
+                  # (Origa_x64-setup.exe / Origa_amd64.AppImage) — single-naming
+                  # per ADR-025 addendum; only the alias asset exists in the
+                  # release. The manifest's `version` field is the bare version
+                  # (1.0.0) the updater compares against. Signature is
+                  # content-based (Minisign), so it stays valid after the
+                  # versioned → alias rename in _build-tauri.yml.
                   jq -n \
                     --arg version "$VERSION" \
                     --arg notes "Release $VERSION" \
                     --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
                     --arg win_sig "$WIN_SIG" \
                     --arg linux_sig "$LINUX_SIG" \
-                    --arg win_url "https://github.com/yurvon-screamo/origa/releases/download/${GIT_TAG}/Origa_${VERSION}_x64-setup.exe" \
-                    --arg linux_url "https://github.com/yurvon-screamo/origa/releases/download/${GIT_TAG}/Origa_${VERSION}_amd64.AppImage" \
+                    --arg win_url "https://github.com/yurvon-screamo/origa/releases/download/${GIT_TAG}/Origa_x64-setup.exe" \
+                    --arg linux_url "https://github.com/yurvon-screamo/origa/releases/download/${GIT_TAG}/Origa_amd64.AppImage" \
                     '{
                       version: $version,
                       notes: $notes,
@@ -199,21 +202,20 @@ jobs:
             - name: Prepare release assets
               run: |
                   mkdir -p release_assets
-                  # Keep only installable bundles + the updater manifest.
-                  # Each platform ships BOTH a versioned name (release history
-                  # + the exact asset latest.json points at) and a fixed-name
-                  # alias (so /releases/latest/download/<alias> resolves for the
-                  # landing page). Intermediate artifacts (frontend-dist WASM,
-                  # *.sig signatures already embedded into latest.json) are
-                  # excluded so the release stays small. cp -f (not -n): every
-                  # tag is a fresh release, no accumulation across runs.
+                  # Keep only installable bundles + the updater manifest. Each
+                  # platform ships a single fixed-name asset per ADR-025
+                  # addendum (no versioned duplicate) so /releases/latest/download/
+                  # <alias> resolves for the landing page. Intermediate artifacts
+                  # (frontend-dist WASM, *.sig signatures already embedded into
+                  # latest.json) are excluded so the release stays small.
+                  # cp -f (not -n): every tag is a fresh release, no accumulation.
                   find artifacts -type f \( \
                       -name '*-setup.exe' -o \
                       -name '*.msi' -o \
                       -name '*.AppImage' -o \
                       -name '*.deb' -o \
                       -name '*.dmg' -o \
-                      -name 'Origa_*macos-arm64.zip' -o \
+                      -name 'Origa_macos-arm64.zip' -o \
                       -name '*.apk' -o \
                       -name 'latest.json' \
                   \) -exec cp -f {} release_assets/ \;
@@ -231,18 +233,14 @@ jobs:
                       Commit: ${{ github.sha }}
 
                       ## Windows
-                      - `Origa_${{ needs.version.outputs.version }}_x64-setup.exe` — NSIS installer
-                      - `Origa_x64-setup.exe` — fixed-name alias (latest direct download)
+                      - `Origa_x64-setup.exe` — NSIS installer (single-name, no versioned duplicate per ADR-025 addendum)
 
                       ## Linux
-                      - `Origa_${{ needs.version.outputs.version }}_amd64.AppImage` — portable
-                      - `Origa_amd64.AppImage` — fixed-name alias
-                      - `Origa_${{ needs.version.outputs.version }}_amd64.deb` — Debian/Ubuntu
-                      - `Origa_amd64.deb` — fixed-name alias
+                      - `Origa_amd64.AppImage` — portable
+                      - `Origa_amd64.deb` — Debian/Ubuntu
 
                       ## macOS
-                      - `Origa_${{ needs.version.outputs.version }}_macos-arm64.zip` — Apple Silicon
-                      - `Origa_macos-arm64.zip` — fixed-name alias
+                      - `Origa_macos-arm64.zip` — Apple Silicon
 
                       ## Android
                       - `origa.apk`

--- a/docs/decisions/ADR-025-ci-cd-tag-based-releases.md
+++ b/docs/decisions/ADR-025-ci-cd-tag-based-releases.md
@@ -407,3 +407,58 @@ Actions). Verification is therefore layered:
 - `softprops/action-gh-release` v2 (current `@v2` resolves to v2.6.2; v2.5.0 had a prerelease-detection bug fixed in v2.5.1+)
 - `tauri/tauri.conf.json:56` — updater endpoint `/releases/latest/download/latest.json` (unchanged by this ADR)
 - Existing stable release (0.4.0) assets verified via `gh api repos/yurvon-screamo/origa/releases/latest`
+
+## Addendum (2026-07-12): Single artifact naming (alias-only)
+
+### What changed
+
+§6 "Dual artifact naming" is replaced with **single artifact naming** for
+desktop platforms (Windows NSIS, Linux AppImage/DEB, macOS zip). Each release
+now ships only the fixed-name alias — the versioned copy produced by Tauri's
+default output is renamed (not duplicated) via `mv` in `_build-tauri.yml`.
+
+| Platform | Sole asset in release |
+| --- | --- |
+| Windows NSIS | `Origa_x64-setup.exe` |
+| Linux AppImage | `Origa_amd64.AppImage` |
+| Linux DEB | `Origa_amd64.deb` |
+| macOS zip | `Origa_macos-arm64.zip` |
+| Android APK | `origa.apk` (already single-naming) |
+
+### Rationale
+
+The versioned filename (`Origa_0.4.1_x64-setup.exe`) was redundant with the
+release tag (`v0.4.1`) — both identify the version. The dual naming forced
+users to scan a release asset list that contained two near-identical entries
+per platform, with no guidance on which to pick. Switching to alias-only
+resolves the user complaint ("asset list cluttered with duplicates") while
+preserving every functional contract that dual naming served:
+
+- §9 (landing direct download) — `/releases/latest/download/Origa_x64-setup.exe`
+  still resolves because the alias is still published.
+- `latest.json` URLs (`tauri.yml` `generate-latest-json`) now point at the
+  alias asset inside the git tag, e.g.
+  `releases/download/v0.4.2/Origa_x64-setup.exe`.
+- Tauri updater signature validity is preserved — the `.sig` file is a
+  Minisign signature over the **content** of the bundle, not its filename, so
+  the versioned → alias rename in `_build-tauri.yml` does not invalidate it.
+  The `.sig` is renamed alongside the bundle.
+
+### What did NOT change
+
+- §9 (landing direct download links) — alias filenames are still the contract
+  with `origa_landing/src/pages/download.rs`.
+- §5 (`latest.json` is stable-only) — prereleases still do not refresh the
+  updater manifest.
+- The macOS bundle format (manual `.app` zip, not `.app.tar.gz`) — updater
+  support for macOS remains a known limitation; the signature output is empty
+  for macOS and `latest.json` does not include a `darwin-*` platform entry.
+
+### Migration
+
+Historical releases (`v0.4.0`, `v0.4.1`) keep their dual assets — only
+`v0.4.2+` uses single naming. There is no backward-compat break: the alias
+filenames are unchanged from before, only the versioned duplicates are no
+longer produced. The first post-addendum tag (rc-first per §Migration)
+validates that the rename produces a single asset per platform and that
+`latest.json` URLs resolve against it.

--- a/origa_ui/src/core/updater.rs
+++ b/origa_ui/src/core/updater.rs
@@ -1,4 +1,12 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use leptos::wasm_bindgen::JsValue;
+use leptos::wasm_bindgen::closure::Closure;
 use serde::Deserialize;
+
+use crate::core::tauri::{event_listen_fn, invoke_with_args, is_tauri};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UpdateInfo {
@@ -6,209 +14,143 @@ pub struct UpdateInfo {
     pub current_version: String,
 }
 
-#[cfg(all(
-    target_arch = "wasm32",
-    any(target_os = "windows", target_os = "macos", target_os = "linux")
-))]
-fn get_js_property(
-    obj: &leptos::wasm_bindgen::JsValue,
-    name: &str,
-    error_msg: &str,
-) -> Option<leptos::wasm_bindgen::JsValue> {
-    let result = js_sys::Reflect::get(obj, &leptos::wasm_bindgen::JsValue::from_str(name));
-    if result.is_err() {
-        leptos::logging::warn!("{}", error_msg);
-    }
-    result.ok()
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "event", content = "data")]
+enum DownloadEvent {
+    #[serde(rename_all = "camelCase")]
+    Started {
+        content_length: Option<u64>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Progress {
+        chunk_length: usize,
+    },
+    Finished,
 }
 
+#[derive(Default)]
+struct ProgressState {
+    total_size: Option<u64>,
+    downloaded: u64,
+}
+
+const PROGRESS_EVENT: &str = "origa-update-progress";
+
+/// Checks the Tauri updater endpoint for a newer release.
+///
+/// Returns `None` outside the Tauri WebView (browser build) or when no update
+/// is available. The runtime `is_tauri()` gate is preferred over a compile-time
+/// `cfg(target_os = …)` because Tauri CLI does not always inject `target_os`
+/// cfg-flags for the WASM build, while `window.__TAURI__` is always present
+/// inside the desktop WebView.
 pub async fn check_for_updates() -> Option<UpdateInfo> {
-    #[cfg(all(
-        target_arch = "wasm32",
-        any(target_os = "windows", target_os = "macos", target_os = "linux")
-    ))]
-    {
-        check_for_updates_tauri().await
-    }
-
-    #[cfg(not(all(
-        target_arch = "wasm32",
-        any(target_os = "windows", target_os = "macos", target_os = "linux")
-    )))]
-    {
-        leptos::logging::log!("Update check is only available in the desktop version");
-        None
-    }
-}
-
-#[cfg(all(
-    target_arch = "wasm32",
-    any(target_os = "windows", target_os = "macos", target_os = "linux")
-))]
-async fn check_for_updates_tauri() -> Option<UpdateInfo> {
-    use super::tauri;
-    use leptos::logging;
-    use leptos::wasm_bindgen::JsCast;
-    use leptos::wasm_bindgen::JsValue;
-
-    let tauri_obj = tauri::tauri_object();
-    let updater_mod = tauri_obj
-        .as_ref()
-        .and_then(|obj| get_js_property(obj, "updater", "Tauri updater module unavailable"));
-    let check_fn_val = updater_mod
-        .as_ref()
-        .and_then(|mod_| get_js_property(mod_, "check", "Tauri updater.check unavailable"));
-    let check_fn = check_fn_val.as_ref().and_then(|val| {
-        let fn_result = val.dyn_into::<js_sys::Function>().ok();
-        if fn_result.is_none() {
-            logging::warn!("updater.check is not a function");
-        }
-        fn_result
-    });
-
-    let result = check_fn
-        .as_ref()
-        .map(|fn_val| fn_val.call0(&JsValue::UNDEFINED));
-
-    match result {
-        Some(Ok(promise)) => {
-            let promise_result =
-                wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(promise)).await;
-            match promise_result {
-                Ok(update_result) => {
-                    if update_result.is_null() || update_result.is_undefined() {
-                        logging::log!("No updates found");
-                        None
-                    } else {
-                        parse_update_info(&update_result)
-                    }
-                },
-                Err(e) => {
-                    logging::warn!("Error checking for updates: {:?}", e);
-                    None
-                },
-            }
-        },
-        Some(Err(e)) => {
-            logging::warn!("Error calling updater.check: {:?}", e);
-            None
-        },
-        None => {
-            if web_sys::window().is_none() {
-                logging::warn!("Window unavailable");
-            }
-            None
-        },
-    }
-}
-
-#[cfg(all(
-    target_arch = "wasm32",
-    any(target_os = "windows", target_os = "macos", target_os = "linux")
-))]
-fn parse_update_info(value: &leptos::wasm_bindgen::JsValue) -> Option<UpdateInfo> {
-    use super::version::VERSION;
-    use leptos::wasm_bindgen::JsValue;
-
-    let Ok(version) = js_sys::Reflect::get(value, &JsValue::from_str("version")) else {
+    if !is_tauri() {
+        tracing::debug!("updater: skipping check outside Tauri WebView");
         return None;
-    };
-
-    let version_str = version.as_string()?;
-
-    Some(UpdateInfo {
-        version: version_str,
-        current_version: VERSION.to_string(),
-    })
-}
-
-pub async fn download_and_install<F>(_on_progress: F) -> Result<(), String>
-where
-    F: Fn(u8) + Send + Sync + 'static,
-{
-    #[cfg(all(
-        target_arch = "wasm32",
-        any(target_os = "windows", target_os = "macos", target_os = "linux")
-    ))]
-    {
-        download_and_install_tauri(_on_progress).await
     }
 
-    #[cfg(not(all(
-        target_arch = "wasm32",
-        any(target_os = "windows", target_os = "macos", target_os = "linux")
-    )))]
-    {
-        leptos::logging::log!("Update download is only available in the desktop version");
-        Ok(())
+    match invoke_with_args("check_for_update", &JsValue::UNDEFINED).await {
+        Ok(result) if result.is_null() || result.is_undefined() => {
+            tracing::debug!("updater: no update available");
+            None
+        },
+        Ok(result) => match serde_wasm_bindgen::from_value::<UpdateInfo>(result) {
+            Ok(info) => {
+                tracing::info!(?info, "updater: update available");
+                Some(info)
+            },
+            Err(e) => {
+                tracing::warn!("updater: failed to parse UpdateInfo: {e:?}");
+                None
+            },
+        },
+        Err(e) => {
+            tracing::warn!("updater: check_for_update invoke failed: {e}");
+            None
+        },
     }
 }
 
-#[cfg(all(
-    target_arch = "wasm32",
-    any(target_os = "windows", target_os = "macos", target_os = "linux")
-))]
-async fn download_and_install_tauri<F>(on_progress: F) -> Result<(), String>
+/// Downloads and installs the pending update.
+///
+/// Subscribes to `"origa-update-progress"` events emitted by the Rust
+/// `install_update` command, converts chunks into a 0–100 percent value and
+/// forwards it to `on_progress`. Outside Tauri this is a no-op success.
+pub async fn download_and_install<F>(on_progress: F) -> Result<(), String>
 where
     F: Fn(u8) + Send + Sync + 'static,
 {
-    use super::tauri;
-    use leptos::wasm_bindgen::JsCast;
-    use leptos::wasm_bindgen::JsValue;
-    use leptos::wasm_bindgen::closure::Closure;
-    use std::sync::Arc;
+    if !is_tauri() {
+        tracing::debug!("updater: skipping install outside Tauri WebView");
+        return Ok(());
+    }
 
-    let tauri_obj = tauri::tauri_object().ok_or("Tauri API unavailable")?;
+    let listen_fn = event_listen_fn().ok_or_else(|| {
+        "Tauri event.listen unavailable — cannot subscribe to update progress".to_string()
+    })?;
 
-    let updater_mod = js_sys::Reflect::get(&tauri_obj, &JsValue::from_str("updater"))
-        .map_err(|_| "Tauri updater module unavailable")?;
-
-    let download_fn = js_sys::Reflect::get(&updater_mod, &JsValue::from_str("downloadAndInstall"))
-        .map_err(|_| "Tauri updater.downloadAndInstall unavailable")?;
-
-    let download_fn = download_fn
-        .dyn_into::<js_sys::Function>()
-        .map_err(|_| "updater.downloadAndInstall is not a function")?;
-
+    let state = Rc::new(RefCell::new(ProgressState::default()));
     let on_progress = Arc::new(on_progress);
-    let closure = Closure::<dyn Fn(JsValue)>::new(move |event| {
-        if let Ok(data) = js_sys::Reflect::get(&event, &JsValue::from_str("data")) {
-            if let Some(content_length) =
-                js_sys::Reflect::get(&data, &JsValue::from_str("contentLength"))
-                    .ok()
-                    .and_then(|v| v.as_f64())
-            {
-                if content_length > 0.0 {
-                    if let Some(chunk_length) =
-                        js_sys::Reflect::get(&data, &JsValue::from_str("chunkLength"))
-                            .ok()
-                            .and_then(|v| v.as_f64())
-                    {
-                        let progress = ((chunk_length / content_length) * 100.0).min(100.0) as u8;
-                        on_progress(progress);
-                    }
+
+    let state_for_closure = state.clone();
+    let on_progress_for_closure = on_progress.clone();
+    let progress_closure = Closure::<dyn Fn(JsValue)>::new(move |envelope: JsValue| {
+        let Some(event) = extract_event(&envelope) else {
+            return;
+        };
+        let mut s = state_for_closure.borrow_mut();
+        match event {
+            DownloadEvent::Started { content_length } => {
+                s.total_size = content_length;
+            },
+            DownloadEvent::Progress { chunk_length } => {
+                s.downloaded = s.downloaded.saturating_add(chunk_length as u64);
+                if let Some(total) = s.total_size
+                    && total > 0
+                {
+                    let ratio = (s.downloaded as f64 / total as f64).clamp(0.0, 1.0);
+                    on_progress_for_closure((ratio * 100.0) as u8);
                 }
-            }
+            },
+            DownloadEvent::Finished => {
+                on_progress_for_closure(100);
+            },
         }
     });
 
-    let event_name = JsValue::from_str("tauri://update-download-progress");
-
-    let listen_fn = tauri::event_listen_fn().ok_or("Tauri event.listen unavailable")?;
-
-    let _unlisten = listen_fn.call2(&JsValue::UNDEFINED, &event_name, closure.as_ref());
-    closure.forget();
-
-    let result = download_fn.call0(&JsValue::UNDEFINED);
-
-    match result {
-        Ok(promise) => {
-            let promise = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(promise));
-            promise
-                .await
-                .map(|_| ())
-                .map_err(|e| format!("Error downloading update: {:?}", e))
-        },
-        Err(e) => Err(format!("Error calling downloadAndInstall: {:?}", e)),
+    let event_name = JsValue::from_str(PROGRESS_EVENT);
+    if listen_fn
+        .call2(&JsValue::UNDEFINED, &event_name, progress_closure.as_ref())
+        .is_err()
+    {
+        // Bail out before invoking install_update: without a listener we cannot
+        // surface download progress, and the failure mode is silent (install
+        // would still download but the user would see a frozen progress bar).
+        return Err(
+            "Tauri event.listen call failed — cannot subscribe to update progress".to_string(),
+        );
     }
+    // Intentionally leak: the listener must survive for the duration of
+    // download_and_install (and the app exits/restarts immediately after
+    // install), so there is no natural unlisten point.
+    progress_closure.forget();
+
+    // install_update never returns on Windows (NSIS terminates the process
+    // mid-install); on Linux/macOS the Rust command calls `app.restart()`
+    // which terminates the process before the promise resolves. The only way
+    // this await resolves is when install_update itself returns an Err
+    // (e.g. no pending update) — propagate that, otherwise the success path
+    // never reaches here.
+    invoke_with_args("install_update", &JsValue::UNDEFINED)
+        .await
+        .map(|_| ())
+}
+
+fn extract_event(envelope: &JsValue) -> Option<DownloadEvent> {
+    let payload = js_sys::Reflect::get(envelope, &JsValue::from_str("payload"))
+        .ok()
+        .filter(|v| !v.is_undefined() && !v.is_null())?;
+    serde_wasm_bindgen::from_value::<DownloadEvent>(payload)
+        .map_err(|e| tracing::warn!("updater: failed to parse DownloadEvent payload: {e:?}"))
+        .ok()
 }

--- a/tauri/build_config.rs
+++ b/tauri/build_config.rs
@@ -31,15 +31,16 @@ pub(crate) const DEFAULT_LANDING: &str = "https://origa.uwuwu.net";
 /// Build the Content-Security-Policy directive by substituting env-controlled
 /// hosts into the static template. The CDN host is referenced from `font-src`
 /// because all fonts are self-hosted there (ADR-028). Other third-party hosts
-/// (huggingface, cdn.pyke.io for ort-rs WASM, OAuth providers) remain
-/// hardcoded — they are not environment-dependent.
+/// (huggingface, cdn.pyke.io for ort-rs WASM, signal.pyke.io for pyke SDK
+/// telemetry, OAuth providers) remain hardcoded — they are not
+/// environment-dependent.
 ///
 /// The literal is kept on a single line because `rustfmt` does not reflow
 /// string-literal contents, and byte-equality with `tauri.conf.json` must hold
 /// (verified by `build_csp_with_production_defaults_matches_committed_tauri_conf`).
 pub(crate) fn build_csp(cdn: &str, landing: &str, trailbase: &str) -> String {
     format!(
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co https://cdn.pyke.io; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
     )
 }
 

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -1,10 +1,12 @@
 mod auth_store;
+mod updater_commands;
 
 use std::sync::Mutex;
 
 use auth_store::{auth_store_delete, auth_store_get, auth_store_set};
 use tauri::{Emitter, Listener, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
+use updater_commands::{PendingUpdate, check_for_update, install_update};
 
 struct PendingDeepLink(Mutex<Option<String>>);
 
@@ -27,6 +29,7 @@ pub fn run() {
                 .set_focus();
         }));
         builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+        builder = builder.plugin(tauri_plugin_process::init());
     }
 
     builder
@@ -35,11 +38,16 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_tts::init())
         .manage(PendingDeepLink(Mutex::new(None)))
+        .manage(PendingUpdate::new())
         .invoke_handler(tauri::generate_handler![
             get_pending_deep_link,
             auth_store_get,
             auth_store_set,
-            auth_store_delete
+            auth_store_delete,
+            #[cfg(desktop)]
+            check_for_update,
+            #[cfg(desktop)]
+            install_update
         ])
         .setup(|app| {
             tracing::info!("[deep-link] setup started");

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod auth_store;
+#[cfg(desktop)]
 mod updater_commands;
 
 use std::sync::Mutex;
@@ -6,6 +7,7 @@ use std::sync::Mutex;
 use auth_store::{auth_store_delete, auth_store_get, auth_store_set};
 use tauri::{Emitter, Listener, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
+#[cfg(desktop)]
 use updater_commands::{PendingUpdate, check_for_update, install_update};
 
 struct PendingDeepLink(Mutex<Option<String>>);
@@ -30,6 +32,7 @@ pub fn run() {
         }));
         builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
         builder = builder.plugin(tauri_plugin_process::init());
+        builder = builder.manage(PendingUpdate::new());
     }
 
     builder
@@ -38,7 +41,6 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_tts::init())
         .manage(PendingDeepLink(Mutex::new(None)))
-        .manage(PendingUpdate::new())
         .invoke_handler(tauri::generate_handler![
             get_pending_deep_link,
             auth_store_get,

--- a/tauri/src/updater_commands.rs
+++ b/tauri/src/updater_commands.rs
@@ -1,0 +1,197 @@
+//! Tauri IPC commands for the auto-updater (`tauri-plugin-updater`).
+//!
+//! The frontend (WASM) calls these commands through `invoke` to check for
+//! available updates and install them. Progress events are emitted via
+//! `app.emit("origa-update-progress", DownloadEvent)` so the WASM side can
+//! subscribe through the existing `core::tauri::event_listen_fn()` helper
+//! without any new JS-reflection code.
+//!
+//! The `Update` returned by `check` is stored in `PendingUpdate` state and
+//! consumed by `install_update` — this avoids a second network round-trip and
+//! the race condition of the manifest changing between check and install.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+use tauri_plugin_updater::{Update, UpdaterExt};
+
+/// Holds the `Update` returned by `check_for_update` until `install_update`
+/// consumes it. Without this state, `install_update` would have to re-run the
+/// check (extra network round-trip + manifest race).
+pub struct PendingUpdate(pub Mutex<Option<Update>>);
+
+impl PendingUpdate {
+    pub fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+impl Default for PendingUpdate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateMetadata {
+    pub version: String,
+    pub current_version: String,
+}
+
+/// Event emitted on the `"origa-update-progress"` channel during
+/// `install_update`. Per-variant `rename_all = "camelCase"` so the WASM side
+/// receives canonical JS-style field names (`contentLength`, `chunkLength`).
+#[derive(Clone, Serialize)]
+#[serde(tag = "event", content = "data")]
+pub enum DownloadEvent {
+    #[serde(rename_all = "camelCase")]
+    Started {
+        content_length: Option<u64>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Progress {
+        chunk_length: usize,
+    },
+    Finished,
+}
+
+const PROGRESS_EVENT: &str = "origa-update-progress";
+
+/// Checks the configured updater endpoint for a newer release.
+///
+/// Returns `Ok(None)` when the current build is already up to date. When an
+/// update exists, its metadata is returned AND the `Update` object is stashed
+/// in `PendingUpdate` so `install_update` can consume it without re-checking.
+#[tauri::command]
+#[cfg(desktop)]
+pub async fn check_for_update(
+    app: AppHandle,
+    pending: State<'_, PendingUpdate>,
+) -> Result<Option<UpdateMetadata>, String> {
+    let update = app
+        .updater()
+        .map_err(|e| e.to_string())?
+        .check()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let metadata = update.as_ref().map(|u| UpdateMetadata {
+        version: u.version.clone(),
+        current_version: u.current_version.clone(),
+    });
+
+    tracing::info!(?metadata, "updater check result");
+
+    *pending.0.lock().unwrap_or_else(|e| e.into_inner()) = update;
+
+    Ok(metadata)
+}
+
+/// Downloads and installs the update previously stashed by `check_for_update`.
+///
+/// Emits `Started` (once, on the first chunk), `Progress` (per chunk), and
+/// `Finished` on the `"origa-update-progress"` channel, then restarts the app.
+///
+/// On Windows the NSIS installer terminates the process during
+/// `download_and_install`, so `app.restart()` is unreachable there — it
+/// remains as the restart path for Linux and macOS.
+#[tauri::command]
+#[cfg(desktop)]
+pub async fn install_update(
+    app: AppHandle,
+    pending: State<'_, PendingUpdate>,
+) -> Result<(), String> {
+    let update_opt = pending.0.lock().unwrap_or_else(|e| e.into_inner()).take();
+    let update = update_opt.ok_or_else(|| "no pending update".to_string())?;
+
+    let started = AtomicBool::new(false);
+    let app_for_progress = app.clone();
+    let app_for_finish = app.clone();
+
+    update
+        .download_and_install(
+            move |chunk_length, content_length| {
+                if !started.swap(true, Ordering::Relaxed) {
+                    let _ = app_for_progress
+                        .emit(PROGRESS_EVENT, DownloadEvent::Started { content_length });
+                }
+                let _ =
+                    app_for_progress.emit(PROGRESS_EVENT, DownloadEvent::Progress { chunk_length });
+            },
+            move || {
+                let _ = app_for_finish.emit(PROGRESS_EVENT, DownloadEvent::Finished);
+            },
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    app.restart();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Wire-format contract: the WASM side (`origa_ui/src/core/updater.rs`)
+    /// mirrors `DownloadEvent` with the same serde tags and per-variant
+    /// `rename_all = "camelCase"`. This round-trip test pins the canonical
+    /// JSON shape; if either side drifts, deserialization on the WASM side
+    /// fails silently (progress events stop arriving) — the same class of
+    /// bug this updater rewrite was meant to eliminate.
+    #[test]
+    fn download_event_started_serializes_camel_case() {
+        let event = DownloadEvent::Started {
+            content_length: Some(12345),
+        };
+        let json = serde_json::to_string(&event).expect("serialize Started");
+        assert_eq!(
+            json,
+            r#"{"event":"Started","data":{"contentLength":12345}}"#
+        );
+    }
+
+    #[test]
+    fn download_event_started_with_null_content_length() {
+        let event = DownloadEvent::Started {
+            content_length: None,
+        };
+        let json = serde_json::to_string(&event).expect("serialize Started None");
+        assert_eq!(json, r#"{"event":"Started","data":{"contentLength":null}}"#);
+    }
+
+    #[test]
+    fn download_event_progress_serializes_camel_case() {
+        let event = DownloadEvent::Progress { chunk_length: 1024 };
+        let json = serde_json::to_string(&event).expect("serialize Progress");
+        assert_eq!(json, r#"{"event":"Progress","data":{"chunkLength":1024}}"#);
+    }
+
+    #[test]
+    fn download_event_finished_serializes_with_event_tag() {
+        let event = DownloadEvent::Finished;
+        let json = serde_json::to_string(&event).expect("serialize Finished");
+        // serde tag/content for a unit variant may omit the `data` slot — the
+        // event tag alone identifies the variant. Assert only the tag.
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("Finished JSON must parse");
+        assert_eq!(parsed["event"], "Finished");
+    }
+
+    #[test]
+    fn update_metadata_serializes_with_both_version_fields() {
+        let metadata = UpdateMetadata {
+            version: "0.4.2".to_string(),
+            current_version: "0.4.1-rc3".to_string(),
+        };
+        let json = serde_json::to_string(&metadata).expect("serialize UpdateMetadata");
+        assert_eq!(json, r#"{"version":"0.4.2","current_version":"0.4.1-rc3"}"#);
+    }
+
+    #[test]
+    fn pending_update_new_starts_empty() {
+        let pending = PendingUpdate::new();
+        assert!(pending.0.lock().unwrap().is_none());
+    }
+}

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -21,7 +21,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://cdn.pyke.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
         }
     },
     "bundle": {

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -98,6 +98,7 @@ fn build_csp_substitutes_staging_hosts() {
     // Other third-party hosts must survive any host substitution.
     assert!(csp.contains("https://huggingface.co"));
     assert!(csp.contains("https://cdn.pyke.io"));
+    assert!(csp.contains("https://signal.pyke.io"));
     assert!(csp.contains("https://accounts.google.com"));
     assert!(csp.contains("https://oauth.yandex.ru"));
 


### PR DESCRIPTION
## Summary

Three independent fixes shipped together because they were reported in the same session and touch overlapping files.

### 1. Auto-update was silently broken

The Tauri updater never offered updates despite the Rust-side plugin returning `available: true` (verified in DevTools: `await window.__TAURI__.updater.check()` returned a valid `Update` with `version: '0.4.1'` against `currentVersion: '0.4.1-rc3'`).

**Root cause:** the WASM-side gate

```rust
cfg(all(target_arch = "wasm32", any(target_os = "windows", target_os = "macos", target_os = "linux")))
```

is **always false** under a standard `trunk build` — `target_os` is `"unknown"` for `wasm32-unknown-unknown`. The check never ran. Layered on top, the JS-reflection path (`check_fn.call0(&JsValue::UNDEFINED)`) swallowed every failure mode as `None` without diagnostics.

**Fix:** rewrite both sides using the canonical Tauri v2 pattern.
- `tauri/src/updater_commands.rs` (new): `check_for_update` + `install_update` commands with `PendingUpdate(Mutex<Option<Update>>)` state. `install_update` emits `Started`/`Progress`/`Finished` events on `"origa-update-progress"` via `app.emit()` and calls `app.restart()` after install.
- `tauri/src/lib.rs`: register `tauri_plugin_process::init()` (was missing despite being in deps), manage `PendingUpdate`, extend `invoke_handler` under `#[cfg(desktop)]`.
- `origa_ui/src/core/updater.rs`: full rewrite on `invoke_with_args` + `event_listen_fn` with **runtime `is_tauri()` gate** (replaces the always-false compile-time `cfg`). Event envelope extraction via `Reflect::get(payload)` + `serde_wasm_bindgen`. Removed all dead JS-reflection helpers.
- 6 serde round-trip tests pin the `DownloadEvent`/`UpdateMetadata` wire format so future drift between the two crates fails loudly.

### 2. Duplicate release assets

Each release shipped both a versioned bundle (`Origa_0.4.1_x64-setup.exe`) and a fixed-name alias (`Origa_x64-setup.exe`) per platform. The versioned name was redundant with the release tag.

**Fix:** `cp` -> `mv` in `_build-tauri.yml` so Tauri's default versioned output is renamed to the alias. Update `generate-latest-json` URLs to point at the alias inside the git tag. Simplify release notes, narrow the macOS glob. ADR-025 addendum documents the change-of-decision.

The Tauri updater signature stays valid — `.sig` is a Minisign signature over bundle **content**, not filename.

### 3. CSP violation for pyke telemetry

`_telemetry.js` loaded from `cdn.pyke.io` (already whitelisted) was blocked from sending telemetry to `signal.pyke.io` — CSP violation in the WebView console on every session start.

**Fix:** add `https://signal.pyke.io` to `connect-src` in all three CSP sources (tauri.conf.json, build_config.rs template, test assertion). Explicit whitelist, no wildcard, per ADR-015. Byte-equality between dev and production CSP preserved.

## Verification

| Check | Status |
|-------|--------|
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets --exclude origa_landing -- -D warnings` | pass (origa_landing excluded — needs env vars unavailable in shell) |
| `cargo clippy -p origa_ui --lib --target wasm32-unknown-unknown -- -D warnings` | pass |
| `cargo test --workspace --exclude origa_landing` | pass — 1521+ tests (1515 + 6 new) |
| `actionlint tauri.yml _build-tauri.yml` | pass — exit 0 |
| Code review (`@code-quality-reviewer`) | approve after 1 cycle |

## Operational follow-ups (post-merge)

- **Manual smoke on Windows desktop** (`cargo tauri dev` with version bumped down in `tauri.conf.json`): drawer appears -> click "Update now" -> progress grows -> install -> app exit + relaunch.
- **rc-first E2E** (`v0.4.2-rc1`): verify release assets contain only alias names; `latest.json` not regenerated (prerelease).
- **Stable E2E** (`v0.4.2`): verify `/releases/latest/download/<alias>` resolves, `latest.json` updated, auto-update from 0.4.0/0.4.1-rc3 works end-to-end.

## Known limitations (out of scope)

- `DownloadEvent`/`UpdateMetadata` defined in both crates (`tauri` + `origa_ui`) — drift is now caught by round-trip serde tests, but a shared types crate would be cleaner. Follow-up.
- On mobile `is_tauri() == true` but `check_for_update` is `#[cfg(desktop)]` -> invoke rejects -> `warn!` log noise on each Android startup (returns `None`, not a crash). Needs an `is_desktop()` runtime gate. Follow-up.
- macOS updater still ships a manual `.app` zip without `.app.tar.gz` — updater support for macOS remains a known limitation (no `darwin-*` entry in `latest.json`).

## Test plan

- [x] Workspace tests pass (1521+)
- [x] clippy clean (desktop + wasm32 targets)
- [x] actionlint clean
- [x] 6 new serde round-trip tests for updater wire format
- [ ] Manual smoke on Windows desktop (post-merge, before next stable tag)
- [ ] rc-first E2E on `v0.4.2-rc1` tag
- [ ] Stable E2E on `v0.4.2` tag
