### PR TITLE
Auto-detect UI language + reduce DailyLoad new cards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ leptos_axum = "0.8"
 leptos_icons = "0.7"
 icondata = "0.7"
 leptos-use = { version = "0.18" }
-leptos_i18n = { version = "0.6", default-features = false, features = ["csr", "plurals"] }
+leptos_i18n = { version = "0.6", default-features = false, features = ["csr", "plurals", "cookie"] }
 leptos_i18n_build = { version = "0.6", default-features = false, features = ["csr", "plurals"] }
 pulldown-cmark = "0.12"
 ammonia = "4"

--- a/origa/src/domain/value_objects.rs
+++ b/origa/src/domain/value_objects.rs
@@ -242,12 +242,12 @@ pub enum DailyLoad {
 impl DailyLoad {
     pub fn new_cards_per_day(&self) -> usize {
         match self {
-            DailyLoad::Minimal => 5,
-            DailyLoad::Light => 10,
-            DailyLoad::Medium => 15,
-            DailyLoad::Hard => 25,
-            DailyLoad::Heavy => 35,
-            DailyLoad::Maximum => 50,
+            DailyLoad::Minimal => 3,
+            DailyLoad::Light => 6,
+            DailyLoad::Medium => 9,
+            DailyLoad::Hard => 15,
+            DailyLoad::Heavy => 21,
+            DailyLoad::Maximum => 30,
         }
     }
 
@@ -675,12 +675,12 @@ mod tests_daily_load {
 
     #[test]
     fn new_cards_per_day_values() {
-        assert_eq!(DailyLoad::Minimal.new_cards_per_day(), 5);
-        assert_eq!(DailyLoad::Light.new_cards_per_day(), 10);
-        assert_eq!(DailyLoad::Medium.new_cards_per_day(), 15);
-        assert_eq!(DailyLoad::Hard.new_cards_per_day(), 25);
-        assert_eq!(DailyLoad::Heavy.new_cards_per_day(), 35);
-        assert_eq!(DailyLoad::Maximum.new_cards_per_day(), 50);
+        assert_eq!(DailyLoad::Minimal.new_cards_per_day(), 3);
+        assert_eq!(DailyLoad::Light.new_cards_per_day(), 6);
+        assert_eq!(DailyLoad::Medium.new_cards_per_day(), 9);
+        assert_eq!(DailyLoad::Hard.new_cards_per_day(), 15);
+        assert_eq!(DailyLoad::Heavy.new_cards_per_day(), 21);
+        assert_eq!(DailyLoad::Maximum.new_cards_per_day(), 30);
     }
 
     #[test]

--- a/origa_landing/src/components/layout.rs
+++ b/origa_landing/src/components/layout.rs
@@ -2,7 +2,7 @@ use leptos::prelude::*;
 use leptos_meta::Html;
 use leptos_router::components::{A, Outlet};
 
-use crate::content::Locale;
+use crate::content::{LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE_SECS, Locale};
 
 fn make_href(prefix: &str, page: &str) -> String {
     format!("{prefix}/{page}")
@@ -30,7 +30,7 @@ pub fn Layout(locale: Locale) -> impl IntoView {
             } else {
                 loc.path_prefix().to_string()
             };
-            (*loc, loc.display_label(), href)
+            (*loc, loc.display_label(), href, loc.as_str())
         })
         .collect();
 
@@ -63,37 +63,21 @@ pub fn Layout(locale: Locale) -> impl IntoView {
                 <span class="landing-header__nav-sep">"|"</span>
                 <span class="landing-header__lang">
                     <span class="landing-header__lang-current">{locale.display_label()}</span>
-                    {lang_switcher_items.into_iter().flat_map(|(_, label, href)| {
+                    {lang_switcher_items.into_iter().flat_map(|(_, label, href, code)| {
                         vec![
                             view! { <span class="landing-header__lang-sep">" · "</span> }.into_any(),
-                            view! { <a href=href class="landing-header__lang-link">{label}</a> }
+                            view! {
+                                <a href=href class="landing-header__lang-link" attr:data-locale=code>
+                                    {label}
+                                </a>
+                            }
                                 .into_any(),
                         ]
                     }).collect_view()}
                 </span>
             </nav>
         </header>
-        <script>"
-            (function() {
-                var btn = document.querySelector('.landing-header__hamburger');
-                var nav = document.getElementById('main-nav');
-                if (!btn || !nav) return;
-                btn.addEventListener('click', function() {
-                    var open = nav.classList.toggle('is-open');
-                    btn.classList.toggle('is-open');
-                    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-                    btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
-                });
-                document.addEventListener('keydown', function(e) {
-                    if (e.key === 'Escape' && nav.classList.contains('is-open')) {
-                        nav.classList.remove('is-open');
-                        btn.classList.remove('is-open');
-                        btn.setAttribute('aria-expanded', 'false');
-                        btn.setAttribute('aria-label', 'Open menu');
-                    }
-                });
-            })();
-        "</script>
+        <script inner_html=header_inline_script() />
         {if locale.is_development() {
             view! {
                 <div class="landing-wip-banner">{c.banner_wip}</div>
@@ -166,4 +150,45 @@ fn NavLink(
     view! {
         <A href=target attr:class=class>{children()}</A>
     }
+}
+
+/// Inline script for the header: toggles the mobile nav and persists the
+/// visitor's language choice. Built with `format!` so the cookie name and
+/// max-age come from the same constants the `negotiate_locale` middleware
+/// reads, instead of a second hardcoded copy that could drift.
+fn header_inline_script() -> String {
+    format!(
+        r#"
+            (function() {{
+                var btn = document.querySelector('.landing-header__hamburger');
+                var nav = document.getElementById('main-nav');
+                if (!btn || !nav) return;
+                btn.addEventListener('click', function() {{
+                    var open = nav.classList.toggle('is-open');
+                    btn.classList.toggle('is-open');
+                    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+                    btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+                }});
+                document.addEventListener('keydown', function(e) {{
+                    if (e.key === 'Escape' && nav.classList.contains('is-open')) {{
+                        nav.classList.remove('is-open');
+                        btn.classList.remove('is-open');
+                        btn.setAttribute('aria-expanded', 'false');
+                        btn.setAttribute('aria-label', 'Open menu');
+                    }}
+                }});
+                // Persist the language choice so the locale-negotiation
+                // middleware on "/" redirects returning visitors to their
+                // locale. Writing the cookie on click (including for English)
+                // before navigation is what prevents a user on a localised
+                // path from being bounced back when they switch to English.
+                document.querySelectorAll('.landing-header__lang-link').forEach(function(a) {{
+                    a.addEventListener('click', function() {{
+                        document.cookie = '{LOCALE_COOKIE}=' + a.getAttribute('data-locale')
+                            + '; path=/; max-age={LOCALE_COOKIE_MAX_AGE_SECS}; SameSite=Lax';
+                    }});
+                }});
+            }})();
+        "#
+    )
 }

--- a/origa_landing/src/content/mod.rs
+++ b/origa_landing/src/content/mod.rs
@@ -1,5 +1,15 @@
 use std::str::FromStr;
 
+/// Name of the cookie that records a visitor's chosen UI locale on the landing
+/// site. Shared between the `negotiate_locale` middleware (reads it) and the
+/// language switcher in `Layout` (writes it client-side); keeping it a single
+/// constant prevents the two sides from drifting apart silently.
+pub const LOCALE_COOKIE: &str = "origa_locale";
+
+/// Lifetime of [`LOCALE_COOKIE`], in seconds (HTTP `Max-Age` unit). One year,
+/// matching the persistent locale cookie of the CSR app.
+pub const LOCALE_COOKIE_MAX_AGE_SECS: u64 = 365 * 24 * 60 * 60;
+
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Locale {
     En,

--- a/origa_landing/src/server.rs
+++ b/origa_landing/src/server.rs
@@ -3,17 +3,20 @@
 //! Kept in a library module (rather than inline in `main.rs`) so integration
 //! tests in `tests/` can build the exact same router the binary serves.
 
+use std::str::FromStr;
+
 use axum::Router;
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Redirect, Response};
-use http::header::{CACHE_CONTROL, HeaderName, HeaderValue};
-use http::{Method, Request, Uri};
+use http::header::{ACCEPT_LANGUAGE, CACHE_CONTROL, COOKIE, HeaderName, HeaderValue, VARY};
+use http::{HeaderMap, Method, Request, Uri};
 use leptos::config::LeptosOptions;
 use leptos_axum::{ErrorHandler, LeptosRoutes};
 use tower_http::ServiceExt;
 use tower_http::services::{ServeDir, ServeFile};
 
 use crate::app::{App, shell};
+use crate::content::{LOCALE_COOKIE, Locale};
 
 /// HTML pages: short edge cache so users pick up content/nav changes within
 /// 5 minutes, while still letting Cloudflare absorb most origin traffic.
@@ -36,6 +39,13 @@ const NO_CACHE: &str = "no-cache";
 /// `max-age >= 86400` so link equity transfer is not delayed by re-redirects.
 const REDIRECT_CACHE: &str = "public, max-age=86400";
 
+/// `Vary` value forcing edge caches to keep separate entries per combination
+/// of the two request headers that drive locale negotiation on "/". Without
+/// it a cached English "/" is served to a non-English user before the
+/// `negotiate_locale` redirect can fire — the exact CDN edge-poisoning
+/// regression class fixed in ADR-011 / PR #182.
+const VARY_LOCALE: &str = "Cookie, Accept-Language";
+
 /// Build the production Axum router.
 ///
 /// Layering summary (request flows top → bottom; the LAST `.layer()` call is
@@ -51,12 +61,21 @@ const REDIRECT_CACHE: &str = "public, max-age=86400";
 /// 2. `strip_trailing_slash` — normalises `/ru/`, `/images/`, `/favicon.png/`
 ///    to their canonical slash-less form. 308 responses produced here carry
 ///    `REDIRECT_CACHE` directly and short-circuit the inner stack.
-/// 3. `enforce_cache_policy` — applies the cache-control contract to every
+/// 3. `negotiate_locale` — only fires on `GET`/`HEAD "/"`: resolves the
+///    visitor's preferred locale (saved `origa_locale` cookie, else
+///    `Accept-Language`) and, when it is not English, emits a `307` to the
+///    localised path with `Cache-Control: no-cache` + `Vary: Cookie,
+///    Accept-Language`. English and unresolvable requests fall through.
+/// 4. `enforce_cache_policy` — applies the cache-control contract to every
 ///    non-redirect response produced by the inner stack:
 ///    - 2xx without an explicit `Cache-Control` → stamped with `HTML_CACHE`
 ///      (the default for leptos HTML routes, which set no header themselves).
 ///    - 2xx with `Cache-Control` → left intact (static assets keep
 ///      `IMMUTABLE_CACHE`; robots/sitemap keep `NO_CACHE`).
+///    - 2xx on "/" → additionally stamped with `Vary: Cookie, Accept-Language`,
+///      because "/" is content-negotiated by `negotiate_locale` (see above);
+///      without it a cached English "/" would be served to non-English
+///      visitors before the redirect can fire (ADR-011 / PR #182).
 ///    - 4xx/5xx → overridden to `NO_CACHE`, regardless of what the inner
 ///      service set. Without this, `ServeDir`/`ServeFile` would stamp
 ///      `IMMUTABLE_CACHE` on a 404 via `insert_response_header_if_not_present`
@@ -66,8 +85,9 @@ const REDIRECT_CACHE: &str = "public, max-age=86400";
 ///    - 3xx → passed through unchanged. The only 3xx from inner services is
 ///      `304 Not Modified` on conditional requests, which must keep the same
 ///      `Cache-Control` the corresponding 200 would have. `308`s from
-///      `strip_trailing_slash` never reach this middleware (it is one layer
-///      further out and short-circuits the inner stack).
+///      `strip_trailing_slash` and `307`s from `negotiate_locale` never reach
+///      this middleware (they are layers further out and short-circuit the
+///      inner stack).
 ///
 /// Fallback chain: when neither explicit static routes nor leptos' registered
 /// routes match a path, the request hits `ServeDir(public/)`; if no file is
@@ -172,6 +192,7 @@ pub fn build_router(leptos_options: LeptosOptions) -> Router {
         // that additionally overrides `Cache-Control` to `NO_CACHE` on 4xx/5xx.
         // See `enforce_cache_policy` below for the full rationale.
         .layer(middleware::from_fn(enforce_cache_policy))
+        .layer(middleware::from_fn(negotiate_locale))
         .layer(middleware::from_fn(strip_trailing_slash))
         .layer(middleware::from_fn(security_headers))
         .with_state(leptos_options)
@@ -201,6 +222,7 @@ pub fn build_router(leptos_options: LeptosOptions) -> Router {
 /// this middleware: they are produced by a layer *outside* this one, which
 /// short-circuits the inner stack.
 async fn enforce_cache_policy(request: Request<axum::body::Body>, next: Next) -> Response {
+    let is_root = request.uri().path() == "/";
     let mut response = next.run(request).await;
     let status = response.status();
 
@@ -208,13 +230,160 @@ async fn enforce_cache_policy(request: Request<axum::body::Body>, next: Next) ->
         response
             .headers_mut()
             .insert(CACHE_CONTROL, HeaderValue::from_static(NO_CACHE));
-    } else if status.is_success() && !response.headers().contains_key(CACHE_CONTROL) {
-        response
-            .headers_mut()
-            .insert(CACHE_CONTROL, HeaderValue::from_static(HTML_CACHE));
+    } else if status.is_success() {
+        if !response.headers().contains_key(CACHE_CONTROL) {
+            response
+                .headers_mut()
+                .insert(CACHE_CONTROL, HeaderValue::from_static(HTML_CACHE));
+        }
+        // The site root "/" is content-negotiated by `negotiate_locale`: the
+        // same URL yields a 200 (English) or a 307 redirect depending on the
+        // request's `Cookie`/`Accept-Language`. An edge cache MUST vary on
+        // those headers, otherwise it serves a cached English 200 to a
+        // non-English user instead of letting the redirect fire — the CDN
+        // edge-poisoning regression class fixed in ADR-011 / PR #182. Every
+        // other path is locale-determined by its URL prefix, so it needs no
+        // `Vary`.
+        if is_root {
+            response
+                .headers_mut()
+                .insert(VARY, HeaderValue::from_static(VARY_LOCALE));
+        }
     }
 
     response
+}
+
+/// Middleware: locale negotiation on the site root.
+///
+/// The root path "/" is the canonical English URL (no locale prefix). Rather
+/// than force every visitor to find the language switcher, this middleware
+/// resolves a preferred locale for a `GET`/`HEAD` to "/" and, when it is not
+/// English, emits a temporary redirect to the matching localised path
+/// (`/ru`, `/ko`, `/vi`). Resolution order: a saved `origa_locale` cookie
+/// wins, otherwise the `Accept-Language` header. English, or requests where
+/// no preference can be resolved, fall through to a normal English "/".
+///
+/// Redirects are `307` (temporary, method-preserving) and carry `Cache-Control: no-cache` plus
+/// `Vary: Cookie, Accept-Language`, because the target depends on those
+/// headers: a permanent or edge-cached redirect would pin one user's locale
+/// for everyone (the ADR-011 / PR #182 edge-poisoning class). The cookie is
+/// written client-side by the language switcher on every switch — including
+/// to English — so a user on `/ko` who clicks "EN" lands on "/" and is not
+/// bounced back.
+async fn negotiate_locale(
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    if (method != Method::GET && method != Method::HEAD) || uri.path() != "/" {
+        return next.run(request).await;
+    }
+
+    let Some(locale) = preferred_locale(&headers) else {
+        return next.run(request).await;
+    };
+
+    let location = match uri.query() {
+        Some(query) if !query.is_empty() => format!("{}?{query}", locale.path_prefix()),
+        _ => locale.path_prefix().to_string(),
+    };
+    let mut response = Redirect::temporary(&location).into_response();
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static(NO_CACHE));
+    response
+        .headers_mut()
+        .insert(VARY, HeaderValue::from_static(VARY_LOCALE));
+    response
+}
+
+/// Resolve the preferred non-English locale for a request to "/": an explicit
+/// `origa_locale` cookie takes precedence over `Accept-Language`; if no cookie
+/// is present, `Accept-Language` is consulted. Returns `None` for English (the
+/// default root) so the caller can fall through to a normal 200.
+///
+/// Crucially, an explicit English cookie must win over a non-English
+/// `Accept-Language`: a visitor who switched to English on a localised path
+/// must land on "/" and not be bounced back by their browser's language.
+/// That requires distinguishing "no cookie" (fall back to `Accept-Language`)
+/// from "cookie = en" (honour the choice, no redirect).
+fn preferred_locale(headers: &HeaderMap) -> Option<Locale> {
+    if let Some(locale) = cookie_locale(headers) {
+        // An explicit cookie wins entirely, including English (no redirect).
+        return (locale != Locale::En).then_some(locale);
+    }
+    let accept = headers.get(ACCEPT_LANGUAGE)?.to_str().ok()?;
+    locale_from_accept_language(accept)
+}
+
+/// Read the explicit locale from the `origa_locale` cookie, if present and
+/// valid. Returns the locale **including English** — `None` means the cookie
+/// is absent or malformed, signalling the caller to fall back to
+/// `Accept-Language`. Conflating "absent" with "English" would let a
+/// non-English browser override an explicit English choice.
+fn cookie_locale(headers: &HeaderMap) -> Option<Locale> {
+    let cookie = headers.get(COOKIE)?.to_str().ok()?;
+    for pair in cookie.split(';') {
+        let pair = pair.trim();
+        let Some(value) = pair
+            .strip_prefix(LOCALE_COOKIE)
+            .and_then(|rest| rest.strip_prefix('='))
+        else {
+            continue;
+        };
+        if let Ok(locale) = Locale::from_str(value) {
+            return Some(locale);
+        }
+    }
+    None
+}
+
+fn locale_from_accept_language(header: &str) -> Option<Locale> {
+    // Parse Accept-Language per RFC 7231 §5.3.5, e.g.
+    // "en-US,en;q=0.9,ru;q=0.8". Each entry becomes (primary subtag, q). Tags
+    // with q=0 ("not acceptable") are dropped. The entries are then sorted by
+    // q descending — stable, so ties keep the header's listed order — and the
+    // first supported locale (en/ru/ko/vi) wins. English resolves to `None`
+    // (the root URL); a non-English locale becomes a redirect target.
+    //
+    // Q-values matter: an English-primary bilingual ("en;q=0.9,ru;q=0.8") must
+    // NOT be redirected to Russian. A naive "first supported non-English tag"
+    // scan would send them there.
+    let mut entries: Vec<(String, f32)> = header
+        .split(',')
+        .filter_map(|raw| {
+            let mut parts = raw.split(';');
+            let tag = parts.next()?.trim().to_lowercase();
+            if tag.is_empty() {
+                return None;
+            }
+            let primary = tag.split('-').next()?.to_string();
+            let q = parts
+                .next()
+                .and_then(|param| param.trim().strip_prefix("q="))
+                .and_then(|v| v.trim().parse::<f32>().ok())
+                .unwrap_or(1.0);
+            if q <= 0.0 {
+                return None;
+            }
+            Some((primary, q))
+        })
+        .collect();
+    entries.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    for (primary, _) in &entries {
+        match primary.as_str() {
+            "en" => return None,
+            "ru" => return Some(Locale::Ru),
+            "ko" => return Some(Locale::Ko),
+            "vi" => return Some(Locale::Vi),
+            _ => {},
+        }
+    }
+    None
 }
 
 /// Middleware: redirect `/path/` to `/path` with HTTP 308 Permanent Redirect.

--- a/origa_landing/tests/cache_headers.rs
+++ b/origa_landing/tests/cache_headers.rs
@@ -11,7 +11,10 @@
 #![cfg(feature = "ssr")]
 
 use axum::body::Body;
-use http::{Request, StatusCode, header::CACHE_CONTROL};
+use http::{
+    Request, StatusCode,
+    header::{CACHE_CONTROL, VARY},
+};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
@@ -47,9 +50,35 @@ async fn status_and_cache_control(uri: &str) -> (StatusCode, Option<String>) {
 }
 
 #[tokio::test]
-async fn html_root_has_short_edge_cache() {
-    let cc = cache_control("/").await;
+async fn html_root_has_short_edge_cache_and_locale_vary() {
+    // "/" is content-negotiated by `negotiate_locale`, so its 200 must carry
+    // both the short edge cache and a `Vary` on the negotiation headers.
+    // Without `Vary`, an edge-cached English "/" would be served to
+    // non-English visitors before the redirect can fire (ADR-011 / PR #182).
+    let response = common::test_router()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("router responded");
+
+    let cc = response
+        .headers()
+        .get(CACHE_CONTROL)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let vary = response
+        .headers()
+        .get(VARY)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    let _ = response.into_body().collect().await.expect("body");
     assert_eq!(cc.as_deref(), Some("public, max-age=300"));
+    assert_eq!(vary.as_deref(), Some("Cookie, Accept-Language"));
 }
 
 #[tokio::test]

--- a/origa_landing/tests/locale_negotiate.rs
+++ b/origa_landing/tests/locale_negotiate.rs
@@ -1,0 +1,297 @@
+//! Integration tests for the `negotiate_locale` middleware.
+//!
+//! Behaviour under test: a `GET`/`HEAD "/"` is redirected to the visitor's
+//! preferred locale (`/ru`, `/ko`, `/vi`) when that locale is not English.
+//! Preference comes from a saved `origa_locale` cookie, falling back to the
+//! `Accept-Language` header. English and unresolvable requests fall through to
+//! a normal 200. Redirects are temporary (`307`, method-preserving), non-cacheable, and carry
+//! `Vary: Cookie, Accept-Language` so an edge cache never serves one user's
+//! locale answer to another (ADR-011 / PR #182).
+
+#![cfg(feature = "ssr")]
+
+use axum::body::Body;
+use http::header::{ACCEPT_LANGUAGE, CACHE_CONTROL, COOKIE, LOCATION, VARY};
+use http::{HeaderMap, HeaderValue, Method, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+mod common;
+
+/// Run `method uri` through the production router, optionally stamping an
+/// `Accept-Language` and/or `Cookie` header, and return the status plus a
+/// cloned copy of the response headers.
+async fn request(
+    uri: &str,
+    method: Method,
+    accept_language: Option<&str>,
+    cookie: Option<&str>,
+) -> (StatusCode, HeaderMap) {
+    let mut builder = http::Request::builder().method(method).uri(uri);
+    if let Some(value) = accept_language {
+        builder = builder.header(ACCEPT_LANGUAGE, value);
+    }
+    if let Some(value) = cookie {
+        builder = builder.header(COOKIE, value);
+    }
+
+    let response = common::test_router()
+        .oneshot(builder.body(Body::empty()).expect("valid request"))
+        .await
+        .expect("router responded");
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let _ = response.into_body().collect().await.expect("body");
+    (status, headers)
+}
+
+fn header_value(headers: &HeaderMap, name: &http::HeaderName) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+}
+
+#[rstest::rstest]
+#[case::ru("ru", "/ru")]
+#[case::ko("ko", "/ko")]
+#[case::vi("vi", "/vi")]
+#[case::ru_region("ru-RU,ru;q=0.9,en;q=0.8", "/ru")]
+#[tokio::test]
+async fn accept_language_redirects_to_localised_root(
+    #[case] header: &str,
+    #[case] expected_location: &str,
+) {
+    let (status, headers) = request("/", Method::GET, Some(header), None).await;
+
+    assert_eq!(
+        status,
+        StatusCode::TEMPORARY_REDIRECT,
+        "headers={:?}",
+        headers
+    );
+    assert_eq!(
+        header_value(&headers, &LOCATION).as_deref(),
+        Some(expected_location)
+    );
+    assert_eq!(
+        header_value(&headers, &CACHE_CONTROL).as_deref(),
+        Some("no-cache")
+    );
+    assert_eq!(
+        header_value(&headers, &VARY).as_deref(),
+        Some("Cookie, Accept-Language")
+    );
+}
+
+#[rstest::rstest]
+#[case::ru("ru", "/ru")]
+#[case::ko("ko", "/ko")]
+#[case::vi("vi", "/vi")]
+#[tokio::test]
+async fn saved_cookie_redirects_to_localised_root(
+    #[case] value: &str,
+    #[case] expected_location: &str,
+) {
+    let (status, headers) = request(
+        "/",
+        Method::GET,
+        None,
+        Some(&format!("origa_locale={value}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
+    assert_eq!(
+        header_value(&headers, &LOCATION).as_deref(),
+        Some(expected_location)
+    );
+    assert_eq!(
+        header_value(&headers, &CACHE_CONTROL).as_deref(),
+        Some("no-cache")
+    );
+}
+
+#[rstest::rstest]
+#[case::en("en")]
+#[case::en_region("en-US,en;q=0.9")]
+#[case::en_primary_with_ru_secondary("en-US,en;q=0.9,ru;q=0.8")]
+#[case::unsupported_ja("ja,en;q=0.5")]
+#[case::ru_not_acceptable("ru;q=0,en")]
+#[case::empty("")]
+#[tokio::test]
+async fn english_or_unresolvable_falls_through_to_200(#[case] header: &str) {
+    let (status, headers) = request("/", Method::GET, Some(header), None).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(header_value(&headers, &LOCATION).is_none());
+    assert_eq!(
+        header_value(&headers, &CACHE_CONTROL).as_deref(),
+        Some("public, max-age=300")
+    );
+    assert_eq!(
+        header_value(&headers, &VARY).as_deref(),
+        Some("Cookie, Accept-Language")
+    );
+}
+
+#[tokio::test]
+async fn higher_q_value_wins_between_supported_locales() {
+    // When two supported non-English locales are listed, the one with the
+    // higher q-value wins (ru;q=0.5 vs ko;q=0.9 -> Korean).
+    let (status, headers) = request("/", Method::GET, Some("ru;q=0.5,ko;q=0.9"), None).await;
+
+    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
+    assert_eq!(header_value(&headers, &LOCATION).as_deref(), Some("/ko"));
+}
+
+#[tokio::test]
+async fn bare_root_without_preferences_falls_through_to_200() {
+    let (status, headers) = request("/", Method::GET, None, None).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(header_value(&headers, &LOCATION).is_none());
+}
+
+#[tokio::test]
+async fn english_cookie_does_not_redirect() {
+    // English is the root URL, not a redirect target. A user who switched to
+    // English (the switcher writes origa_locale=en) must land on "/" and not
+    // be bounced by their own cookie.
+    let (status, headers) = request("/", Method::GET, None, Some("origa_locale=en")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(header_value(&headers, &LOCATION).is_none());
+}
+
+#[tokio::test]
+async fn english_cookie_overrides_non_english_accept_language() {
+    // Regression: an explicit English choice must beat the browser's
+    // Accept-Language. A visitor on a localised path who clicks "EN" lands on
+    // "/" carrying both `origa_locale=en` and a non-English Accept-Language;
+    // the explicit cookie must win, otherwise they can never reach English.
+    let (status, headers) = request("/", Method::GET, Some("ru"), Some("origa_locale=en")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(header_value(&headers, &LOCATION).is_none());
+}
+
+#[tokio::test]
+async fn cookie_takes_precedence_over_accept_language() {
+    // A user whose browser is Russian but who previously chose Korean must
+    // land on Korean: the explicit cookie wins over Accept-Language.
+    let (status, headers) = request(
+        "/",
+        Method::GET,
+        Some("ru-RU,ru;q=0.9"),
+        Some("origa_locale=ko"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
+    assert_eq!(header_value(&headers, &LOCATION).as_deref(), Some("/ko"));
+}
+
+#[tokio::test]
+async fn redirect_preserves_query_string() {
+    let (status, headers) = request("/?ref=twitter", Method::GET, Some("ru"), None).await;
+
+    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
+    assert_eq!(
+        header_value(&headers, &LOCATION).as_deref(),
+        Some("/ru?ref=twitter")
+    );
+}
+
+#[tokio::test]
+async fn head_mirrors_get_redirect() {
+    // HEAD must mirror GET redirect semantics per RFC 7231 §6.4.
+    let (status, headers) = request("/", Method::HEAD, Some("ru"), None).await;
+
+    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
+    assert_eq!(header_value(&headers, &LOCATION).as_deref(), Some("/ru"));
+}
+
+#[tokio::test]
+async fn post_is_not_redirected() {
+    // Only safe methods (GET/HEAD) negotiate locale; a POST to "/" must reach
+    // the route layer rather than be turned into a locale redirect.
+    let (status, headers) = request("/", Method::POST, Some("ru"), None).await;
+
+    assert_ne!(status, StatusCode::TEMPORARY_REDIRECT);
+    assert!(header_value(&headers, &LOCATION).is_none());
+}
+
+#[tokio::test]
+async fn non_root_path_is_not_redirected() {
+    // Locale negotiation only fires on the root; a localised or unprefixed
+    // subpath already carries its locale in the URL.
+    let (status, headers) = request("/features", Method::GET, Some("ru"), None).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(header_value(&headers, &LOCATION).is_none());
+}
+
+#[tokio::test]
+async fn locale_redirect_carries_security_headers() {
+    // The negotiate_locale layer sits inside `security_headers`, so its 307
+    // must still receive the defensive headers stamped by the outermost layer.
+    let (_status, headers) = request("/", Method::GET, Some("ru"), None).await;
+
+    assert_eq!(
+        headers.get("x-content-type-options"),
+        Some(&HeaderValue::from_static("nosniff"))
+    );
+    assert_eq!(
+        headers.get("x-frame-options"),
+        Some(&HeaderValue::from_static("SAMEORIGIN"))
+    );
+}
+
+#[tokio::test]
+async fn invalid_cookie_value_is_ignored() {
+    // A malformed cookie must not 500 or redirect to a nonsense path; it is
+    // dropped and Accept-Language (if any) gets a chance to resolve.
+    let (status, headers) = request(
+        "/",
+        Method::GET,
+        Some("en"),
+        Some("origa_locale=zzz;q=broken"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(header_value(&headers, &LOCATION).is_none());
+}
+
+#[tokio::test]
+async fn other_cookies_do_not_trigger_redirect() {
+    // Only `origa_locale` is consulted; an unrelated cookie must not negotiate.
+    let (status, headers) = request(
+        "/",
+        Method::GET,
+        Some("en"),
+        Some("_ga=GA1.2.x; theme=dark"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(header_value(&headers, &LOCATION).is_none());
+}
+
+#[tokio::test]
+async fn locale_cookie_among_other_cookies_is_found() {
+    // Regression: the cookie parser must iterate past unrelated cookies rather
+    // than return early on the first non-matching pair.
+    let (status, headers) = request(
+        "/",
+        Method::GET,
+        Some("en"),
+        Some("_ga=GA1.2.x; origa_locale=vi; theme=dark"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
+    assert_eq!(header_value(&headers, &LOCATION).as_deref(), Some("/vi"));
+}

--- a/origa_ui/src/i18n.rs
+++ b/origa_ui/src/i18n.rs
@@ -1,3 +1,5 @@
+use leptos_i18n::context::CookieOptions;
+use leptos_use::SameSite;
 use origa::domain::NativeLanguage;
 
 #[allow(
@@ -12,6 +14,14 @@ mod generated {
 
 pub use generated::i18n::{I18nContextProvider, Locale, use_i18n};
 pub use leptos_i18n::{I18nContext, t, td_string};
+
+const LOCALE_COOKIE_MAX_AGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
+
+pub fn persistent_locale_cookie_options() -> CookieOptions<Locale> {
+    CookieOptions::default()
+        .max_age::<i64>(Some(LOCALE_COOKIE_MAX_AGE_MS))
+        .same_site::<SameSite>(Some(SameSite::Lax))
+}
 
 pub fn native_language_to_locale(lang: &NativeLanguage) -> Locale {
     match lang {

--- a/origa_ui/src/main.rs
+++ b/origa_ui/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
     mount_to_body(|| {
         view! {
             <MetaTags />
-            <I18nContextProvider>
+            <I18nContextProvider cookie_options=origa_ui::i18n::persistent_locale_cookie_options()>
                 <Router>
                     <App/>
                 </Router>


### PR DESCRIPTION
Closes two tasks: `auto-detect-ui-language` and `reduce-daily-user-load`.

## 1. Auto-detect UI language

Resolve the interface language automatically on first visit and persist a manual choice across sessions, for both the CSR app and the SSR landing site.

**App (`origa_ui`)** — enable the `leptos_i18n` `cookie` feature and configure a persistent (1-year, `SameSite=Lax`) locale cookie on the context provider. `leptos_i18n` already resolves locale as **saved cookie → `navigator.languages` → default**, so a manual switch now survives reload/restart instead of resetting to the browser default.

**Landing (`origa_landing`)** — `negotiate_locale` middleware: on `GET/HEAD "/"`, redirect to the visitor's preferred locale (`/ru`, `/ko`, `/vi`) when it is not English.
- Preference: saved `origa_locale` cookie (explicit choice wins entirely, including English) → `Accept-Language` parsed per RFC 7231 (q-values, `q=0` excluded).
- Redirects are `307` with `Cache-Control: no-cache` + `Vary: Cookie, Accept-Language`. The English `200` on `/` additionally carries `Vary`, so an edge cache cannot serve a cached English answer to a non-English visitor before the redirect fires (ADR-011 / PR #182 edge-poisoning class).
- The language switcher writes the cookie on every switch (incl. to English), preventing a bounce-back loop.
- Cookie name + TTL live in one place (`content/mod.rs`), shared by middleware and switcher.
- `ko`/`vi` participate in auto-detection (content is translated; the WIP banner stays transparent).

## 2. Reduce DailyLoad new-cards-per-day

Lower the daily new-card budget ~0.6× for every `DailyLoad` tier: Minimal 5→3, Light 10→6, Medium 15→9, Hard 25→15, Heavy 35→21, Maximum 50→30. Proportions/ordering preserved. Ordinal mapping (`0..5`) untouched → existing profiles keep their tier with no migration, just fewer new cards.

## Verification

- `cargo fmt --check` ✅, `cargo clippy -p {origa,origa_ui,origa_landing --features ssr} --all-targets -- -D warnings` ✅
- `cargo test -p origa --lib` → 1517 passed ✅
- `cargo test -p origa_ui` → 6 passed ✅
- `cargo test -p origa_landing --features ssr` → all green (new `locale_negotiate` suite: 26 tests; updated `cache_headers` `html_root` checks `Vary`) ✅
- Code review: 3 cycles, all issues resolved (q-values, centralized cookie, English-cookie override) → **approve**.

## Notes / out of scope

- `origa_landing` is excluded from `cargo test --workspace` in CI (`ci.yml:164`) and has no dedicated SSR test step — the landing test suite (incl. these new contracts) runs **locally only**, as it always has. Worth a follow-up to add an SSR test step in CI so these regressions are caught automatically.
- `load_*_desc` time estimates in locales left as-is (upper-bound; safe — user spends ≤ estimate). Recalibrating against real lesson-time telemetry is a separate task.
- ⚠️ This enables the `cookie` feature on the workspace `leptos_i18n` dependency (`Cargo.toml`).