### PR TITLE
🐛 fix(auth): recover OAuth deep-link on Android via resume polling

### DIFF
--- a/origa_ui/src/pages/login/oauth_buttons.rs
+++ b/origa_ui/src/pages/login/oauth_buttons.rs
@@ -1,8 +1,9 @@
 use crate::core::tauri;
-use crate::i18n::{t, use_i18n};
+use crate::i18n::{I18nContext, Locale, t, use_i18n};
 use crate::repository::OAuthProvider;
 use crate::repository::set_pkce_verifier_async;
 use crate::repository::trailbase_client::trailbase_url;
+use crate::store::auth_store::AuthStore;
 use js_sys::Promise;
 use leptos::prelude::*;
 use leptos::task::spawn_local;
@@ -82,6 +83,9 @@ pub fn OAuthButtons(
     #[prop(optional)] debug_sink: Option<OAuthDebugSink>,
 ) -> impl IntoView {
     let i18n = use_i18n();
+    let auth_store = use_context::<AuthStore>().expect("AuthStore not provided");
+    let auth_store_google = auth_store.clone();
+    let auth_store_yandex = auth_store.clone();
     let test_id_val = move || {
         let val = test_id.get();
         if val.is_empty() { None } else { Some(val) }
@@ -112,8 +116,9 @@ pub fn OAuthButtons(
                 class="w-full flex items-center justify-center gap-3 px-4 py-3 border border-[var(--border-dark)] bg-[var(--bg-cream)] hover:bg-[var(--bg-aged)] transition-colors"
                 data-testid=google_test_id
                 on:click=move |_: leptos::ev::MouseEvent| {
+                    let auth_store = auth_store_google.clone();
                     spawn_local(async move {
-                        open_oauth_url(OAuthProvider::Google, debug_sink).await;
+                        open_oauth_url(OAuthProvider::Google, debug_sink, auth_store, i18n).await;
                     });
                 }
             >
@@ -126,8 +131,9 @@ pub fn OAuthButtons(
                 class="w-full flex items-center justify-center gap-3 px-4 py-3 border border-[var(--border-dark)] bg-[var(--bg-cream)] hover:bg-[var(--bg-aged)] transition-colors"
                 data-testid=yandex_test_id
                 on:click=move |_: leptos::ev::MouseEvent| {
+                    let auth_store = auth_store_yandex.clone();
                     spawn_local(async move {
-                        open_oauth_url(OAuthProvider::Yandex, debug_sink).await;
+                        open_oauth_url(OAuthProvider::Yandex, debug_sink, auth_store, i18n).await;
                     });
                 }
             >
@@ -202,7 +208,12 @@ fn open_url_external(url: &str, debug_sink: Option<OAuthDebugSink>) {
     }
 }
 
-async fn open_oauth_url(provider: OAuthProvider, debug_sink: Option<OAuthDebugSink>) {
+async fn open_oauth_url(
+    provider: OAuthProvider,
+    debug_sink: Option<OAuthDebugSink>,
+    auth_store: AuthStore,
+    i18n: I18nContext<Locale>,
+) {
     use crate::repository::TrailBaseClient;
     use crate::repository::trailbase_auth::{generate_pkce_challenge, generate_pkce_verifier};
 
@@ -245,6 +256,13 @@ async fn open_oauth_url(provider: OAuthProvider, debug_sink: Option<OAuthDebugSi
     report_debug!(debug_sink, "oauth url built: {url}");
 
     open_url_external(&url, debug_sink);
+
+    // On Android the WebView JS is frozen while the app is backgrounded in the
+    // external browser, so the deep-link callback event emitted by Rust on
+    // return is lost (its webview.eval delivery never runs). Polling on a timer
+    // sidesteps the missing resume signal: the timer pauses while frozen and
+    // resumes on Activity onResume, recovering the pending callback URL.
+    super::oauth_listeners::start_resume_polling(auth_store, i18n);
 }
 
 #[component]

--- a/origa_ui/src/pages/login/oauth_listeners.rs
+++ b/origa_ui/src/pages/login/oauth_listeners.rs
@@ -3,12 +3,15 @@ use crate::i18n::{I18nContext, Locale};
 use crate::pages::login::auth_handlers::{handle_oauth_callback, handle_oauth_callback_desktop};
 use crate::repository::take_pkce_verifier_async;
 use crate::store::auth_store::AuthStore;
+use gloo_timers::future::TimeoutFuture;
 use leptos::prelude::*;
 use leptos::task::spawn_local;
 use leptos::wasm_bindgen::JsCast;
 use leptos::wasm_bindgen::prelude::*;
 use origa::domain::User;
+use std::sync::{Mutex, OnceLock};
 use tracing::{debug, error, trace, warn};
+use wasm_bindgen_futures::JsFuture;
 
 const LOGIN_PATH: &str = "/login";
 
@@ -33,6 +36,11 @@ pub fn setup_oauth_listener(auth_store: AuthStore, i18n: I18nContext<Locale>) {
         auth_store.oauth_error.set(None);
         spawn_local(async move {
             debug!(url = %url, "processing oauth url");
+            if url.starts_with("origa://auth/callback") {
+                *last_processed_callback()
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = Some(url.clone());
+            }
             auth_store.is_oauth_loading.set(true);
             let result = process_oauth_url(&url, &auth_store, &i18n).await;
             debug!(result = ?result, "process_oauth_url result");
@@ -175,6 +183,11 @@ fn poll_current_deep_link(auth_store: AuthStore, i18n: I18nContext<Locale>) {
         let i18n = i18n_clone;
         auth_store.oauth_error.set(None);
         spawn_local(async move {
+            if url.starts_with("origa://auth/callback") {
+                *last_processed_callback()
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = Some(url.clone());
+            }
             auth_store.is_oauth_loading.set(true);
             let result = process_oauth_url(&url, &auth_store, &i18n).await;
             debug!(result = ?result, "current deep-link process result");
@@ -190,6 +203,79 @@ fn poll_current_deep_link(auth_store: AuthStore, i18n: I18nContext<Locale>) {
     let _ = promise.then2(&on_resolve, &on_reject);
     on_resolve.forget();
     on_reject.forget();
+}
+
+async fn fetch_current_deep_link_url() -> Option<String> {
+    let invoke_fn = tauri::invoke_fn()?;
+    let result = invoke_fn
+        .call1(
+            &JsValue::UNDEFINED,
+            &JsValue::from_str("get_current_deep_link"),
+        )
+        .ok()?;
+    let promise = result.dyn_into::<js_sys::Promise>().ok()?;
+    JsFuture::from(promise).await.ok()?.as_string()
+}
+
+// Cross-attempt memory of the last auth-callback URL processed by the poll.
+// `get_current()` does not clear after read (returns the same URL until a new
+// deep link arrives), so without this a retry that starts a new poll would
+// re-process the stale previous URL and stop before the fresh redirect arrives.
+static LAST_PROCESSED_AUTH_CALLBACK: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+
+fn last_processed_callback() -> &'static Mutex<Option<String>> {
+    LAST_PROCESSED_AUTH_CALLBACK.get_or_init(|| Mutex::new(None))
+}
+
+/// Polls the pending deep-link URL on a short interval after the user opens the
+/// OAuth provider externally. On Android the WebView JS is frozen while
+/// backgrounded, so the live `deep-link-received` event emitted during that
+/// window is lost; the poll's timer is paused while frozen and resumes on
+/// Activity `onResume`, recovering the pending callback URL. See ADR-010.
+pub fn start_resume_polling(auth_store: AuthStore, i18n: I18nContext<Locale>) {
+    spawn_local(async move {
+        const POLL_INTERVAL_MS: u32 = 1500;
+        const MAX_POLLS: usize = 120;
+
+        for _ in 0..MAX_POLLS {
+            TimeoutFuture::new(POLL_INTERVAL_MS).await;
+
+            if auth_store.user.with(|u| u.is_some()) {
+                debug!("resume-poll: authenticated, stopping");
+                return;
+            }
+
+            let Some(url) = fetch_current_deep_link_url().await else {
+                continue;
+            };
+            if !url.starts_with("origa://auth/callback") {
+                continue;
+            }
+
+            let already_processed = last_processed_callback()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .as_deref()
+                == Some(url.as_str());
+            if already_processed {
+                // Stale URL from a previous attempt; keep polling for a fresh one.
+                continue;
+            }
+
+            debug!(url = %url, "resume-poll: processing auth callback");
+            *last_processed_callback()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = Some(url.clone());
+            auth_store.oauth_error.set(None);
+            auth_store.is_oauth_loading.set(true);
+            let result = process_oauth_url(&url, &auth_store, &i18n).await;
+            debug!(result = ?result, "resume-poll process result");
+            handle_oauth_result(result, &auth_store);
+            auth_store.is_oauth_loading.set(false);
+            return;
+        }
+        debug!("resume-poll: deadline reached without callback");
+    });
 }
 
 pub fn check_url_oauth_callback(auth_store: &AuthStore, i18n: &I18nContext<Locale>) {


### PR DESCRIPTION
## Problem

On Android, OIDC login (Google/Yandex) was intermittent: after returning from the external browser the app foregrounded but **nothing happened** — no loading overlay, no `/api/auth/v1/token`. Stable on Windows, in the browser, and in **split-screen**.

## Root cause (verified)

While the app is backgrounded in the external OAuth browser, the Android **WebView JS is frozen** (webview throttling, not disableable). The `deep-link-received` event emitted by Rust on return is delivered via `webview.eval(JS)`, which **never runs** in frozen JS → the event is lost. Split-screen is stable because the JS never freezes.

This is the real cause behind the earlier PR #260 attempt (which targeted Activity-recreate with a one-shot `getCurrent` snapshot — it didn't help, because warm return doesn't remount the frontend and the live event is lost in frozen JS).

## Fix

After opening the OAuth provider, start a **self-rescheduling poll** (`gloo_timers::future::TimeoutFuture`, 1.5s × 120 = 3 min) that invokes `get_current_deep_link`. The timer pauses while the JS is frozen and resumes on Activity `onResume`, so the next tick recovers the pending callback URL against the now-active JS and processes it.

This sidesteps the **absence of a resume signal in Tauri 2.10.3**: `tauri-runtime-wry` does not route Android `onResume` to any `RunEvent`, and `WindowEvent::Resumed` does not exist (verified by compile-check + source grep). A Rust-side resume handler is therefore impossible in 2.10.3; a frontend timer is the reliable alternative.

### Guard (cross-attempt dedup)

A static `LAST_PROCESSED_AUTH_CALLBACK` (`OnceLock<Mutex<Option<String>>>`) remembers the last processed auth-callback URL. `get_current()` does **not** clear after read (verified: `tauri-plugin-deep-link 2.4.7` returns a clone of the cached URL), so without this a retry would re-process the stale previous URL, fail (code/verifier mismatch), and stop before the fresh redirect arrives. The guard is updated from all three process sites (live event, cold-start poll, resume poll) and skips stale URLs via `continue` (keeps polling for a fresh one).

Dedup against the live-event path is via the PKCE verifier (`take_pkce_verifier_async` single-consumption, `Ok(None)` silent skip from PR #260).

## Verification

| Check | Result |
| --- | --- |
| `cargo fmt --check` | ✅ |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ 0 warnings |
| `cargo build -p origa_ui --bin origa_ui_bin` | ✅ |
| `cargo test --workspace --lib` | ✅ origa 1517, origa_ui 250+10, 0 failed |
| Code review (@code-quality-reviewer) | ✅ approve (3 rounds: blocked Rust `WindowEvent::Resumed` approach caught & reverted → frontend polling → guard added) |

> **On-device verification is pending** (no Android device in this environment). Poll traces (`resume-poll: ...`) go to `tracing::debug!` → logcat for `adb logcat` confirmation after merge. Expected: warm resume from browser → poll tick recovers the URL → login completes; stale URL after a completed login → `continue` skip, no error.

## Scope & long-term

This is an **interim** fix. The architecturally correct long-term solution is a native in-app auth-session plugin (`ASWebAuthenticationSession` / Chrome Custom Tabs — e.g. `tauri-plugin-auth-session`), where the app is never backgrounded and the class of problem disappears entirely. That path is blocked on a **backend change** (registering `origa://` as a redirect URI in the Google/Yandex OAuth consoles + TrailBase whitelist) and is tracked separately.

Refs: ADR-008, ADR-010, PR #260.