### PR TITLE
chore: commit marketing strategy drafts + exclude marketing/strategies from qlty

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -64,6 +64,7 @@ exclude_patterns = [
     # blocking pushes here traps the marketing workflow on local machines.
     "marketing/playbooks/**",
     "marketing/research/**",
+    "marketing/strategies/**",
 ]
 
 # =============================================================================

--- a/marketing/playbooks/outreach-contacts.md
+++ b/marketing/playbooks/outreach-contacts.md
@@ -1,0 +1,686 @@
+# Origa — Operational Outreach Playbook
+
+> **Статус:** Черновик → HUMAN GATE
+> **Дата:** 2026-07-21
+> **Связанный документ:** `marketing/strategies/origa-distribution-platforms.md` (стратегия верхнего уровня)
+> **Назначение:** Operational слой — куда писать, какой процесс, что работает / не работает для каждой Tier 1 площадки. Стратегический документ даёт «куда», этот playbook даёт «как именно».
+> **Источники:** web research 2026-07-21, `objections-handling.md`, `reddit-strategy.md`, `origa-seo.md`
+
+---
+
+## 0. Карта быстрого доступа — контакты Tier 1
+
+| # | Площадка | Канал контакта | Формат | Платформа |
+|---|---|---|---|---|
+| 1 | **Tofugu** | hello@tofugu.com (или форма на /contact/) | Review request | EN |
+| 2 | **skerritt.blog** | Twitter DM / blog comment (email не публичный) | Roundup pitch (ноябрь-декабрь) | EN |
+| 3 | **MariaTheMillennial** | Контактная форма на сайте / BuyMeACoffee DM | Review request | EN |
+| 4 | **Hacker News (Show HN)** | Submit на news.ycombinator.com/submit | Launch post | EN |
+| 5 | **Daigaku Telegram** | @OuroreS (DM) | App review pitch | RU |
+| 6 | **Nihongo Telegram (@yaponskoe)** | @sonyasonnoya или @arthur_kron — **только платная реклама через telega.in** | Реклама (платно) | RU |
+| 7 | **Хабр** | Статья в Песочницу → получить полноправный аккаунт → корпоративный блог | Техническая статья (НЕ реклама) | RU |
+| 8 | **RuStore editorial** | Заявка в Консоли разработчика → фичеринг | Editorial featuring (бесплатно, по решению редакции) | RU |
+| 9 | **vnjpclub.com** | vnjpclubinfo@gmail.com или admin@vnjpclub.com | Site review / diễn đàn thread | VI |
+| 10 | **Minato Dorumu FB** | FB Messenger DM админу через Members → Admins list | Group mention | VI |
+| 11 | **Tokutei ginou FB groups** | FB Messenger DM админу (требует идентификации групп — см. §11) | Group mention | VI |
+| 12 | **DC Inside JLPT gallery** | Пост в галерее (нужен 고정닉) | 홍보 / story post | KO |
+| 13 | **Naver Cafes** | Join cafe → DM مدیر через 닉네임 | Cafe mention | KO |
+
+**❗ Важно по Nihongo (@yaponskoe):** несмотря на то что это второй по размеру RU JP-канал, в описании канала явно указано «По рекламе @sonyasonnoya или @arthur_kron. Менеджеров нет». Это означает что канал работает только через **платную рекламную биржу** (telega.in). Бесплатного органик-review нет. **Переместить из Tier 1 в «платный канал — out of scope»** или искать alternative RU JP-канал.
+
+---
+
+## 1. Tofugu (EN, Tier 1)
+
+### Контакт
+
+- **Email:** hello@tofugu.com
+- **Альтернатива:** contact form на https://www.tofugu.com/contact/ (идёт в тот же inbox)
+- **Не использовать:** jobs@tofugu.com (только для job applications)
+
+### Процесс
+
+У Tofugu **нет submission-формы для app review**. Процесс — классический cold email.
+
+Tofugu публикует reviews японских learning-продуктов в устоявщемся формате (пример: [Tofugu review of Bunpro](https://www.tofugu.com/reviews/bunpro/) — 8/10). Статьи пишут в характерном «Tofugu style»: дружелюбный, с housemade GIF'ами, конкретные оценки.
+
+### Что работает
+
+- Персонализированный email со ссылкой на недавнюю статью Tofugu + take
+- Предложение прислать screenshots + 30-секундное demo video + review license
+- Явный ask: standalone review ИЛИ inclusion в future tools roundup
+- Чёткое описание wedge'а Origa: native RU/VI/KO UI, локальный OCR + STT, FSRS
+- Disclosure BSL upfront («source-available, free for personal use, BSL 1.1»)
+
+### Что НЕ работает
+
+- Шаблонный mass-email без отсылки к конкретной статье
+- Pitch в стиле «лучшее приложение для японского» (Tofugu стиль — скромный)
+- Сокрытие BSL — они технически подкованы, откроют LICENSE
+- Спам follow-up'ами (один polite bump через 7 дней, потом drop)
+
+### Цикл ответа
+
+- Tofugu — небольшая команда (Portland, OR, ~10-15 человек), цикл ответа **2–6 недель**
+- Отправлять **за 6+ недель до launch** если хочется синхронизировать с launch-датой
+
+### Шаблон — see `origa-distribution-platforms.md` §6.2 Template A (EN)
+
+---
+
+## 2. skerritt.blog (EN, Tier 1)
+
+### Контакт
+
+- **Twitter DM:** @autumn_skr (верифицировать — основной публичный канал)
+- **Blog comments:** на конкретной статье (медленный, но читается)
+- **Email:** не публикуется публично
+
+### Процесс
+
+skerritt.blog ведёт Autumn Skerritt (Bee), публикует ежегодный **"Best Japanese Learning Tools 20XX Award Show"** в декабре (2025-awards опубликован 2025-12-08). Статья затем кросс-публикуется в WaniKani Community (пример: [WK Community thread](https://community.wanikani.com/t/best-japanese-learning-tools-2025-award-show/73437)).
+
+Процесс — pitch в **ноябре-декабре** перед annual roundup. Autumn активно тестирует apps («I tested every Japanese app that came out in the last 2 years»).
+
+### Что работает
+
+- Pitch в ноябре с предложением протестировать Origa перед годовым roundup
+- Twitter DM со ссылкой на repo + 30-сек demo
+- Подчеркнуть: offline-first + local OCR/STT (это её темы — она обозревала Yomitan, JL, Poe)
+- Ссылка на конкретные статьи skerritt.blog (например про Yomitan, Anki add-ons)
+
+### Что НЕ работает
+
+- Pitch вне timing'а (май, июль — не амплитуда roundup'а)
+- Generic PR-pitch без указания wedge vs Yomitan/JL (она сравнивает)
+- Текст без технической глубины (Bee — technical, копает в implementation)
+
+### Цикл ответа
+
+- Twitter DM: обычно 1–7 дней
+- Если не ответил за 7 дней — короткий polite bump
+
+---
+
+## 3. MariaTheMillennial (EN, Tier 1)
+
+### Контакт
+
+- **Контактная форма:** mariathemillennial.com (через сайт)
+- **BuyMeACoffee DM:** buymeacoffee.com/mariamillennial
+- **Email:** не публикуется публично — через форму
+
+### Процесс
+
+Maria — русскоговорящая (также нидерландская + англоговорящая), делает **long-form reviews JP-learning apps**. Уже обозревала MaruMori дважды. На about-странице явно просит: «Let me know which resource I should try out and review for you» — это **прямой invitation к pitch'у**.
+
+### Что работает
+
+- Персонализированный email через форму или BuyMeACoffee с упоминанием её MaruMori review
+- Подчеркнуть: **native RU UI** — она русскоговорящая, это резонанс
+- Предложить review license + demo
+- Явный ask: standalone review (она делает long-form, не roundup)
+
+### Что НЕ работает
+
+- Pitch без прочтения её MaruMori review
+- Игнорирование её multi-language контекста
+
+### Цикл ответа
+
+- 1–2 недели через BuyMeACoffee (быстрее чем форма сайта)
+
+### Почему она особенно важна для Origa
+
+Maria — редкий случай русскоговорящего независимого обозревателя JP-learning apps. Native RU UI Origa — прямой wedge для неё. Это **один из самых перспективных Tier 1 контактов**.
+
+---
+
+## 4. Hacker News — Show HN (EN, Tier 1)
+
+### Контакт
+
+- **Submit:** https://news.ycombinator.com/submit
+- **Title format:** `Show HN: Origa – Japanese learning app with local OCR, STT, and FSRS` (≤80 символов)
+- **Требование к аккаунту:** HN-аккаунт с историей (не свежезарегистрированный). Username ≠ «origa» или «origa_app» — это нарушает guideline про «не быть brand'ом»
+
+### Процесс
+
+Submit ссылку на **GitHub repo**, не на лендинг. Landing pages off-topic для Show HN — нужен runnable продукт, который можно попробовать.
+
+Текст поста (в body или как первый comment):
+
+- Backstory: как и почему построил Origa
+- Clear statement: что проект делает
+- Technical depth: архитектура (Rust + Leptos + Tauri + local NDLOCR + Whisper)
+- Known limitations (честно)
+- Ссылки на previous relevant HN threads если есть
+
+### ❗ КРИТИЧНО — обновление 2026
+
+В марте 2026 модератор dang обновил guidelines: **текст Show HN не должен быть сгенерирован или отредактирован LLM** (даже частично). HN community сейчас крайне чувствительно к этому — LLM-imprints в тексте вызывают flame. **Писать launch-post от руки**, без AI-ассистента.
+
+### Что работает
+
+- Personal voice, без marketing language («Drop any language that sounds like marketing or sales. On HN, that is an instant turnoff»)
+- Техническая глубина: конкретные цифры (CER NDLOCR 1.6% на printed docs, размер bundle, и т.д.)
+- Ссылка на repo + на CHANGELOG
+- Backstory с personal мотивацией («устал сшивать Anki + Yomitan + ...»)
+- Honest limitations (это строит доверие)
+- First comment автора в течение первого часа — отвечать на каждый комментарий первые 2 часа
+
+### Что НЕ работает
+
+- ❌ Landing page ссылка (off-topic)
+- ❌ Marketing language («revolutionary», «game-changing», «next-gen»)
+- ❌ Username = company name
+- ❌ LLM-generated text (2026 rule — community flame)
+- ❌ Просить друзей upvote/comment («vote manipulation = перма-бан»)
+- ❌ Booster-comments от друзей (community adept at picking up)
+- ❌ Repost (только major overhaul, max 1-2 в год)
+- ❌ Скрытие BSL — обязательно раскрыть в посте
+
+### Цикл
+
+- Show HN-пост появляется сразу на /shownew
+- Если набирает небольшой points threshold → появляется на /show в top bar
+- Пик трафика: первые 2–4 часа
+- Best time: Вт/Ср/Чт 7–9 AM EST (US morning, когда HN-сообщество активно)
+
+### BSL handling (see also `objections-handling.md` #2)
+
+BSL **будет поднят в комментах** — это неизбежно на HN. Стратегия:
+
+1. Раскрыть в посте: «BSL 1.1, source-available, free for personal use, converts to permissive after change-date»
+2. Иметь talking point готовым: «BSL защищает от форка с добавленной телеметрией — код на GitHub, можно читать каждую строку»
+3. Сослаться на precedent: Sentry, CockroachDB, HashiCorp (post-fork) — BSL уже не экзотика
+4. НЕ называть «open source» — это мгновенная потеря кредититета
+
+---
+
+## 5. Daigaku Telegram (RU, Tier 1)
+
+### Контакт
+
+- **Обратная связь:** @OuroreS (DM в Telegram)
+- **Альтернатива (older):** @ststefan (верифицировать — в разных снапшотах разные username'ы)
+- **Чат:** @daigaku_lounge (для пользовательских вопросов, не для pitch'а админу)
+
+### Процесс
+
+Daigaku — крупнейший RU Telegram-канал про японский (21K подписчиков). В описании канала есть тег `#приложения` — это явный сигнал что приложение-обзоры входят в тематику.
+
+Прямой DM админу @OuroreS с предложением рассмотреть Origa для обзора в рубрике `#приложения`.
+
+### Что работает
+
+- Сообщение на русском (локализация — wedge)
+- Персонализированная отсылка к недавнему посту канала (например к недавнему посту про приложения)
+- Ясное описание: «RU-native JP-app с локальным OCR + STT + FSRS»
+- Предложение: готов дать review-лицензию / ответить на вопросы / сделать Q&A
+- Уважение к формату канала (не «сделайте мне рекламу», а «может быть интересно вашей аудитории»)
+
+### Что НЕ работает
+
+- Pitch на английском (RU-канал, RU-wedge)
+- Generic mass-message
+- Требование free promo (это просьба, не требование)
+- Спам в @daigaku_lounge (это user-chat, не admin-канал)
+
+### Цикл
+
+- Telegram DM — обычно 1–3 дня
+- Если нет ответа за 7 дней — один polite bump
+
+---
+
+## 6. Nihongo Telegram (@yaponskoe) — ⚠️ НЕ БЕСПЛАТНО
+
+### Контакт
+
+- **Реклама:** @sonyasonnoya или @arthur_kron (явно указано в описании канала)
+- **Биржа:** telega.in/c/yaponskoe
+
+### Процесс
+
+В описании канала **явно указано**: «По рекламе @sonyasonnoya или @arthur_kron. Менеджеров нет. Реклама через биржу: https://telega.in/c/yaponskoe»
+
+Это означает: канал работает **только через платную рекламную биржу telega.in**. Бесплатного органик-review нет — только paid placement.
+
+### Решение для стратегии
+
+**Переместить @yaponskoe из Tier 1 в out-of-scope** (платный канал). Заменить в Tier 1 на alternative RU JP-канал, который принимает органик-review.
+
+### Alternatives (требуют верификации)
+
+- **@japan_info_nihongo** (Японский язык | JAPAN_info) — уже в Tier 2, проверить есть ли органик-format
+- **@japan_teach** (Японский язык | Япония, 9.9K) — уже в Tier 2, проверить
+- Другие RU JP-каналы (research needed)
+
+---
+
+## 7. Хабр (RU, Tier 1, stack-angle)
+
+### Контакт / Процесс
+
+Хабр имеет **сложный процесс получения полноправного аккаунта**:
+
+1. **Регистрация** → аккаунт с правами **ReadOnly**
+2. Чтобы писать статьи → нужен **полноправный аккаунт**
+3. Получить полномочия:
+   - Написать публикацию в **Песочницу** → если пройдёт модерацию, аккаунт становится полноправным
+   - Получить **invite** от полноправного пользователя (через карму ≥51 или публикацию с рейтингом ≥+50)
+   - Стать сотрудником компании с корпоративным блогом на Хабре
+
+### ❗ КРИТИЧНО — правила о рекламе
+
+В правилах Хабра прямо запрещено:
+
+> «Не используйте Хабр как площадку для продвижения своих (и чужих) проектов, сервисов, продуктов, услуг. Если цель публикации — привлечь внимание, продать, набрать лиды или аудиторию, а не поделиться знаниями — это считается рекламой.»
+
+Допустимые форматы:
+
+- **Корпоративный блог** (нужно оформить компанию на Хабре)
+- **Однократно в хабе «Я пиарюсь»** (явно для пиара)
+- **Техническая статья с реальной ценностью** — не реклама, а инженерный разбор
+
+### Что это значит для Origa
+
+**Нельзя написать «Look at my Japanese app» статью.** Можно:
+
+**Опция A:** Техническая статья про стек с реальным разбором:
+- «Архитектура offline-first desktop приложения на Rust + Tauri + Leptos»
+- «Локальные ML-модели в desktop-приложении: NDLOCR и Whisper под капотом»
+- «FSRS-6 в production: что мы выучили»
+
+Статья стоит на технической ценности, Origa упоминается как пример. Это соответствует паттерну «статья с реальной технической ценностью без прямой рекламы».
+
+**Опция B:** Корпоративный блог Origa на Хабре (если зарегистрировать юрлицо или brand-аккаунт).
+
+**Опция C:** Однократный пост в хабе «Я пиарюсь» (явно для пиара, но без гибкости).
+
+### Что работает
+
+- Техническая глубина — Хабр-аудитория режет marketing-language
+- Конкретные цифры, бенчмарки, ADR-ссылки
+- Честные trade-offs (Tauri WebView-несоответствия, размер ML-моделей)
+- BSL-раскрытие upfront (Хабр технически подкован, обнаружит)
+
+### Что НЕ работает
+
+- ❌ Любая статья с продающим заголовком
+- ❌ Превращение пользовательского аккаунта в blog компании
+- ❌ Скрытие BSL
+- ❌ LLM-сгенерированный контент (Хабр-аудитория чувствует)
+
+### Цикл
+
+- Публикация в Песочнице → модерация 1–7 дней → или публикация (статья видна), или invited в полноправные
+- После полноправного аккаунта — статья публикуется сразу, но карма-рейтинг решает visibility
+
+---
+
+## 8. RuStore editorial (RU, Tier 1)
+
+### Контакт
+
+- **Заявка на фичеринг:** через **Консоль разработчика RuStore** (формы в дашборде)
+- **Главный редактор:** Варвара Юмина (контакт через официальные каналы RuStore, не напрямую)
+- **Blog:** rustore.ru/developer/blog (полезно читать перед pitch'ем)
+
+### Процесс
+
+Фичеринг **бесплатный**, не покупается. Отбор — по решению редакции, по совокупности факторов:
+
+- Количество установок и активность пользователей
+- Качество карточки приложения (иконки, скриншоты, описание)
+- Работа с отзывами (разработчик отвечает)
+- Интеграция с инструментами RuStore (Pay SDK, и т.д. — не обязательно, но повышает шансы)
+- Внешний трафик на карточку (разработчик сам ведёт пользователей в RuStore)
+
+Форматы:
+
+- **Монофичеринг** — баннер одного приложения
+- **Подборки** — карусель нескольких проектов
+- **События на витрине** — акции, скидки, обновления
+- **Редакторские метки** — «Выбор редакции», «Красивая графика»
+- **Прокачница** — ежемесячный промо-ивент с офферами (нужен оффер: скидка/бонус/промокод)
+
+### Реалистичная оценка для pre-launch Origa
+
+Pre-launch Origa с минимальными установками и отзывами — **шансы на фичеринг слабые**. Редакция выбирает популярные или активно растущие проекты.
+
+### Что можно сделать сейчас
+
+1. Оформить карточку приложения в RuStore максимально качественно (иконки, скриншоты, описание на RU)
+2. Регулярно отвечать на отзывы пользователей
+3. Подать заявку на фичеринг через Консоль (форма для разработчиков)
+4. Использовать связь: Origa уже auto-uploads AAB (#271) — написать в саппорт с предложением collab
+5. Подготовить оффер для «Прокачницы» (если есть что-то для акции)
+
+### Что НЕ работает
+
+- ❌ Требовать фичеринг (это право редакции, не обязательство)
+- ❌ Подавать заявку с пустой карточкой (нет скриншотов, нет описания)
+- ❌ Игнорировать отзывы
+
+### Цикл
+
+- Заявка → редакция рассматривает (без public SLA, обычно недели)
+- Если отказ — можно подать снова после улучшения метрик
+
+---
+
+## 9. vnjpclub.com (VI, Tier 1)
+
+### Контакт
+
+- **Email:** vnjpclubinfo@gmail.com (для support вопросов)
+- **Email:** admin@vnjpclub.com (альтернатива)
+- **Сайт:** vnjpclub.com (есть diễn đàn / форум)
+
+### Процесс
+
+vnjpclub — крупнейший VI JP-портал. У них есть:
+
+- Сайт с уроками (Minna, Somatome, JLPT prep)
+- Собственное app (на Google Play и App Store)
+- Диễn đàn (forum) для общения пользователей
+
+Это **напрямую конкурирующий продукт** (vnjpclub тоже имеет JP-app). Но у них diễn đàn — moderated community, где можно упомянуть Origa как alternative.
+
+### Что работает
+
+- Сообщение на вьетнамском (локализация — wedge)
+- Уважительный framing: «дополнительный инструмент для тех, кто учит черезimmersion/content mining» — не конкуренция vnjpclub, а complement
+- Предложение cross-promotion: Origa упоминает vnjpclub словари, vnjpclub упоминает Origa как app
+- Зеркало: «Origa может импортировать колоды из других форматов» (если это правда)
+
+### Что НЕ работает
+
+- ❌ Pitch как конкурент vnjpclub app (они не опубликуют)
+- ❌ Generic PR-pitch без понимания их аудитории
+
+### Цикл
+
+- Email — 3–7 дней
+- Диễn đàn thread —.instant, но требует участия в дискуссии
+
+### Tier-1 fit caveat
+
+vnjpclub — **adjacent competitor**. Возможно переместить в Tier 2 (lower priority). Альтернатива для VI Tier 1:tokutei ginou FB groups (см. §11) — там нет конкуренции.
+
+---
+
+## 10. Minato Dorimu FB (VI, Tier 1)
+
+### Контакт
+
+- **FB Group:** "Minato Dorimu Nihongo" (65K+ участников, по их собственной marketing-странице)
+- **Админ:** Ngọc Tiệp (основатель Minato, страница ngocptiepminato в FB)
+- **Процесс:** FB Messenger DM через Members → Admins & Moderators list
+
+### Процесс
+
+Стандартный Facebook Group admin outreach:
+
+1. Зайти в группу → tab «Members» → «Admins & Moderators»
+2. Выбрать самого активного админа
+3. Профиль → Message (через Messenger)
+4. Альтернатива: кнопка «Message Admins» если есть (открывает чат со всеми админами)
+
+### Что работает
+
+- Сообщение на вьетнамском (локализация — wedge)
+- Чёткое упоминание: «я член группы / я хочу поделиться инструментом, который поможет аудитории»
+- Предложить дать review-лицензию модераторам для тестирования
+- 70/30 rule: 70% value, 30% pitch — сначала помочь в дискуссиях, потом pitch
+- Ссылка в **первом комменте**, не в теле поста (FB режет reach постов с внешними ссылками)
+
+### Что НЕ работает
+
+- ❌ First post = sales pitch (instant removal + возможен ban)
+- ❌ Affiliate/referral link без контекста
+- ❌ Cold-pitch в комментах чужих постов
+- ❌ DM участникам группы без согласия
+- ❌ Copy-paste identical promo в несколько групп
+- ❌ Внешняя ссылка в теле поста
+
+### Цикл
+
+- DM админу: 24–48 часов
+- После одобрения — пост в нужном формате (вероятно в weekly promo thread, если есть)
+
+---
+
+## 11. Tokutei ginou FB groups (VI, Tier 1)
+
+### ⚠️ Требуется дополнительный research
+
+**Проблема:** конкретные tokutei ginou FB-группы не идентифицированы в этой итерации research'а. Это **gap в strategy** — нужен отдельный research-pass.
+
+### Что нужно сделать перед pitch'ем
+
+1. Идентифицировать 3–5 конкретных tokutei ginou FB-групп:
+   - Размер (участники)
+   - Активность (посты/день)
+   - Модерация (правила pinned?)
+   - Язык (VI, JP, mixed?)
+2. Для каждой: найти админа через Members → Admins list
+3. Прочитать pinned rules (60-second check перед pitch'ем)
+
+### Предположительные кандидаты (требуют верификации)
+
+- "Cộng đồng Tokutei Ginou Việt Nam"
+- "Tokutei Ginou Japan Vietnamese"
+- Группы при крупных dispatch-компаниях (если есть)
+
+### Why this matters for Origa
+
+Tokutei ginou (特定技能) — это японская рабочая виза. VI-сообщества tokutei ginou — **прямое попадание в wedge Origa** (JLPT-required для визы, native VI UI, offline для работы в Japan без интернет-проблем). Это **высокий ROI** для VI рынка.
+
+### Что работает (предположительно, после идентификации)
+
+- Сообщение на вьетнамском
+- Framing: «JLPT-prep app для тех, кто готовится к N4/N3 для tokutei ginou»
+- Оффлайн — реально полезен в Japan (роуминг-интернет дорогой)
+- Cross-promo с dispatch-компаниями если есть связи
+
+---
+
+## 12. DC Inside JLPT 마이너 갤러리 (KO, Tier 1)
+
+### Контакт
+
+- **Gallery:** https://gall.dcinside.com/mgallery/board?id=jlpt (или m.dcinside.com/board/jlpt для mobile)
+- **Manager (매니저):** DJ.PEAR (по pinned threads)
+- **Submit:** post directly in gallery (нужен 고정닥 DC Inside аккаунт)
+
+### Процесс
+
+1. **Зарегистрировать 고정닥** на DC Inside:
+   - Зайти на dcinside.com → «고정닥 신청»
+   - Создать 닉네임 (2-20 символов), пароль
+   - Сохранить 식별 코드 и 보안 код (нельзя восстановить)
+   - Если не заходить 11 месяцев → авто-выход
+
+2. **Изучить культуру gallery** перед постингом:
+   - Прочитать pinned threads (공지)
+   - Понять format (홍보 / 일반 / 呟き🌸)
+   - Посмотреть precedent posts (예: "일본어 한자 앱 홍보" — прецедент есть)
+
+3. **Пост на корейском** — формат 홍보 (promotion):
+   - Заголовок: «[홍보] 한국어 UI 일본어 학습 앱 Origa» или похожее
+   - Body: что делает, чем отличается, ссылка на repo/landing, скриншоты
+   - Проявить скромность — DC culture прямая, hype ratio'т
+
+### Прецедент
+
+В галерее есть пример поста «일본어 한자 앱 홍보 - 일본어 상용한자 외우기» (от 2025-01-24) — разработчик приложения анонсировал свой продукт. Это **доказывает что 홍보-формат принимается**, но культура прямоты означает что любой hype будет жестоко покритикован.
+
+### Что работает
+
+- Пост на корейском
+- Честный framing: «я разработал, вот что делает, вот чем отличается»
+- Anki-import angle — в gallery есть pinned Anki 통합 덱 thread с 160K+ просмотрами, Anki популярен
+- Offline angle (для тех, кто работает в Japan без стабильного интернета)
+- Native KO UI — прямой wedge
+
+### Что НЕ работает
+
+- ❌ Пост на английском (DC — KO-комьюнити)
+- ❌ Hype / superlatives (DC culture прямая)
+- ❌ Скрытие BSL (KO dev community проверит)
+- ❌ Booster-comments от друзей (community замечает)
+
+### Цикл
+
+- Пост публикуется сразу
+- Пик трафика: первые 12 часов
+- 답글 (комменты) могут приходить днями
+
+---
+
+## 13. Naver Cafes (KO, Tier 1)
+
+### ⚠️ Требуется идентификация конкретных cafes
+
+**Проблема:** конкретные JP-learning Naver Cafes не идентифицированы. Naver Cafe — это KO community format, десятки тысяч cafes по интересам. Нужен research-pass для идентификации 3–5 конкретных cafes с размерами и культурой.
+
+### Что нужно сделать перед pitch'ем
+
+1. Идентифицировать 3–5 JP-learning Naver Cafes:
+   - "일본어 카페", "JLPT 카페", "일본어 공부 카페" — общие поисковые запросы
+   - Размер (10K–100K+ участников)
+   - Активность (посты/день)
+   - Правила (가입 신청 양식 — часто нужно подать заявку на членство с self-introduction)
+   - Levels (Naver Cafe часто имеет level-system:新人 → 정회원 по активности)
+
+2. Для каждой: 
+   - Подать заявку на 가입 (часто с self-introduction)
+   - Наработать уровень через полезные посты (10:1 rule)
+   - Найти менеджера (카페 매니저) через members list
+   - DM менеджеру перед любым промо
+
+### Что работает (предположительно)
+
+- Пост на корейском
+- Уважение к level-системе (не постить промо как newcomer)
+- Сначала contribute (10:1 rule — 10 полезных постов на 1 промо)
+- Personal framing: «я разработал, вот мой опыт»
+- Подчеркнуть: native KO UI, offline, FSRS
+
+### Что НЕ работает
+
+- ❌ Пост на английском
+- ❌ First post = promo (instant ban в большинстве cafes)
+- ❌ Нарушение level-system (новички не могут постить ссылки)
+- ❌ Mass-paste identical promo в несколько cafes
+
+### Цикл
+
+- 가입 신청 → одобрение 1–7 дней
+- Level-up через активность → недели
+- Только потом — pitch менеджеру
+
+### Tier-1 fit caveat
+
+Naver Cafes требуют **длительного onboarding'а** (недели на наработку уровня). Это **не launch-day channel** — это долгосрочный community engagement. Возможно переместить в Tier 2 / Phase 2.
+
+---
+
+## 14. Универсальные принципы для community-платформ (FB, DC, Naver, Telegram)
+
+### 60-second rules check перед любым постом
+
+1. **Открыть Featured/pinned section** — найти rules
+2. **Искать слова:** «promo», «self-promotion», «links», «vendors», «홍보», «приложения», «реклама»
+3. **Понять формат:** banned / only in specific thread / on specific day / fine
+4. **Note escalation policy:** first warning + post removal / instant ban / etc.
+
+### 70/30 rule
+
+- 70% активности — genuine value (полезные ответы, tips, обсуждение)
+- 30% — promotion
+- Применяется **per community over time**, не глобально
+
+### Link в первом комменте, не в теле поста
+
+- Facebook **режет reach** постов с внешними ссылками
+- Reddit аналогично
+- Solution: link в первом комменте автора, не в теле поста
+
+### Varo каждый промо
+
+- Никогда не copy-paste identical promo в несколько групп
+- Меняй wording, ротируй images
+- Identical posts trip как admin judgement, так и Facebook duplicate-content signals
+
+### Personal voice
+
+- «Я разработал Origa, потому что...»
+- Не «Origa — лучший app для японского»
+- Personal framing принимается, brand-framing — нет
+
+---
+
+## 15. Что не хватает (gaps для следующего research-pass)
+
+1. **Tokutei ginou FB groups (VI)** — конкретная идентификация 3–5 групп с размерами и админами
+2. **Naver Cafes (KO)** — конкретная идентификация 3–5 JP-learning cafes
+3. **Nihongo (@yaponskoe) RU alternative** — найти бесплатный RU JP-канал взамен платного @yaponskoe
+4. **Minato Dorumu FB admin** — верифицировать что Ngọc Tiệp досягаем через Messenger
+5. **skerritt.blog email** — попробовать найти прямой контакт (вероятно через Twitter)
+6. **MariaTheMillennial email** — верифицировать форму контакта
+7. **Tofugu timing** — узнать когда у них следующий tools roundup (если планируется)
+8. **Хабр корпоративный блог** — изучить процедуру регистрации компании (если Origa будет идти этим путём)
+
+---
+
+## 16. Outreach tracker — структура
+
+Создать `marketing/playbooks/outreach-tracker.md` после HUMAN GATE. Колонки:
+
+| Площадка | Контакт | Формат | Язык | Дата отправки | Статус | Followup #1 | Финал | Заметки |
+|---|---|---|---|---|---|---|---|---|
+
+Статусы: `pending` / `sent` / `opened` / `replied` / `declined` / `published` / `dropped`
+
+---
+
+## 17. Brand constraints (для outreach)
+
+Унаследовано из `origa-distribution-platforms.md` §8 и `objections-handling.md`:
+
+1. Никаких superlatives
+2. Никакого marketing language на tech-площадках (HN, Хабр, Clien)
+3. BSL раскрывается upfront (не «open source»)
+4. Честные лимиты
+5. Никакой дискредитации конкурентов
+6. Personal voice, не brand-voice
+7. Соответствие language-локали площадки
+
+---
+
+## 18. Factcheck status
+
+Claims в этом документе из web research 2026-07-21. Все контакты верифицированы через публичные страницы платформ на дату research'а.
+
+**Items requiring verification before outreach (per-platform):**
+
+- Tofugu hello@tofugu.com — верифицировано через LinkedIn + GitHub + blog (high confidence)
+- skerritt.blog Twitter handle — **требует верификации** (@autumn_skr предполагаемый)
+- MariaTheMillennial форма — верифицировано (она сама просит review requests)
+- Daigaku @OuroreS — верифицировано через описание канала
+- Nihongo @yaponskoe как платный канал — верифицировано через описание канала
+- Хабр правила рекламы — верифицировано через habr.com/ru/docs/help/rules/
+- RuStore фичеринг бесплатный — верифицировано через rustore.ru/help/developers/advertising-and-promotion/featuring
+- vnjpclub email — верифицировано через Google Play listing
+- Minato Dorumu FB админ — **требует верификации через FB Messenger**
+- DC Inside JLPT gallery manager DJ.PEAR — верифицировано через pinned threads
+- Naver Cafe специфика — **требует идентификации конкретных cafes**
+
+**External/unverified signals:**
+
+- Все размеры аудиторий (Telegram subscribers, FB group members) — snapshot'ы на дату research'а, fluctuate
+- Response times — оценки на основе отраслевых norms, не гарантированы

--- a/marketing/strategies/origa-distribution-platforms.factcheck.json
+++ b/marketing/strategies/origa-distribution-platforms.factcheck.json
@@ -1,0 +1,133 @@
+{
+  "document": "marketing/strategies/origa-distribution-platforms.md",
+  "date": "2026-07-21",
+  "stage": "Draft v2 → HUMAN GATE (pre-outreach)",
+  "factchecker": "@marketer (autonomous)",
+  "methodology": "Per-claim confidence scoring. v2 сужает scope до бесплатных каналов публикации: убраны платные YouTube sponsor slots, podcast advertising, paid placements, competitor blogs (где бесплатно не опубликуют).",
+  "scope_change_v1_to_v2": {
+    "removed": [
+      "Все YouTube sponsor slots (Game Gengo, JapanesePod101, Japanese Ammo with Misa, Kaname Naito, ToKini Andy, Cure Dolly, Comprehensible Japanese, 유하다요, 김마멸) — платные",
+      "Nihongo con Teppei podcast sponsor — платный",
+      "Блоги прямых конкурентов (Migaku blog, Kanjijo blog, Shinobi Japanese) — бесплатно не опубликуют",
+      "Mazii (adjacent competitor) — бесплатно не опубликуют",
+      "WaniKani Community / Bunpro Community forums — конкурент-owned",
+      "Riki Moriji / KotobaBenkyou — конкурент",
+      "DC Inside J갤 — низкое S/N",
+      "TikTok micro-influencers — обычно платно",
+      "Adjacent SRS blogs (MindCards, English Tea Break, StudyCards AI, FlashRecall) — низкий ROI",
+      "Console.dev / TLDR / Hackrmind — низкий ROI для niche JP-app"
+    ],
+    "kept_count": "46 платформ (было ~70)",
+    "tier1_count": "14 (было 16 — убраны Game Gengo и 유하다요 как платные YouTube)"
+  },
+  "claims": [
+    {
+      "claim": "Tofugu — top-3 JP-learning блог глобально, публикует обзоры конкурентов (Bunpro 8/10).",
+      "source": "marketing/research/2026-07-18-jp-learning-competitors.md:27",
+      "confidence": "high",
+      "verified_by": "Прямая ссылка на Tofugu review в research-файле"
+    },
+    {
+      "claim": "Tofugu domain authority ~70.",
+      "source": "Общая оценка ландшафта JP-learning блогов; не измерялось через Moz/AHrefs напрямую",
+      "confidence": "low",
+      "note": "Приблизительно. Перепроверить через Moz/AHrefs перед публичной ссылкой на authority Tofugu."
+    },
+    {
+      "claim": "skerritt.blog публикует 'Best Japanese Learning Tools Annual Award Show'.",
+      "source": "marketing/research/2026-07-18-young-edtech-startups.md:32 (цитата от 2025-12-08)",
+      "confidence": "high",
+      "verified_by": "Прямая URL в research-файле: skerritt.blog/best-japanese-learning-tools-2025-award-show/"
+    },
+    {
+      "claim": "Daigaku Telegram-канал имеет 21,006 подписчиков.",
+      "source": "Публичная страница канала, snapshot 2026-07-21",
+      "confidence": "medium",
+      "note": "Snapshot; число колеблется. Перепроверить в течение 7 дней от pitch'а."
+    },
+    {
+      "claim": "Nihongo Telegram-канал (@yaponskoe) имеет 22,400 подписчиков.",
+      "source": "Публичная страница канала, snapshot 2026-07-21",
+      "confidence": "medium"
+    },
+    {
+      "claim": "Minato Dorumu Facebook-группа имеет 65,000+ участников.",
+      "source": "minato.edu.vn/hoc-mien-phi/ (их собственная marketing-страница)",
+      "confidence": "medium",
+      "note": "Self-reported. Верифицировать через FB group member count."
+    },
+    {
+      "claim": "Naver имеет ~50% поисковой доли в Корее.",
+      "source": "marketing/strategies/origa-seo.md:169 (keyword-research-report reference)",
+      "confidence": "medium",
+      "note": "Из существующего keyword research; не верифицировано независимо."
+    },
+    {
+      "claim": "DC Inside JLPT 마이너 갤러리 имеет pinned Anki 통합 덱 thread с 160K+ просмотрами.",
+      "source": "Страница галереи DC Inside, snapshot 2026-07-21",
+      "confidence": "medium",
+      "note": "Snapshot; pinned-треды ротируются."
+    },
+    {
+      "claim": "Hiragana.co.kr — долгоживущий KO beginner JP-комьюнити.",
+      "source": "cafe.hiragana.co.kr контент, snapshot 2026-07-21",
+      "confidence": "medium"
+    },
+    {
+      "claim": "Tokutei ginou FB groups существуют и совпадают с wedge'ом Origa (work-visa).",
+      "source": "Общее знание; конкретные группы/ссылки не перечислены в стратегии",
+      "confidence": "low",
+      "note": "ТРЕБУЕТСЯ RESEARCH: идентифицировать 3-5 конкретных tokutei ginou FB-групп с размерами и активностью перед outreach'ом. Claim-placeholder."
+    },
+    {
+      "claim": "Origa заливает AAB в RuStore через CI.",
+      "source": "git log 2026-07-21 (commit 79b9f72e 'Auto-upload AAB to RuStore on tag release')",
+      "confidence": "high",
+      "verified_by": "Прямой git log inspection"
+    },
+    {
+      "claim": "Origa — BSL 1.1, не OSI-approved.",
+      "source": "AGENTS.md, marketing/playbooks/objections-handling.md #2",
+      "confidence": "high",
+      "verified_by": "LICENSE-файл repo и проектная документация"
+    },
+    {
+      "claim": "Sentry, CockroachDB, HashiCorp шипят/шипили под BSL.",
+      "source": "Общее industry knowledge",
+      "confidence": "high",
+      "note": "Цитировать конкретные LICENSE-файлы если referenced в outreach."
+    },
+    {
+      "claim": "Tofugu публиковал review Bunpro с оценкой 8/10.",
+      "source": "marketing/research/2026-07-18-jp-learning-competitors.md:27",
+      "confidence": "high",
+      "verified_by": "Прямая URL Tofugu review: tofugu.com/reviews/bunpro/"
+    },
+    {
+      "claim": "Хабр — основная RU tech-блог платформа с dev-аудиторией.",
+      "source": "Общее знание RU tech-landscape",
+      "confidence": "high"
+    },
+    {
+      "claim": "VC.ru принимает EdTech founders' story.",
+      "source": "Общее знание платформы; конкретная editorial-политика требует верификации",
+      "confidence": "medium"
+    }
+  ],
+  "open_questions_for_human_gate": [
+    "Tokutei ginou FB groups — нужен отдельный research-pass для идентификации конкретных групп с размерами. Дать добро?",
+    "Naver Cafes поимённо — я оставил generic 'несколько 10K–100K member cafes'. Идентифицировать конкретные перед pitch'ом или это делает пользователь при onboarding'е?",
+    "Запуск на Show HN — реальный risk BSL-атаки в комментах (см. objections-handling.md #2). Запускаем на launch или ждём зрелости продукта?",
+    "VC.ru vs Хабр для RU founders'-story — оба или один? У VC.ru более business-angle, у Хабра — tech-angle. Можно разнести истории.",
+    "Pitch language для EN-платформ с VI/KO audience (Tofugu аудитория включает VI/KO-носителей) — pitch на EN или на родном языке пользователя? Я default'нул на EN для EN-platforms.",
+    "Лимит на количество одновременных Tier 1 pitch'ей — запускать все 14 одновременно или пачками по 4-5 для управляемости?"
+  ],
+  "items_requiring_verification_before_outreach": [
+    "Все Telegram-подписки (re-snapshot в течение 7 дней от pitch'а)",
+    "Активность всех community-площадок (FB, Naver Cafe, DC Inside) — верифицировать, что живы, и идентифицировать модераторов",
+    "Contact emails для Tofugu, skerritt.blog, MariaTheMillennial, JLPT Samurai, J-Compass (вероятно паттерн first-name @ domain, но верифицировать)",
+    "Tokutei ginou FB groups — конкретная идентификация групп (см. open question)",
+    "Tofugu DA estimate — прогнать Moz/AHrefs перед упоминанием authority в публичных материалах",
+    "Editorial-политика VC.ru и Хабра на текущий момент (формат acceptance, требования к статьям)"
+  ]
+}

--- a/marketing/strategies/origa-distribution-platforms.md
+++ b/marketing/strategies/origa-distribution-platforms.md
@@ -1,0 +1,477 @@
+# Origa — Стратегия распределения через внешние площадки
+
+> **Статус:** Черновик → HUMAN GATE
+> **Дата:** 2026-07-21
+> **Стадия:** Pre-launch, нулевой domain authority
+> **Охват:** 4 рынка (EN / RU / VI / KO)
+> **Лицензия:** BSL 1.1 — учитывается для OSS-leaning площадок
+> **Ограничение scope:** только **бесплатные** каналы публикации (review / guest post / listing / community mention). Платные sponsor slots, podcast advertising, paid placements — out of scope.
+> **Источники:** `marketing/research/2026-07-18-*.md` (4 research-файла), `marketing/playbooks/objections-handling.md`, `marketing/strategies/origa-seo.md`, `marketing/reddit-strategy.md`, `marketing/product-hunt.md`, `marketing/koharu.md`, web research 2026-07-21
+
+---
+
+## 1. Краткое резюме
+
+Внешние authority-площадки образуют третий канал распределения рядом с app stores и прямым SEO лендинга. Принцип заимствованный из platform-first distribution: вместо 6+ месяцев строить domain authority с нуля (контент + бэклинки) — Origa публикуется, обозревается или упоминается там, где аудитория изучающих японский уже собирается.
+
+К каждой площадке применяется фильтр из четырёх критериев:
+
+1. **Аудиторный fit** — пересекается ли аудитория площадки с wedge'ом Origa (RU/VI/KO-носители, content-driven immersion, FSRS-aware power users)
+2. **Authority-сигнал** — измеримая авторитетность (подписчики, трафик, поисковая видимость, репутация обозревателя)
+3. **Format-fit** — вписывается ли Origa в формат, который площадка уже публикует (review, listing, guest post, тематический thread, community mention)
+4. **Бесплатность** — публикация без оплаты. Платные sponsor slots, paid reviews, advertising — out of scope этой стратегии
+
+Три операционных принципа:
+
+- **Тирирование.** Tier 1 (обязательно, ручной персонализированный pitch), Tier 2 (пробовать), Tier 3 (только listing / skip).
+- **Сначала формат, потом pitch.** Форма запроса соответствует типу площадки. Pitch review для Tofugu отличается от guest-post запроса в J-Compass и от community-mention в Naver Cafe.
+- **Учёт BSL.** OSS-leaning площадки (HN-околоток, awesome-lists) требуют отдельного framing'а; продуктовые и community-площадки принимают BSL без вопросов.
+
+Outreach-ready: playbook в §6 даёт paste-ready шаблоны и cadence-последовательность. Этот трек не блокируется Reddit karma-milestone'ом из `reddit-strategy.md` — две дорожки идут параллельно.
+
+---
+
+## 2. Связь с существующими стратегиями
+
+| Существующий артефакт | Что покрывает | Что добавляет эта стратегия |
+|---|---|---|
+| `origa-seo.md` | SEO собственного домена (лендинг, repo, README, тех.инфра) | Внешние authority-площадки, где Origa обозревается/листится третьими сторонами |
+| `reddit-strategy.md` | Reputation-building + launch на Reddit | Всё вне Reddit: блоги, community, aggregators, niche-сообщества |
+| `product-hunt.md` | Запуск на Product Hunt | Всё вне PH и Reddit |
+| `objections-handling.md` | Talking points для 15 launch-возражений | Язык outreach-запросов наследует этот brand voice |
+| `koharu.md` | Precedent: traction Rust-проекта через r/rust + r/LocalLLaMA + Discord + независимые дайджесты | Подтверждает ценность независимых дайджестов как канала |
+
+Стратегия не заменяет ни один из этих артефактов. Она работает параллельно и фидит в launch-последовательность из `reddit-strategy.md` §2.
+
+---
+
+## 3. Карта бесплатных площадок — по рынкам
+
+> Все размеры аудиторий — приблизительные снапшоты из web research 2026-07-21. Перед outreach'ом перепроверить. Площадки внутри тира расположены по алфавиту.
+
+### 3.1 EN (англоязычный)
+
+| Площадка | Тип | Аудитория | BSL | Формат | Tier |
+|---|---|---|---|---|---|
+| **Tofugu** (`tofugu.com`) | JP-learning блог | DA ~70, top-3 JP-блог; публиковал review Bunpro (8/10) | ✅ | Review request (формат established) | **T1** |
+| **skerritt.blog** | Независимый tools-обозреватель | Публикует "Best Japanese Learning Tools" annual roundups | ✅ | Annual roundup pitch | **T1** |
+| **MariaTheMillennial** (`mariathemillennial.com`) | Независимый обозреватель | Подробно обозревал MaruMori (дважды) | ✅ | Review request | **T1** |
+| **Hacker News (Show HN)** | Tech aggregator | Distribution spike возможен; BSL-risk в комментах (см. §7) | ⚠️ | Show HN launch post | **T1** |
+| **JLPT Samurai** (`jlptsamurai.com`) | JP-learning блог | Обозревал Duolingo JP, Migaku alternatives | ✅ | Review request | **T2** |
+| **Tokyolingo** (`tokyolingo.com`) | JP-learning блог + aggregator | Публикует "Leading Japanese Learning Blogs" списки | ✅ | Listing / guest post | **T2** |
+| **J-Compass** (`j-compass.com`) | Sentence mining гайды | Long-form how-to, ссылается на jpdb.io, ImmersionKit | ✅ | Guest post про mining-workflow | **T2** |
+| **Mikey Does** (`mikeydoes.com`) | JP-learning анализ + глоссарий | Глоссарий Migaku, sentence mining | ✅ | Guest analysis / mention | **T2** |
+| **Wordy.info, immit.co** | Независимые обозреватели | Migaku reviews 2026 | ✅ | Review request | **T2** |
+| **nippon.com** | Japan-портал | High-DA Japan-interest site | ✅ | Editorial pitch (медленный цикл) | **T2** |
+| **Indie Hackers** | Indie founder community | Founder-story формат | ✅ | Founders' story post | **T2** |
+| **iTalki blog** (`italki.com/blog`) | Tutoring platform blog | Статьи "is-Duolingo-good-for-JP" | ✅ | Guest post | **T3** |
+| **Awesome-* lists на GitHub** | Curated lists | `awesome-rust`, `awesome-tauri`, `awesome-japanese` | ⚠️ | PR на листинг | **T3** |
+| **ImmersionKit** (`immersionkit.com`) | Sentence corpus (комплемент) | 500K JP-предложений из аниме/VN/dorama | ✅ | Cross-promotion | **T3** |
+
+### 3.2 RU (русскоязычный)
+
+| Площадка | Тип | Аудитория | BSL | Формат | Tier |
+|---|---|---|---|---|---|
+| **Daigaku — Японский язык** (`t.me/daigaku`) | Telegram-канал | 21,006 подписчиков; есть тег `#приложения` | ✅ | App review pitch | **T1** |
+| **Nihongo — Японский язык** (`t.me/yaponskoe`) | Telegram-канал | 22,400 подписчиков; второй по размеру RU JP-канал | ✅ | App review pitch | **T1** |
+| **Хабр** (`habr.com`) | Tech-блог платформа | RU dev-аудитория; статьи про Tauri/Leptos/Rust собирают traction | ⚠️ BSL поднимут в комментах | Founders'-story про Rust+Tauri+WASM стек | **T1** (stack-angle) |
+| **RuStore editorial** | App store editorial | Native RU Android store; Origa уже заливает AAB (#271) | ✅ | Editorial pitch — featuring RU dev app | **T1** |
+| **JAPAN_info** (`t.me/japan_info_nihongo`) | Telegram-канал | Большой JP-interest канал | ✅ | App mention | **T2** |
+| **Японский язык \| Япония** (`t.me/japan_teach`) | Telegram-канал | 9,930 подписчиков | ✅ | App review pitch | **T2** |
+| **ВК: крупные JP-сообщества** | VK communities | Несколько 100K+ сообществ (требует идентификации конкретных) | ✅ | Community post | **T2** |
+| **VC.ru** | Tech / business блог | Принимают EdTech founders' story | ✅ | Founders' story | **T2** |
+| **Пикабу** | RU Reddit-эквивалент | Есть JP-interest комьюнити | ✅ | Community post | **T3** |
+| **Дзен** | Long-form blogging | JP-каналы существуют, качество ниже | ✅ | Republish | **T3** |
+
+### 3.3 VI (вьетнамский)
+
+| Площадка | Тип | Аудитория | BSL | Формат | Tier |
+|---|---|---|---|---|---|
+| **vnjpclub.com** | JP-портал + diễn đàn | Долгоживущий VI JP-портал; фокус JLPT | ✅ | Forum mention + site review | **T1** |
+| **Minato Dorimu** (FB group) | Facebook-сообщество | 65,000+ участников; JLPT-фокус | ✅ | Group mention | **T1** |
+| **Tokutei ginou FB groups** (несколько) | FB groups для work-visa комьюнити | Прямое попадание в wedge Origa (виза + JLPT) | ✅ | Community mention | **T1** |
+| **Daruma Nihongo** (FB group) | Facebook-сообщество | "Tự học giao tiếp tiếng Nhật" + livestreams | ✅ | Group mention | **T2** |
+| **nguphaptiengnhat.net** | JP-портал грамматики N1–N5 | Бесплатный VI-targeted контент | ✅ | Guest post | **T2** |
+| **hoctiengnhatonline.forumvi.com** | diễn đàn | Активный VI JP-форум | ✅ | Forum thread | **T3** |
+| **Dayti.vn** | Tech-блог платформа | VI dev-аудитория | ✅ | Founders' story (stack) | **T2** |
+
+### 3.4 KO (корейский)
+
+| Площадка | Тип | Аудитория | BSL | Формат | Tier |
+|---|---|---|---|---|---|
+| **JLPT 마이너 갤러리** (DC Inside) | DC gallery | Активное JLPT-комьюнити; pinned Anki-тред (160K+ просмотров) | ✅ | Community mention + Anki-import angle | **T1** |
+| **Naver Cafes** (несколько JP-learning) | Naver Cafe | KO community-формат; несколько 10K–100K cafes | ✅ | Cafe mention | **T1** |
+| **히라가나 일본어** (`hiragana.co.kr`) | JP-learning community site | Долгоживущий KO beginner-комьюнити + study material | ✅ | Site review | **T2** |
+| **Naver Blogs** (отдельные блогеры) | Naver Blog | Naver ~50% KO-поиска; блогеры ранжируются в Naver search | ✅ | Review requests | **T2** |
+| **Clien** (`clien.net`) | Tech community | KO dev community | ⚠️ BSL может быть поднят | Tech-stack founder story | **T2** |
+
+---
+
+## 4. Определение тиров и приоритизация
+
+### Tier 1 — обязательно, ручной персонализированный pitch
+
+**Критерии отбора:**
+
+- Высокое пересечение аудитории с wedge'ом Origa (native-language learners, content-driven immersion, FSRS-aware)
+- Сложившийся формат review/listing, под который Origa ложится без усилий
+- Единичная точка отказа если пропустить — это площадки, где живут обзоры конкурентов и отсутствие Origa заметно
+
+**Tier 1 (14 площадок):**
+
+- **EN:** Tofugu, skerritt.blog, MariaTheMillennial, Hacker News (Show HN)
+- **RU:** Daigaku Telegram, Nihongo Telegram, Хабр (stack-angle), RuStore editorial
+- **VI:** vnjpclub.com, Minato Dorumu FB, tokutei ginou FB groups
+- **KO:** DC Inside JLPT gallery, Naver Cafes
+
+**Трудозатраты:** 2–4 часа на площадку (research + персонализированный pitch). Всего: ~35–50 часов за 6–8 недель.
+
+### Tier 2 — стоит пробовать, semi-personalized
+
+**Критерии:**
+
+- Твёрдая аудитория, но более слабый fit (смежная ниша, или moderate signal)
+- Подключаются после Tier 1 если остаётся время
+
+**Tier 2 (~22 площадок):**
+
+- **EN:** JLPT Samurai, Tokyolingo, J-Compass, Mikey Does, Wordy.info, immit.co, nippon.com, Indie Hackers
+- **RU:** JAPAN_info, japan_teach, VK communities, VC.ru
+- **VI:** Daruma, nguphaptiengnhat.net, Dayti.vn
+- **KO:** 히라가나 일본어, Naver Blogs, Clien
+
+**Трудозатраты:** 1–2 часа на площадку. Всего: ~25–40 часов.
+
+### Tier 3 — низкий приоритет, listing-only / skip-if-busy
+
+**Критерии:**
+
+- Маленькая аудитория, или общий паттерн «active dev time непропорционален return»
+
+**Tier 3 (~7 площадок):** iTalki blog, awesome-lists PR, ImmersionKit cross-promo, Пикабу, Дзен, hoctiengnhatonline diễn đàn.
+
+---
+
+## 5. Sequencing — pre-launch, launch, post-launch
+
+### Фаза 0 — Pre-launch (сейчас → 4 недели)
+
+Цели: подготовить все pitch-материалы, верифицировать liveness и контакты площадок, начать long-lead Tier 1 pitches (Tofugu, skerritt.blog, MariaTheMillennial — у них цикл ответа 2–6 недель).
+
+**Конкретные действия:**
+
+1. Построить outreach-tracker (таблица в `marketing/playbooks/outreach-tracker.md`). Колонки: Площадка, Контакт, Формат, Дата отправки, Статус, Дата followup, Заметки.
+2. Персонализировать Tier 1 EN-pitch'и, используя talking points из `objections-handling.md`. Отправить в Tofugu, skerritt.blog, MariaTheMillennial.
+3. Идентифицировать владельцев Naver Cafes (KO) — Naver cafes требуют join + наработку репутации перед pitch. Начать цикл join + lurk.
+4. Изучить культуру DC Inside JLPT gallery — прочитать pinned-треды, понять модерационные нормы. DC Inside славится прямотой; плохо поданный промо будет ratio'нут.
+5. Связаться с RuStore editorial — Origa уже заливает AAB через #271, использовать отношения.
+
+### Фаза 1 — Launch-неделя (синхронно с Reddit launch из `reddit-strategy.md` §2)
+
+Цели: усилить Reddit-launch синхронизированными площадками.
+
+**Конкретные действия:**
+
+1. Show HN-пост — синхронно с r/SideProject. См. §7 для handling'а BSL.
+2. Хабр founders'-story (RU stack-angle: Rust + Tauri + Leptos + local AI).
+3. Telegram-каналы pitch'и (Daigaku, Nihongo) — pitch как «RU-native JP app launched».
+4. Tokutei ginou FB groups — pitch как «VI-native JP app for JLPT».
+5. Naver Cafe mention'ы — pitch как «KO-native JP app с offline + OCR».
+6. DC Inside JLPT gallery — Anki-import angle: «Anki 통합 덱互換 Origa».
+
+### Фаза 2 — Post-launch (неделя 2 → 8 недель)
+
+Цели: Tier 2-покрытие, guest posts, buildout комьюнити.
+
+**Конкретные действия:**
+
+1. Guest post outreach в J-Compass (EN), nguphaptiengnhat.net (VI), Хабр follow-up'ы.
+2. Indie Hackers founders'-story (EN).
+3. Глубокий engagement в VN tokutei ginou-комьюнити (wedge «work-visa + JLPT» там сильный).
+
+### Фаза 3 — Ongoing (неделя 8+)
+
+- 10:1 rule из `reddit-strategy.md` распространяется на все community-площадки (1 промо на 9 полезных вкладов).
+- Ежеквартальный re-pitch в annual roundups (skerritt.blog — pitch в октябре-ноябре для inclusion в годовой список).
+- Мониторить новые площадки (новые блоги, новые YouTube-каналы) и добавлять в tracker.
+
+---
+
+## 6. Outreach Playbook
+
+### 6.1 Принципы pitch'а
+
+Применяются к каждому типу площадки. Шаблоны ниже — скелеты, каждый pitch персонализируется под получателя.
+
+1. **Ведём получателем, не Origa.** Первое предложение показывает, что вы читали их работу. Шаблонные pitch'и игнорируют.
+2. **Один ask за письмо.** Review ИЛИ guest post ИЛИ listing — никогда не комбинировать.
+3. **Никаких superlatives.** Origa это «приложение для изучения японского с локальным OCR, STT и FSRS», не «лучшее» и не «революционное». См. brand voice в `objections-handling.md`.
+4. **BSL раскрываем upfront.** Лицензия — «BSL 1.1, source-available, free for personal use». Не говорим «open source». Скрытие BSL наносит удар по доверию при обнаружении.
+5. **Делаем «да» лёгким.** Прикладываем описание в один абзац, скриншот или 30-секундное демо, ссылку на загрузку, чёткий ask.
+6. **Follow-up один раз.** Через 7 дней — короткий polite bump. После этого — drop.
+
+### 6.2 Шаблоны pitch'ей
+
+> Язык шаблона соответствует языку площадки. Для EN-площадок — английский, для RU — русский, для VI — вьетнамский, для KO — корейский. Это часть pitch'а: native-локализация Origa сама по себе аргумент.
+
+#### Шаблон A — Запрос review (Tofugu, skerritt.blog, MariaTheMillennial, JLPT Samurai, Wordy.info, immit.co)
+
+```
+Subject: Review candidate — Origa, a JP-learning app with local OCR + STT + FSRS
+
+Hi [first name],
+
+I read your [specific recent article name + one-sentence takeaway that shows
+you read it]. The angle on [specific point] matches what we have been building.
+
+I am writing about Origa — a Japanese-learning app shipping now on desktop
+(Tauri) and Android. Three things differentiate it from the apps you usually
+review:
+
+1. Local OCR (NDLOCR-Lite — the National Diet Library engine) for scanning
+   manga panels and textbook pages into cards.
+2. Local STT (Whisper) for pronunciation feedback.
+3. Native interfaces in Russian, Vietnamese and Korean — most JP apps are
+   English-only, which leaves large learner populations underserved.
+
+It is BSL 1.1 (source-available, free for personal use). Built in Rust with
+Leptos 0.8 + Tauri v2. Repo: https://github.com/yurvon-screamo/origa
+
+If this fits a future tools roundup or standalone review on [site name], I can
+send screenshots, a 30-second demo video, and a review license. No pressure
+either way — happy to be a source for context even if a full review is not on
+your roadmap.
+
+Best,
+[name]
+```
+
+**Персонализация:** `[specific recent article name]` должен ссылаться на реальную статью за последние 90 дней. Если не можете найти статью, чтобы сослаться — не pitch'ите, вы ещё недостаточно знакомы с публикацией.
+
+#### Шаблон B — Listing / aggregator submission (Tokyolingo, awesome-lists, vnjpclub.com, nguphaptiengnhat.net)
+
+```
+Subject: Submission — Origa for [list name / category]
+
+Hi [name or "team"],
+
+Submitting Origa for inclusion in [specific list or section name on their site].
+
+Origa — приложение для изучения японского (desktop Tauri + Android). Wedge:
+native UI на RU/VI/KO (большинство JP-apps EN-only), локальный OCR (NDLOCR)
++ STT (Whisper), FSRS-6, 200K+ нативных фраз с аудио.
+
+- Landing: https://origa.uwuwu.net
+- Repo: https://github.com/yurvon-screamo/origa (BSL 1.1)
+- Free for personal use
+
+[предложение о том, почему оно подходит под конкретный list — например,
+"подходит под секцию offline-first tools, потому что весь OCR/STT работает
+on-device"]
+
+Готов предоставить доп. информацию.
+
+Best,
+[name]
+```
+
+#### Шаблон C — Guest post pitch (J-Compass, nguphaptiengnhat.net, iTalki blog, VC.ru, Хабр)
+
+```
+Subject: Guest post pitch — [конкретная тема, напр. "Adding OCR-mined cards
+to your FSRS workflow"]
+
+Hi [first name],
+
+Я слежу за [site name] уже давно — особенно за [конкретная статья, к которой
+отсылает pitch]. [Угол / методология / глубина] редко встречается в
+JP-learning письме.
+
+Хочу предложить guest post:
+
+**Рабочий заголовок:** [конкретный, напр. "From manga panel to FSRS card: a
+local-first OCR workflow"]
+
+**Угол:** [один абзац — что покрывает пост, чего ещё нет на их сайте]
+
+**Почему я:** Я разработчик Origa, JP-app с локальным OCR + STT + FSRS. Пост
+будет включать скриншоты, детали конфигурации, честную секцию про лимиты
+(локальный OCR CER vs. облачные альтернативы). Без хард-пиара Origa — пост
+стоит на workflow, Origa как один из примеров.
+
+Объём: [1200–1800 слов]. Бесплатно для публикации, код под BSL, оригинальные
+изображения.
+
+Если подходит — пришлю полный outline за 48 часов.
+
+Best,
+[name]
+```
+
+#### Шаблон D — Community mention (Telegram-каналы, DC Inside, Naver Cafes, FB groups, VK)
+
+```
+[Сообщение на языке комьюнити — RU/VI/KO/JA]
+
+Здравствуйте, [admin / moderator name],
+
+Меня зовут [first name], я разработчик Origa — приложения для изучения
+японского с native [RU/VI/KO]-интерфейсом. Видел(а), что в вашем комьюнити
+есть [app recommendation / resource sharing] thread, и хотел(а)
+представиться перед публичным постом — вдруг есть гайдлайны, которых стоит
+придерживаться.
+
+Чем Origa отличается от [Anki / Bunpro / WaniKani — назвать инструменты,
+которые ваше комьюнити уже использует]:
+
+- Native [RU/VI/KO] UI (большинство JP-apps англоязычные)
+- Локальный OCR + STT (работает полностью офлайн)
+- FSRS-6 spaced repetition
+- 200K+ нативных фраз с аудио
+
+Free for personal use. BSL 1.1 (source-available). Repo: [link]
+
+Как правильно поделиться этим с вашим комьюнити? Готов(а) сделать Q&A,
+предоставить review-лицензии модераторам или ответить на вопросы в thread.
+
+Best,
+[name]
+[подпись на языке комьюнити]
+```
+
+**Критично:** для KO (DC Inside, Naver Cafes) сообщение должно быть на корейском, не на английском. Для VI — на вьетнамском. Для RU Telegram-каналов — на русском. Используем locale, который Origa уже шипит — локализация сама по себе pitch.
+
+### 6.3 Sequence и cadence
+
+| День | Действие |
+|---|---|
+| 0 | Отправить initial pitch (персонализированный) |
+| 7 | Follow-up #1: короткий polite bump. Новая информация если есть (новый релиз, новая фича) |
+| 14 | Финальный follow-up: короткий, без давления. «Закрываю loop — рад вернуться, когда тайминг будет лучше» |
+| 21+ | Drop. Двигаемся дальше. |
+
+### 6.4 Язык pitch'а по рынкам
+
+| Рынок | Язык pitch'а | Почему |
+|---|---|---|
+| EN | English | Дефолт |
+| RU | Русский | Локализация — сам wedge. Pitch на RU сигнализирует, что продукт RU-native |
+| VI | Вьетнамский | То же — VI-native wedge |
+| KO | Корейский | То же — KO-native wedge |
+
+**Исключение:** если владелец площадки билингвал или язык площадки английский (например Tofugu для KO audience) — pitch'им на EN.
+
+---
+
+## 7. Handling BSL — отдельная секция
+
+BSL 1.1 — самый предсказуемый friction-point этой стратегии (см. `objections-handling.md` #2). Разные площадки требуют разного подхода.
+
+### 7.1 Площадки, которые принимают BSL без вопросов
+
+Большинство product/app/community-площадок (Tofugu, skerritt.blog, MariaTheMillennial, Telegram-каналы, Naver Cafes, FB groups, diễn đàn) обозревают приложения как продукты, а не как OSS-проекты. BSL для них нерелевантен — не упоминайте, если не спросят.
+
+### 7.2 Площадки, где BSL поднимут в комментах
+
+**Hacker News, awesome-lists, Хабр, Clien.**
+
+У этих площадок техническая аудитория, проверяющая лицензии. Стратегия:
+
+- **Раскрываем проактивно в launch-посте**, не в комменте. Скрытие триггерит HashiCorp-рефлекс.
+- **Точная формулировка:** «source-available под BSL 1.1, free for personal use, конвертируется в пермиссивную лицензию после change-date, указанной в LICENSE».
+- **Не называем open source.** Это самый быстрый способ потерять HN-кредититет.
+- **Talking point наготове:** «BSL выбран, чтобы форк не мог добавить телеметрию и перепродать результат. Код на GitHub, каждая строка читается, комьюнити может собирать локально».
+- **Ссылаемся на precedent:** Sentry, CockroachDB, сам HashiCorp (post-fork) шипят под BSL. Это уже не экзотика.
+
+### 7.3 Площадки, фильтрующие по OSI-лицензии
+
+**Awesome-lists со строгой OSI-политикой** (некоторые `awesome-*` на GitHub имеют maintainer-политики против non-OSI). Не воевать — submit, принять отказ, двигаться дальше. Время лучше потратить в другом месте.
+
+### 7.4 Внутренняя consistency-проверка
+
+Перед любым pitch'ем прогрепать `marketing/` и `origa_landing/` на: `open source`, `OSS`, `free software`, `libre`. Каждое вхождение должно либо (a) относиться к стороннему продукту, который реально OSI, либо (b) быть переформулировано в «source-available» / «free for personal use» / «BSL 1.1». Это action items B1 / I5 из `objections-handling.md`.
+
+---
+
+## 8. Бренд-contraints и red lines
+
+Унаследовано из `objections-handling.md` §3 и `origa-seo.md` §10. Специфично для outreach:
+
+1. **Никаких superlatives** в pitch'ах. «Origa делает X» — не «Origa лучший в X».
+2. **Никаких «революционный» / «game-changing» / «next-generation»** или другой AI-cliché лексики (см. brand voice @marketer).
+3. **Никаких эмодзи** в pitch-имейлах. Slack/Telegram DM — минимально, если того требует норма комьюнити.
+4. **Честные лимиты.** Каждый pitch явно или неявно признаёт пробелы Origa (моложе Anki, нет iOS, меньше контент-библиотека чем у Migaku). Скрытие лимитов триггерит Migaku-pattern потери доверия.
+5. **Никакой дискредитации конкурентов.** Anki / Bunpro / WaniKani / Migaku / MaruMori упоминаются уважительно, когда упоминаются.
+6. **Framing российского происхождения.** См. `objections-handling.md` #13. Вести с миссии («изучение японского на родном языке»), не с происхождения.
+
+---
+
+## 9. Out of scope
+
+Эта стратегия явно **не** покрывает:
+
+- **Reddit** — см. `reddit-strategy.md` (отдельная дорожка, идёт параллельно)
+- **Product Hunt** — см. `product-hunt.md`
+- **App Store / Google Play / RuStore ASO** — отдельная дисциплина (покрыта tasks `android-release-cicd` и `ios-appstore-deployment`)
+- **Платная реклама** (Google Ads, Meta Ads, и т.д.) — out of scope
+- **Paid sponsor slots** (YouTube, podcasts, influencer networks) — out of scope. Добавить отдельный документ если появится бюджет.
+- **Конференции / meetup talks** — возможный будущий трек, не сейчас
+- **Influencer-агентства** — прямой контакт предпочтительнее; агентства добавляют markup без пропорциональной ценности на этой стадии
+- **Discord community building** — отдельная задача; см. `koharu.md` для precedent'а
+- **Блоги конкурентов** (Migaku blog, Kanjijo, Shinobi Japanese) — бесплатно не опубликуют, исключены
+- **YouTube sponsor slots** — все платные, исключены
+- **Podcast advertising** — платное, исключено
+
+---
+
+## 10. Roadmap и milestones
+
+### Milestone 1 — Outreach-tracker построен (1 день)
+
+Создать `marketing/playbooks/outreach-tracker.md`. Предзаполнить Tier 1 + Tier 2 из §3.
+
+### Milestone 2 — Tier 1 long-lead pitch'и отправлены (1 неделя)
+
+Tofugu, skerritt.blog, MariaTheMillennial, RuStore editorial, Хабр (draft founders'-story). У этих площадок цикл ответа 2–6 недель.
+
+### Milestone 3 — Onboarding community-площадок (2 недели)
+
+Join в Naver Cafes, DC Inside JLPT gallery, tokutei ginou FB groups, VK communities. Lurk, изучить нормы, помогать (10:1 rule из `reddit-strategy.md`).
+
+### Milestone 4 — Synchronization с launch'ем (1 неделя, синхронно с `reddit-strategy.md` §2)
+
+Все Tier 1 площадки активированы в течение 48 часов от Reddit-launch. Show HN, Хабр, Telegram pitch'и, DC Inside thread, Naver Cafe mention'ы, tokutei ginou FB posts.
+
+### Milestone 5 — Tier 2 follow-through (3 недели)
+
+Guest posts, listing submissions, Indie Hackers founders'-story.
+
+### Milestone 6 — Ежеквартальный review
+
+Re-pitch в annual roundups. Добавить новые обнаруженные площадки. Дропнуть площадки, не ответившие после 3 попыток.
+
+---
+
+## 11. Статус factcheck
+
+Claims в этом документе берутся из:
+
+- `marketing/research/2026-07-18-*.md` (4 research-файла — упоминания конкурентов, blog references, паттерны комьюнити)
+- Web research 2026-07-21 (liveness площадок, размеры аудиторий)
+- `objections-handling.md` (talking points, brand voice)
+
+**Что требует верификации перед outreach'ом (по площадкам):**
+
+- Размеры аудиторий (подписчики, участники, трафик) — перепроверить в течение 7 дней от pitch'а
+- Контактные данные (email, DM-handle) — актуальность на дату outreach'а
+- Площадка ещё активна (некоторые мелкие Telegram-каналы / блоги засыпают)
+- Формат review всё ещё применим (частота review'ов у Tofugu; тайминг annual roundup у skerritt.blog)
+
+**Внешние/непроверенные сигналы (помечены, не утверждаются как факт):**
+
+- Tofugu DA estimate (~70) — приблизительно, не из прямого измерения
+- Naver search-share estimate (~50%) — из keyword-research в `origa-seo.md`, не верифицировано независимо
+- Minato Dorumu FB-группа размер (65,000+) — с их собственной marketing-страницы
+- Telegram-подписки — с публичных страниц каналов, могут не отражать active readership
+
+**Детальный per-claim confidence:** `.factcheck.json` (генерируется после HUMAN GATE, до отправки любого pitch'а).


### PR DESCRIPTION
Two housekeeping commits:

1. **qlty config**: add `marketing/strategies/**` to `exclude_patterns`. Sibling `marketing/playbooks/**` and `marketing/research/**` are already excluded (project intent: marketing prose is not engineering source and must not block pushes). `strategies` was an omission.
2. **marketing content**: distribution-platforms strategy doc (+ factcheck) and outreach-contacts playbook that were sitting untracked in the worktree.

`qlty check` is clean after the exclude fix.