### PR TITLE
🔥(android): remove AndroidTV support declarations

### DIFF
--- a/tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -11,11 +11,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
-    <!-- AndroidTV support -->
-    <uses-feature android:name="android.software.leanback" android:required="false" />
-
     <!-- Camera/microphone are optional so the app installs on devices without
-         them (tablets, Android TV). Required=false matches leanback above. -->
+         them (e.g. tablets without camera). -->
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
@@ -33,8 +30,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
-                <!-- AndroidTV support -->
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
             <intent-filter >


### PR DESCRIPTION
## Summary

Removes opportunistic AndroidTV support declarations from `AndroidManifest.xml`.

## Why

Origa's core UX (FSRS review, OCR camera capture, STT microphone capture) is built around touch input. None of these map to a TV remote/D-pad — the app would be unusable on TV even though Play Store / RuStore would list it as TV-supported.

## Changes

Removed from `tauri/gen/android/app/src/main/AndroidManifest.xml`:

- `<uses-feature android:name="android.software.leanback" required="false" />` (declares the app can run on TV)
- `<category android:name="android.intent.category.LEANBACK_LAUNCHER" />` (makes app appear on TV home screen)
- Updated the comment on `camera`/`microphone` optional-feature declarations (was "tablets, Android TV" — now just tablets; the `required="false"` rationale remains valid for tablets without camera).

## Effect

- App no longer appears in TV sections of Play Store / RuStore
- Existing installs on TV devices **remain functional** — only store distribution changes
- No code changes required (no TV-specific code paths existed)

## Verification

| Check | Status |
| --- | --- |
| Manifest syntax (visual) | ✅ |
| No VR / cardboard / daydream declarations (verified) | ✅ |
| No TV-specific resources / drawables / strings | ✅ |
| Build (smoke = next tag push) | ⏭️ |

## Out of scope

- Android VR support — not declared anywhere in the project (grep for `vr`, `cardboard`, `daydream`, `oculus`, `openxr` returned nothing in Android sources)