### PR TITLE
✨(ci): auto-upload AAB to RuStore on tag release

### DIFF
--- a/.github/workflows/_upload-rustore.yml
+++ b/.github/workflows/_upload-rustore.yml
@@ -1,0 +1,163 @@
+name: Upload to RuStore
+
+# Reusable workflow for uploading signed AAB to RuStore via Public API.
+# Called from tauri.yml after build-tauri succeeds on tag pushes.
+#
+# Flow:
+#   1. POST /public/auth/ — exchange signed keyId+timestamp for JWE token (15 min TTL)
+#   2. POST /public/v1/application/{pkg}/version — create draft, returns versionId
+#   3. POST /public/v1/application/{pkg}/version/{id}/aab — multipart upload
+#   4. POST /public/v1/application/{pkg}/version/{id}/commit — submit for moderation
+#
+# Prerequisites (manual, in RuStore Console):
+#   - App created with package net.uwuwu.origa
+#   - AAB signing certificate uploaded (App signing keys section)
+#   - API keypair generated; keyId + private key in GitHub Secrets
+#
+# Auth signature: SHA512withRSA over concatenation keyId+timestamp,
+# using PKCS#8 / PKCS#1 PEM private key. See:
+#   https://www.rustore.ru/help/en/work-with-rustore-api/api-authorization-token
+
+on:
+    workflow_call:
+        inputs:
+            version:
+                type: string
+                required: true
+            version_type:
+                type: string
+                required: true
+        secrets:
+            rustore-key-id:
+                required: true
+            rustore-private-key:
+                required: true
+
+permissions:
+    contents: read
+
+jobs:
+    upload:
+        if: inputs.version_type == 'stable' || inputs.version_type == 'prerelease'
+        runs-on: ubuntu-latest
+        env:
+            PACKAGE_NAME: net.uwuwu.origa
+            RUSTORE_API: https://public-api.rustore.ru
+        steps:
+            - name: Download AAB artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: android-aab
+                  path: aab/
+
+            - name: Locate AAB file
+              id: locate
+              run: |
+                  set -e
+                  AAB_PATH=$(find aab/ -name "*.aab" -type f | head -1)
+                  if [ -z "$AAB_PATH" ] || [ ! -f "$AAB_PATH" ]; then
+                    echo "::error::No AAB file found under aab/"
+                    ls -la aab/ 2>&1 || true
+                    exit 1
+                  fi
+                  SIZE=$(stat -c%s "$AAB_PATH")
+                  echo "Found AAB: $AAB_PATH ($SIZE bytes)"
+                  echo "aab_path=$AAB_PATH" >> "$GITHUB_OUTPUT"
+
+            - name: Authenticate (get JWE token)
+              env:
+                  KEY_ID: ${{ secrets.rustore-key-id }}
+                  PRIVATE_KEY: ${{ secrets.rustore-private-key }}
+              run: |
+                  set -e
+                  # Write private key to a temp file. openssl sha512 -sign accepts
+                  # both PKCS#1 (RSA PRIVATE KEY) and PKCS#8 (PRIVATE KEY) PEM formats.
+                  KEY_FILE=$(mktemp)
+                  printf '%s\n' "$PRIVATE_KEY" > "$KEY_FILE"
+                  chmod 600 "$KEY_FILE"
+                  trap 'rm -f "$KEY_FILE"' EXIT
+
+                  # ISO 8601 with millisecond precision and tz offset,
+                  # e.g. 2026-07-18T12:34:56.789+03:00. Server rejects timestamps
+                  # more than 60 seconds off, so derive from CI clock.
+                  TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S.%3N%:z")
+
+                  # SHA512withRSA over keyId concatenated with timestamp (no separator).
+                  SIGNATURE=$(printf '%s%s' "$KEY_ID" "$TIMESTAMP" \
+                    | openssl dgst -sha512 -sign "$KEY_FILE" \
+                    | base64 -w0)
+
+                  RESPONSE=$(curl -fsS -X POST "$RUSTORE_API/public/auth/" \
+                    -H "Content-Type: application/json" \
+                    -d "$(jq -n --arg k "$KEY_ID" --arg t "$TIMESTAMP" --arg s "$SIGNATURE" \
+                      '{keyId: $k, timestamp: $t, signature: $s}')")
+
+                  echo "Auth response: $RESPONSE"
+                  JWE=$(echo "$RESPONSE" | jq -r '.body.jwe')
+                  if [ -z "$JWE" ] || [ "$JWE" = "null" ]; then
+                    echo "::error::RuStore auth failed — no JWE in response"
+                    exit 1
+                  fi
+                  echo "JWE token acquired (TTL: $(echo "$RESPONSE" | jq -r '.body.ttl')s)"
+                  echo "JWE_TOKEN=$JWE" >> "$GITHUB_ENV"
+
+            - name: Create version draft
+              env:
+                  VERSION: ${{ inputs.version }}
+              run: |
+                  set -e
+                  # whatsNew max 500 chars — release version + commit ref is enough
+                  # for automated CI uploads; full changelog goes to GitHub Release.
+                  WHATS_NEW="Release $VERSION (automated CI upload)"
+
+                  RESPONSE=$(curl -fsS -X POST \
+                    "$RUSTORE_API/public/v1/application/$PACKAGE_NAME/version" \
+                    -H "Content-Type: application/json" \
+                    -H "Public-Token: $JWE_TOKEN" \
+                    -d "$(jq -n --arg n "$WHATS_NEW" \
+                      '{appName: "Origa", appType: "MAIN", publishType: "INSTANTLY", whatsNew: $n}')")
+
+                  echo "Create draft response: $RESPONSE"
+                  VERSION_ID=$(echo "$RESPONSE" | jq -r '.body.version_id')
+                  if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" = "null" ]; then
+                    echo "::error::Create draft failed — no version_id in response"
+                    echo "Likely cause: an unfinished draft already exists for this app."
+                    echo "Delete drafts in RuStore Console, or via DELETE /version/{id} endpoint."
+                    exit 1
+                  fi
+                  echo "Draft created: version_id=$VERSION_ID"
+                  echo "VERSION_ID=$VERSION_ID" >> "$GITHUB_ENV"
+
+            - name: Upload AAB
+              run: |
+                  set -e
+                  AAB_PATH=${{ steps.locate.outputs.aab_path }}
+                  echo "Uploading $AAB_PATH to version $VERSION_ID..."
+
+                  RESPONSE=$(curl -fsS -X POST \
+                    "$RUSTORE_API/public/v1/application/$PACKAGE_NAME/version/$VERSION_ID/aab" \
+                    -H "Public-Token: $JWE_TOKEN" \
+                    -F "file=@$AAB_PATH")
+
+                  echo "Upload AAB response: $RESPONSE"
+                  CODE=$(echo "$RESPONSE" | jq -r '.code')
+                  if [ "$CODE" != "OK" ]; then
+                    echo "::error::AAB upload failed — code=$CODE"
+                    exit 1
+                  fi
+                  echo "AAB uploaded successfully"
+
+            - name: Submit for moderation
+              run: |
+                  set -e
+                  RESPONSE=$(curl -fsS -X POST \
+                    "$RUSTORE_API/public/v1/application/$PACKAGE_NAME/version/$VERSION_ID/commit?priorityUpdate=0" \
+                    -H "Public-Token: $JWE_TOKEN")
+
+                  echo "Submit response: $RESPONSE"
+                  CODE=$(echo "$RESPONSE" | jq -r '.code')
+                  if [ "$CODE" != "OK" ]; then
+                    echo "::error::Submit for moderation failed — code=$CODE"
+                    exit 1
+                  fi
+                  echo "✅ RuStore upload complete — version $VERSION_ID submitted for moderation"

