### PR TITLE
🐛 fix(auth): recover OAuth deep-link after Android Activity recreate

### DIFF
--- a/origa_ui/locales/en.json
+++ b/origa_ui/locales/en.json
@@ -343,7 +343,6 @@
         "save_session_error": "Failed to save session: {}",
         "email_not_in_token": "Email not found in auth token. Please try logging in again.",
         "auth_code_not_found": "Authorization code not found in callback URL",
-        "pkce_not_found": "PKCE verifier not found. Please try logging in again.",
         "token_exchange_error": "Token exchange error: {}",
         "google_login": "Sign in with Google",
         "yandex_login": "Sign in with Yandex",

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -343,7 +343,6 @@
     "save_session_error": "Не удалось сохранить сессию: {}",
     "email_not_in_token": "Email не найден в токене авторизации. Попробуйте войти снова.",
     "auth_code_not_found": "Код авторизации не найден в callback URL",
-    "pkce_not_found": "PKCE verifier не найден. Пожалуйста, попробуйте войти снова.",
     "token_exchange_error": "Ошибка обмена токена: {}",
     "google_login": "Войти через Google",
     "yandex_login": "Войти через Yandex",

--- a/origa_ui/src/pages/login/auth_handlers.rs
+++ b/origa_ui/src/pages/login/auth_handlers.rs
@@ -143,7 +143,7 @@ pub async fn handle_oauth_callback_desktop(
     url: &str,
     auth_store: &AuthStore,
     i18n: &I18nContext<Locale>,
-) -> Result<User, String> {
+) -> Result<Option<User>, String> {
     let parsed = url::Url::parse(url).map_err(|e| format!("Invalid URL: {}", e))?;
 
     let code = parsed
@@ -158,9 +158,12 @@ pub async fn handle_oauth_callback_desktop(
                 .to_string()
         })?;
 
-    let verifier = take_pkce_verifier_async()
-        .await
-        .ok_or_else(|| i18n.get_keys().login().pkce_not_found().inner().to_string())?;
+    let Some(verifier) = take_pkce_verifier_async().await else {
+        // Verifier already consumed → this callback was already processed
+        // (redelivered after Activity recreate / WASM reload). Silent skip, not
+        // an error, so a replayed callback does not surface pkce_not_found.
+        return Ok(None);
+    };
 
     let client = TrailBaseClient::new();
     let session = client
@@ -191,5 +194,7 @@ pub async fn handle_oauth_callback_desktop(
             .to_string());
     }
 
-    get_or_create_profile(auth_store, &session.email, i18n).await
+    get_or_create_profile(auth_store, &session.email, i18n)
+        .await
+        .map(Some)
 }