--- a/.github/workflows/_upload-rustore.yml
+++ b/.github/workflows/_upload-rustore.yml
@@ -118,9 +118,16 @@ jobs:
                       '{appName: "Origa", appType: "MAIN", publishType: "INSTANTLY", whatsNew: $n}')")
 
                   echo "Create draft response: $RESPONSE"
-                  VERSION_ID=$(echo "$RESPONSE" | jq -r '.body.version_id')
+                  # RuStore API returns the new version_id as a scalar directly
+                  # under .body: {"body": 243242}. Some SDKs/documentations show
+                  # it wrapped as {"body": {"version_id": N}} — handle both
+                  # shapes so a future API tightening doesn't silently break us.
+                  VERSION_ID=$(echo "$RESPONSE" | jq -r '
+                    .body | if type == "object" then (.version_id // .id // empty) else . end
+                  ')
                   if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" = "null" ]; then
                     echo "::error::Create draft failed — no version_id in response"
+                    echo "Response was: $RESPONSE"
                     echo "Likely cause: an unfinished draft already exists for this app."
                     echo "Delete drafts in RuStore Console, or via DELETE /version/{id} endpoint."
                     exit 1

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -254,3 +254,24 @@ jobs:
                   prerelease: ${{ needs.version.outputs.version_type == 'prerelease' }}
                   draft: false
                   make_latest: ${{ needs.version.outputs.version_type == 'stable' }}
+
+    upload-rustore:
+        name: Upload to RuStore
+        # Independent of release: failure does NOT block GitHub Release.
+        # Continue-on-error semantics during burn-in — RuStore API has multiple
+        # hard requirements (signing cert in Console, no stale drafts, version
+        # bump) that may not be met on first run. Soft-fail until stable.
+        if: >
+            always() &&
+            needs.build-tauri.result == 'success' &&
+            startsWith(github.ref, 'refs/tags/v') &&
+            (needs.version.outputs.version_type == 'stable' ||
+             needs.version.outputs.version_type == 'prerelease')
+        needs: [version, build-tauri]
+        uses: ./.github/workflows/_upload-rustore.yml
+        with:
+            version: ${{ needs.version.outputs.version }}
+            version_type: ${{ needs.version.outputs.version_type }}
+        secrets:
+            rustore-key-id: ${{ secrets.RUSTORE_KEY_ID }}
+            rustore-private-key: ${{ secrets.RUSTORE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adds automated RuStore upload via Public API. Replaces manual upload to RuStore Console on every release — same pattern as Tauri Android build itself.

## What's new

### `_upload-rustore.yml` (reusable workflow, +163 lines)
Full RuStore Public API flow:
1. **Auth** — `POST /public/auth/` with SHA512withRSA(keyId+timestamp) → JWE token (15-min TTL)
2. **Create draft** — `POST /public/v1/application/{pkg}/version` with `publishType: INSTANTLY` → versionId
3. **Upload AAB** — `POST /public/v1/application/{pkg}/version/{id}/aab` (multipart)
4. **Submit for moderation** — `POST /public/v1/application/{pkg}/version/{id}/commit?priorityUpdate=0`

### `tauri.yml` (+21 lines)
New job `upload-rustore` parallel to `release`. Triggered on tag `v*.*.*` for stable/prerelease. **Failure does NOT block GitHub Release** during burn-in — RuStore API has hard prerequisites that may not all be met on first run.

## Secrets required

| Secret | Description |
|--------|-------------|
| `RUSTORE_KEY_ID` | Numeric keyId from RuStore Console → API keys section |
| `RUSTORE_PRIVATE_KEY` | PEM private key (PKCS#1 or PKCS#8) generated alongside keyId |

## Prerequisites (manual, in RuStore Console)

Before first CI upload will succeed:

- [ ] App created in RuStore Console with package `net.uwuwu.origa`
- [ ] **AAB signing cert uploaded** to "App signing keys" section (the `rustore-signing-cert.pem` from the one-off PEPK extraction — required before AAB upload is accepted at all)
- [ ] API keypair generated; keyId + private key stored in GitHub Secrets
- [ ] No stale drafts (RuStore allows only 1 draft per app — delete via Console or API if exists)

## Verification strategy

- **actionlint** on both files: ✅ EXIT=0
- **First tag push** (next `v*.*.*`): smoke test
  - If prerequisites met → AAB uploaded + submitted for moderation automatically
  - If prerequisites missing → soft-fail with `::error::` annotation in Actions tab (release still goes out)
- **Switch-checkpoint** (separate micro-task): after ≥1 successful CI upload, harden by making release job depend on upload-rustore

## Out of scope (this PR)

- **Google Play auto-upload** via `r0adkll/upload-google-play@v1` — separate PR (Phase 2). Play Console API is simpler (one action call) but needs its own service-account JSON setup.
- **Draft cleanup automation** — current code fails fast if a draft exists with actionable error message. Auto-cleanup can be added once we see actual failure patterns.
- **Stale JWE token refresh** — current single-job flow completes well within 15-min TTL. Multi-job parallel would need refresh.

## Test plan

After merge, on next tag `v*.*.*`:
1. Watch Actions tab → "Upload to RuStore" job
2. Check step "Authenticate (get JWE token)" succeeds → keyId+private key correctly wired
3. Check step "Create version draft" succeeds → no stale drafts, app exists
4. Check step "Upload AAB" succeeds → signing cert in Console correct
5. Check step "Submit for moderation" succeeds → version moves to "On moderation" in RuStore Console

If any step fails, the `::error::` annotation includes the RuStore API response for diagnosis.

Refs: `origa/android-release-cicd` (Phase 3 — RuStore auto-upload)