--- a/origa_ui/src/pages/login/oauth_listeners.rs
+++ b/origa_ui/src/pages/login/oauth_listeners.rs
@@ -43,7 +43,7 @@ pub fn setup_oauth_listener(auth_store: AuthStore, i18n: I18nContext<Locale>) {
 
     register_tauri_listener(callback);
 
-    check_pending_deep_link(auth_store, i18n);
+    poll_current_deep_link(auth_store, i18n);
 }
 
 fn extract_url_from_event(event: &JsValue) -> String {
@@ -67,7 +67,7 @@ async fn process_oauth_url(
     url: &str,
     auth_store: &AuthStore,
     i18n: &I18nContext<Locale>,
-) -> Result<User, String> {
+) -> Result<Option<User>, String> {
     let parsed = url::Url::parse(url);
     trace!(parsed = ?parsed, "URL parse result");
 
@@ -78,7 +78,9 @@ async fn process_oauth_url(
 
     if let Some(fragment) = url.split('#').nth(1) {
         debug!(fragment = %fragment, "URL has fragment, calling handle_oauth_callback");
-        return handle_oauth_callback(fragment, auth_store, i18n).await;
+        return handle_oauth_callback(fragment, auth_store, i18n)
+            .await
+            .map(Some);
     }
 
     error!(url = %url, "URL has no 'code' param and no fragment");
@@ -90,11 +92,14 @@ async fn process_oauth_url(
         .to_string())
 }
 
-fn handle_oauth_result(result: Result<User, String>, auth_store: &AuthStore) {
+fn handle_oauth_result(result: Result<Option<User>, String>, auth_store: &AuthStore) {
     match result {
-        Ok(user) => {
+        Ok(Some(user)) => {
             debug!(user_id = %user.id(), "OAuth success — updating user signal");
             auth_store.user.set(Some(user));
+        },
+        Ok(None) => {
+            debug!("OAuth callback skipped (verifier already consumed)");
         },
         Err(e) => {
             error!(error = %e, "OAuth callback error");
@@ -126,8 +131,17 @@ fn register_tauri_listener(callback: Closure<dyn Fn(JsValue)>) {
     }
 }
 
-fn check_pending_deep_link(auth_store: AuthStore, i18n: I18nContext<Locale>) {
-    debug!("check_pending_deep_link() called");
+fn poll_current_deep_link(auth_store: AuthStore, i18n: I18nContext<Locale>) {
+    debug!("poll_current_deep_link() called");
+
+    // Optimization: if a session is already restored, there is nothing to do.
+    // This is not the correctness guarantee (check_session may not have
+    // restored the user yet on a fresh mount) — the verifier-existence skip in
+    // handle_oauth_callback_desktop is the guarantee against replayed callbacks.
+    if auth_store.is_authenticated().get() {
+        debug!("already authenticated — skipping current deep-link poll");
+        return;
+    }
 
     let Some(invoke_fn) = tauri::invoke_fn() else {
         debug!("__TAURI__.core.invoke not available — not in Tauri, skipping");
@@ -136,13 +150,13 @@ fn check_pending_deep_link(auth_store: AuthStore, i18n: I18nContext<Locale>) {
 
     let Ok(result) = invoke_fn.call1(
         &JsValue::UNDEFINED,
-        &JsValue::from_str("get_pending_deep_link"),
+        &JsValue::from_str("get_current_deep_link"),
     ) else {
-        warn!("get_pending_deep_link invoke call failed");
+        warn!("get_current_deep_link invoke call failed");
         return;
     };
     let Ok(promise) = result.dyn_into::<js_sys::Promise>() else {
-        warn!("get_pending_deep_link did not return a Promise");
+        warn!("get_current_deep_link did not return a Promise");
         return;
     };
 
@@ -152,10 +166,10 @@ fn check_pending_deep_link(auth_store: AuthStore, i18n: I18nContext<Locale>) {
     let on_resolve = Closure::<dyn FnMut(JsValue)>::new(move |value: JsValue| {
         let url = value.as_string().unwrap_or_default();
         if url.is_empty() {
-            debug!("no pending deep-link");
+            debug!("no current deep-link");
             return;
         }
-        debug!(url = %url, "processing pending deep-link from cold start");
+        debug!(url = %url, "processing current deep-link from app load");
 
         let auth_store = auth_store_clone.clone();
         let i18n = i18n_clone;
@@ -163,14 +177,14 @@ fn check_pending_deep_link(auth_store: AuthStore, i18n: I18nContext<Locale>) {
         spawn_local(async move {
             auth_store.is_oauth_loading.set(true);
             let result = process_oauth_url(&url, &auth_store, &i18n).await;
-            debug!(result = ?result, "pending deep-link process result");
+            debug!(result = ?result, "current deep-link process result");
             handle_oauth_result(result, &auth_store);
             auth_store.is_oauth_loading.set(false);
         });
     });
 
     let on_reject = Closure::<dyn FnMut(JsValue)>::new(|err: JsValue| {
-        warn!(?err, "get_pending_deep_link promise rejected");
+        warn!(?err, "get_current_deep_link promise rejected");
     });
 
     let _ = promise.then2(&on_resolve, &on_reject);

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -2,19 +2,25 @@ mod auth_store;
 #[cfg(desktop)]
 mod updater_commands;
 
-use std::sync::Mutex;
-
 use auth_store::{auth_store_delete, auth_store_get, auth_store_set};
 use tauri::{Emitter, Listener, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
 #[cfg(desktop)]
 use updater_commands::{PendingUpdate, check_for_update, install_update};
 
-struct PendingDeepLink(Mutex<Option<String>>);
-
+/// Returns the deep-link URL that launched (or last targeted) the current
+/// Activity. The frontend polls this on mount because the `deep-link://new-url`
+/// event fires only on warm `onNewIntent`; see ADR-010 for the Android lifecycle.
 #[tauri::command]
-fn get_pending_deep_link(state: tauri::State<'_, PendingDeepLink>) -> Option<String> {
-    state.0.lock().unwrap_or_else(|e| e.into_inner()).take()
+fn get_current_deep_link(app: tauri::AppHandle) -> Option<String> {
+    match app.deep_link().get_current() {
+        Ok(Some(urls)) => urls.first().map(|url| url.to_string()),
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!("[deep-link] get_current error: {:?}", e);
+            None
+        },
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -40,9 +46,8 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_tts::init())
-        .manage(PendingDeepLink(Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
-            get_pending_deep_link,
+            get_current_deep_link,
             auth_store_get,
             auth_store_set,
             auth_store_delete,
@@ -84,32 +89,6 @@ pub fn run() {
             });
 
             tracing::info!("[deep-link] listener for 'deep-link://new-url' registered");
-
-            {
-                let pending = app.state::<PendingDeepLink>();
-                match app.deep_link().get_current() {
-                    Ok(Some(urls)) => {
-                        tracing::info!(
-                            "[deep-link] get_current() returned {} url(s) at startup",
-                            urls.len()
-                        );
-                        if let Some(url) = urls.first() {
-                            tracing::info!(
-                                "[deep-link] saved startup deep-link to pending: {}",
-                                url
-                            );
-                            *pending.0.lock().unwrap_or_else(|e| e.into_inner()) =
-                                Some(url.to_string());
-                        }
-                    },
-                    Ok(None) => {
-                        tracing::info!("[deep-link] get_current() returned no urls at startup");
-                    },
-                    Err(e) => {
-                        tracing::warn!("[deep-link] get_current() error at startup: {:?}", e);
-                    },
-                }
-            }
 
             #[cfg(any(windows, target_os = "linux"))]
             {


### PR DESCRIPTION
## Problem

On Android, OIDC login (Google/Yandex) worked intermittently: after returning from the external browser the app foregrounded but **nothing happened** — no loading overlay, no `/api/auth/v1/token` call. Stable on Windows and in the browser.

## Root cause

The `tauri-plugin-deep-link` contract (verified against upstream — reverted PR [#1770](https://github.com/tauri-apps/plugins-workspace/pull/1770) via [#2008](https://github.com/tauri-apps/plugins-workspace/pull/2008), [issue #1879](https://github.com/tauri-apps/plugins-workspace/issues/1879)):

- The `deep-link://new-url` event fires **only on warm `onNewIntent`**.
- On cold start / **Activity recreate** (warm process, OS killed the backgrounded Activity under memory pressure) the URL is available **only via `getCurrent()`** — no event is emitted.

The Rust `setup` snapshotted `get_current()` once into a single-shot `PendingDeepLink` (`Option` + `.take()`). `setup` runs once per process, so after Activity recreate the snapshot is stale → the frontend's pending-poll finds nothing → the URL is dropped. That's the intermittent: it depends on whether Android killed the Activity (memory pressure varies by device/browser load).

## Fix

- **Fresh `getCurrent()` poll on every frontend mount** (`get_current_deep_link` IPC command). Covers cold start **and** Activity recreate; the warm path keeps using the live `deep-link://new-url` listener. The single-shot `PendingDeepLink` snapshot is removed.
- **Verifier-existence dedup:** a missing PKCE verifier (already consumed) is now a silent `Ok(None)` skip, not a `pkce_not_found` error. Robust across WASM reload / Activity recreate because the verifier lives in the persistent Tauri store and is deleted on `take`.
- Dropped the orphaned `pkce_not_found` i18n key.

## Verification

| Check | Result |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ 0 warnings |
| `cargo fmt --check` | ✅ |
| `cargo build -p origa_ui --bin origa_ui_bin` | ✅ |
| `cargo test --workspace --lib` | ✅ origa 1517, origa_ui 241, 0 failed |
| Code review (@code-quality-reviewer) | ✅ approve (0 High) |

> Note: `cargo test --workspace` (with the bin target) fails on a **pre-existing** `recursion_limit` overflow in `grammar_practice_session` — verified via `git stash` (same overflow on clean `master`, unrelated to this change; landmine documented in `origa_ui/AGENTS.md`). Tests live in the lib crates, hence `--lib`.

## On-device confirmation (pending)

The Activity-recreate trigger can only be reproduced on a device. The `[deep-link]` traces are already in `tauri/src/lib.rs`:

```
adb logcat | grep deep-link
```

Expected after the fix: returning from the browser (after Android killed the Activity) shows the URL delivered via `get_current_deep_link` and a successful token exchange. A stale URL after a completed login should log `Ok(None)` skip with no error.

Refs: ADR-008, ADR-010.