### PR TITLE
perf(lesson): replace 1500ms answer timer with pure-manual advance (ADR-033)

### DIFF
--- a/end2end/pages/lesson.page.ts
+++ b/end2end/pages/lesson.page.ts
@@ -37,6 +37,11 @@ export class LessonPage extends BasePage {
     readonly yesnoYesBtn: Locator;
     readonly yesnoNoBtn: Locator;
 
+    // Pure-manual advance (ADR-033): in-lesson "Next card" button shown after
+    // a quiz/yesno/phrase answer is submitted. Distinct from `nextLessonBtn`
+    // which is on the completion screen and starts the NEXT lesson.
+    readonly lessonCardNextBtn: Locator;
+
     // Lesson completion
     readonly completeScreen: Locator;
     readonly completeBackBtn: Locator;
@@ -90,6 +95,9 @@ export class LessonPage extends BasePage {
         // Yes/No
         this.yesnoYesBtn = page.getByTestId("yesno-yes-btn");
         this.yesnoNoBtn = page.getByTestId("yesno-no-btn");
+
+        // Pure-manual advance (ADR-033): in-lesson "Next card" button.
+        this.lessonCardNextBtn = page.getByTestId("lesson-card-next-btn");
 
         // Lesson completion
         this.completeScreen = page.getByTestId("lesson-complete-screen");
@@ -175,5 +183,15 @@ export class LessonPage extends BasePage {
 
     async selectQuizOption(index: number): Promise<void> {
         await this.quizOptions[index].click();
+    }
+
+    /**
+     * Advance to the next card under the pure-manual advance model
+     * (ADR-033). After a quiz/yesno/phrase answer is submitted, the user is
+     * held on the feedback card until they press Space/Enter or click the
+     * "Next" button. This method clicks that button.
+     */
+    async clickNextCard(): Promise<void> {
+        await this.lessonCardNextBtn.click();
     }
 }

--- a/end2end/tests/lesson.spec.ts
+++ b/end2end/tests/lesson.spec.ts
@@ -62,10 +62,14 @@ async function completeLessonFlexible(
         const isComplete = await lessonPage.completeScreen.isVisible().catch(() => false);
         if (isComplete) break;
 
+        // `anyInteractive` deliberately excludes `lessonCardNextBtn`: after
+        // submitting a quiz/yesno answer, both the (still-visible) quiz
+        // options and the freshly-shown NextCardButton are in the DOM, so
+        // including both in the same `.or()` chain would trip Playwright
+        // strict mode. The NextCardButton is checked separately below.
         const anyInteractive = lessonPage.showAnswerBtn
             .or(lessonPage.quizOptions[0])
             .or(lessonPage.yesnoYesBtn)
-            .or(lessonPage.lessonCardNextBtn)
             .or(lessonPage.completeScreen);
         await expect(anyInteractive).toBeVisible({ timeout: 15_000 });
 

--- a/end2end/tests/lesson.spec.ts
+++ b/end2end/tests/lesson.spec.ts
@@ -65,20 +65,32 @@ async function completeLessonFlexible(
         const anyInteractive = lessonPage.showAnswerBtn
             .or(lessonPage.quizOptions[0])
             .or(lessonPage.yesnoYesBtn)
+            .or(lessonPage.lessonCardNextBtn)
             .or(lessonPage.completeScreen);
         await expect(anyInteractive).toBeVisible({ timeout: 15_000 });
 
         if (await lessonPage.completeScreen.isVisible().catch(() => false)) break;
+
+        // Pure-manual advance (ADR-033): after submitting a quiz/yesno
+        // answer the user is held on the feedback card until they click
+        // "Next" (or press Space/Enter). The previous 1500ms auto-advance
+        // timer was removed — the helper must explicitly advance.
+        if (await lessonPage.lessonCardNextBtn.isVisible().catch(() => false)) {
+            await lessonPage.clickNextCard();
+            continue;
+        }
 
         if (await lessonPage.showAnswerBtn.isVisible().catch(() => false)) {
             await lessonPage.showAnswer();
             await lessonPage.rate("good");
         } else if (await lessonPage.quizOptions[0].isVisible().catch(() => false)) {
             await lessonPage.selectQuizOption(0);
-            await page.waitForTimeout(2000);
+            // No waitForTimeout: pure-manual advance shows NextCardButton
+            // synchronously after the answer is selected; the next loop
+            // iteration will pick it up via the lessonCardNextBtn check above.
         } else if (await lessonPage.yesnoYesBtn.isVisible().catch(() => false)) {
             await lessonPage.yesnoYesBtn.click();
-            await page.waitForTimeout(2000);
+            // Same as above — NextCardButton will be picked up next iteration.
         } else {
             break;
         }

--- a/origa_ui/src/pages/lesson/keyboard_handler.rs
+++ b/origa_ui/src/pages/lesson/keyboard_handler.rs
@@ -18,6 +18,15 @@ pub struct KeyboardActions {
     pub on_next_card: Callback<()>,
 }
 
+/// Keys that dismiss the feedback card under the pure-manual advance model
+/// (ADR-033): Space, Enter, or any single digit (0-9). Used in
+/// `waiting_for_next` state to advance to the next card without an
+/// auto-advance timer. Multi-character strings are rejected so that stray
+/// synthetic events do not advance the card.
+fn is_dismiss_key(key: &str) -> bool {
+    matches!(key, " " | "Enter")
+        || key.len() == 1 && key.chars().next().is_some_and(|c| c.is_ascii_digit())
+}
 pub fn create_keyboard_handler(
     lesson_ctx: LessonContext,
     is_rating: RwSignal<Option<Ulid>>,
@@ -32,8 +41,11 @@ pub fn create_keyboard_handler(
             return;
         }
 
-        // Приоритет: если ждём нажатия "Далее" — Space вызывает on_next_card
-        if state.waiting_for_next && key == " " {
+        // Pure-manual advance (ADR-033): when the user is held on the feedback
+        // card (waiting_for_next), Space, Enter, or any digit dismisses it and
+        // advances to the next card. The previous 1500ms auto-advance timer is
+        // gone — this is the only path forward from the feedback card.
+        if state.waiting_for_next && is_dismiss_key(&key) {
             ev.prevent_default();
             actions.on_next_card.run(());
             return;
@@ -235,5 +247,40 @@ mod tests {
     #[test]
     fn select_is_not_guarded() {
         assert!(!is_typing_target_kind("SELECT", false));
+    }
+
+    // ADR-033: pure-manual advance. The feedback card is dismissed by Space,
+    // Enter, or any digit (0-9). Other keys (e.g. Tab, arrows) do NOT dismiss,
+    // so the user can tab away without accidentally advancing.
+
+    #[test]
+    fn is_dismiss_key_accepts_space_and_enter() {
+        assert!(is_dismiss_key(" "));
+        assert!(is_dismiss_key("Enter"));
+    }
+
+    #[test]
+    fn is_dismiss_key_accepts_any_digit() {
+        for d in 0..=9 {
+            assert!(is_dismiss_key(&d.to_string()), "digit {d} should dismiss");
+        }
+    }
+
+    #[test]
+    fn is_dismiss_key_rejects_non_dismiss_keys() {
+        assert!(!is_dismiss_key("Tab"));
+        assert!(!is_dismiss_key("ArrowUp"));
+        assert!(!is_dismiss_key("Escape"));
+        assert!(!is_dismiss_key("Backspace"));
+        assert!(!is_dismiss_key("a"));
+        assert!(!is_dismiss_key("k"));
+        assert!(!is_dismiss_key("Shift"));
+    }
+
+    #[test]
+    fn is_dismiss_key_rejects_multi_digit_strings() {
+        // Only single digits — "12" or "1a" do not match.
+        assert!(!is_dismiss_key("12"));
+        assert!(!is_dismiss_key("1a"));
     }
 }

--- a/origa_ui/src/pages/lesson/lesson_card_container.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_container.rs
@@ -35,18 +35,29 @@ pub fn LessonCardContainer() -> impl IntoView {
 
     let on_rate_callback = create_on_rate_callback(lesson_state, lesson_ctx.clone(), is_rating);
 
-    let on_quiz_select = create_on_quiz_select(lesson_state, on_rate_callback);
+    let on_quiz_select = create_on_quiz_select(lesson_state);
 
-    let on_yesno_select = create_on_yesno_select(lesson_state, on_rate_callback);
+    let on_yesno_select = create_on_yesno_select(lesson_state);
 
     let on_quiz_toggle = create_on_quiz_toggle(lesson_state);
-    let on_quiz_submit = create_on_quiz_submit(lesson_state, on_rate_callback);
+    let on_quiz_submit = create_on_quiz_submit(lesson_state);
 
-    let on_quiz_dont_know = create_on_dont_know(lesson_state, on_rate_callback);
-    let on_yesno_dont_know = create_on_dont_know(lesson_state, on_rate_callback);
+    let on_quiz_dont_know = create_on_dont_know(lesson_state);
+    let on_yesno_dont_know = create_on_dont_know(lesson_state);
 
     let on_next_card = Callback::new(move |_: ()| {
-        let rating = lesson_state.get().pending_rating.unwrap_or(Rating::Good);
+        // Pure-manual advance (ADR-033) contract: every on_* handler that
+        // flips `waiting_for_next` MUST also set `pending_rating`. A `None`
+        // here means a handler forgot — fail loudly in debug. In release we
+        // fall back to `Rating::Again`, the more conservative SRS choice
+        // (re-show the card soon) rather than `Good`, which would silently
+        // inflate intervals and skew FSRS parameters.
+        let state = lesson_state.get();
+        debug_assert!(
+            state.pending_rating.is_some(),
+            "on_next_card invoked without pending_rating — handler bug"
+        );
+        let rating = state.pending_rating.unwrap_or(Rating::Again);
         on_rate_callback.run(rating);
     });
 
@@ -164,6 +175,8 @@ pub fn LessonCardContainer() -> impl IntoView {
                                     dont_know_selected=Signal::derive(move || lesson_state.get().dont_know_selected)
                                     native_language=native_language.get()
                                     known_kanji=Signal::from(known_kanji)
+                                    waiting_for_next=Signal::derive(move || lesson_state.get().waiting_for_next)
+                                    on_next_card=on_next_card
                                 />
                             })
                         } else {
@@ -211,6 +224,8 @@ pub fn LessonCardContainer() -> impl IntoView {
                                     dont_know_selected=Signal::derive(move || lesson_state.get().dont_know_selected)
                                     native_language=native_language.get()
                                     known_kanji=Signal::from(known_kanji)
+                                    waiting_for_next=Signal::derive(move || lesson_state.get().waiting_for_next)
+                                    on_next_card=on_next_card
                                 />
                             })
                         } else {
@@ -324,6 +339,8 @@ pub fn LessonCardContainer() -> impl IntoView {
                                     native_language=native_language.get()
                                     known_kanji=Signal::from(known_kanji)
                                     quiz_variant=QuizVariant::Grammar
+                                    waiting_for_next=Signal::derive(move || lesson_state.get().waiting_for_next)
+                                    on_next_card=on_next_card
                                 />
                             })
                         } else {

--- a/origa_ui/src/pages/lesson/mod.rs
+++ b/origa_ui/src/pages/lesson/mod.rs
@@ -16,6 +16,7 @@ mod lesson_card_renderer;
 mod lesson_progress;
 mod lesson_state;
 mod na_adjective_helper;
+mod next_card_button;
 mod on_dont_know;
 mod on_quiz_select;
 mod on_quiz_submit;

--- a/origa_ui/src/pages/lesson/next_card_button.rs
+++ b/origa_ui/src/pages/lesson/next_card_button.rs
@@ -1,0 +1,30 @@
+use crate::i18n::*;
+use crate::ui_components::{Button, ButtonVariant};
+use leptos::prelude::*;
+
+/// Unified "Next" button shown after the user submits an answer, under the
+/// pure-manual advance model (ADR-033). Rendered by every lesson card view
+/// (single-select quiz, yesno, multi-quiz, phrase) when the parent decides
+/// the user is held on the feedback card (`waiting_for_next == true`).
+///
+/// The parent owns the `Show when=...` condition; this component renders only
+/// the button. `test_id` is `lesson-card-next-btn` — distinct from the
+/// completion screen's `lesson-next-btn` (which starts the NEXT lesson, not
+/// the next card) to avoid Playwright strict-mode ambiguity during the
+/// async gap between the last card rate and `is_completed = true`.
+#[component]
+pub fn NextCardButton(on_next_card: Callback<()>) -> impl IntoView {
+    let i18n = use_i18n();
+    view! {
+        <div class="mt-4 flex justify-center">
+            <Button
+                variant=Signal::derive(|| ButtonVariant::Filled)
+                on_click=Callback::new(move |_| on_next_card.run(()))
+                test_id=Signal::derive(|| "lesson-card-next-btn".to_string())
+            >
+                <span>{t!(i18n, lesson.next)}</span>
+                <span class="kbd-hint text-[var(--fg-light)]">{t!(i18n, lesson.space_key)}</span>
+            </Button>
+        </div>
+    }
+}

--- a/origa_ui/src/pages/lesson/on_dont_know.rs
+++ b/origa_ui/src/pages/lesson/on_dont_know.rs
@@ -1,29 +1,9 @@
 use super::lesson_state::LessonState;
 use leptos::prelude::*;
-use origa::domain::{CardType, LessonCardView, QuizMode, Rating};
+use origa::domain::Rating;
 
-pub fn create_on_dont_know(
-    lesson_state: RwSignal<LessonState>,
-    on_rate_callback: Callback<Rating>,
-) -> Callback<()> {
+pub fn create_on_dont_know(lesson_state: RwSignal<LessonState>) -> Callback<()> {
     Callback::new(move |_: ()| {
-        let state = lesson_state.get();
-
-        let current_card = state
-            .card_ids
-            .get(state.current_index)
-            .and_then(|id| state.cards.get(id));
-
-        let is_phrase = current_card
-            .map(|c| CardType::from(c.card()) == CardType::Phrase)
-            .unwrap_or(false);
-
-        let is_multi_quiz = current_card
-            .map(|c| {
-                matches!(c.view(), LessonCardView::KanjiReadingQuiz(q) if q.mode() == QuizMode::Multi)
-            })
-            .unwrap_or(false);
-
         lesson_state.update(|state| {
             state.dont_know_selected = true;
             state.selected_quiz_option = None;
@@ -34,17 +14,110 @@ pub fn create_on_dont_know(
             state.multi_quiz_submitted = true;
         });
 
-        if is_phrase || is_multi_quiz {
-            lesson_state.update(|state| {
-                state.waiting_for_next = true;
-                state.pending_rating = Some(Rating::Again);
-            });
-        } else {
-            let on_rate_clone = on_rate_callback;
-            leptos::task::spawn_local(async move {
-                gloo_timers::future::TimeoutFuture::new(1500).await;
-                on_rate_clone.run(Rating::Again);
-            });
-        }
+        // Pure-manual advance (ADR-033): all branches converge on
+        // waiting_for_next, regardless of card type or quiz mode. The
+        // previous 1500ms timer branch for non-phrase non-multi was the
+        // source of the "stuck on the answer window" complaint.
+        lesson_state.update(|state| {
+            state.waiting_for_next = true;
+            state.pending_rating = Some(Rating::Again);
+        });
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use origa::domain::{
+        Card, LessonCard, LessonCardView, PhraseCard, QuizCard, QuizMode, QuizOption,
+    };
+    use ulid::Ulid;
+
+    fn phrase_card() -> Card {
+        Card::Phrase(PhraseCard::new(Ulid::new()))
+    }
+
+    fn quiz_lesson_card(card: Card, mode: QuizMode) -> LessonCard {
+        let options = vec![
+            QuizOption::new_simple("a".to_string(), true),
+            QuizOption::new_simple("b".to_string(), false),
+        ];
+        let quiz = QuizCard::new(card, options, mode);
+        let view = match mode {
+            QuizMode::Multi => LessonCardView::KanjiReadingQuiz(quiz),
+            QuizMode::Single => LessonCardView::Quiz(quiz),
+        };
+        LessonCard::new(Ulid::new(), view, false)
+    }
+
+    fn setup_state(card: LessonCard) -> RwSignal<LessonState> {
+        let slot_id = Ulid::new();
+        let mut cards = std::collections::HashMap::new();
+        cards.insert(slot_id, card);
+        let state = LessonState {
+            card_ids: vec![slot_id],
+            cards,
+            ..LessonState::default()
+        };
+        RwSignal::new(state)
+    }
+
+    // Phrase branch (and multi-quiz branch) set waiting_for_next synchronously
+    // — no spawn_local on this path. Characterize to lock against regression
+    // when Slice-2 unifies the non-phrase non-multi path.
+    #[test]
+    fn dont_know_for_phrase_sets_waiting_for_next_synchronously() {
+        let state = Owner::new().with(|| {
+            let card = quiz_lesson_card(phrase_card(), QuizMode::Single);
+            let lesson_state = setup_state(card);
+            let on_dont_know = create_on_dont_know(lesson_state);
+
+            on_dont_know.run(());
+            lesson_state.get()
+        });
+
+        assert!(state.showing_answer);
+        assert!(state.dont_know_selected);
+        assert!(
+            state.waiting_for_next,
+            "phrase branch must set waiting_for_next"
+        );
+        assert_eq!(state.pending_rating, Some(Rating::Again));
+    }
+
+    // Multi-quiz branch (KanjiReadingQuiz with mode=Multi) — same synchronous
+    // waiting_for_next path as phrase, but reached by quiz shape, not card type.
+    #[test]
+    fn dont_know_for_multi_quiz_sets_waiting_for_next_synchronously() {
+        let state = Owner::new().with(|| {
+            // vocab card serialized via public serde repr — VocabularyCard::new
+            // is #[cfg(test)] pub(crate) in the origa crate.
+            let vocab: Card = serde_json::from_str(
+                r#"{"Vocabulary":{"word":{"text":"test"},"reverse_side":null,"pos":null}}"#,
+            )
+            .expect("deserialize vocab card");
+            let card = quiz_lesson_card(vocab, QuizMode::Multi);
+            let lesson_state = setup_state(card);
+            let on_dont_know = create_on_dont_know(lesson_state);
+
+            on_dont_know.run(());
+            lesson_state.get()
+        });
+
+        assert!(state.showing_answer);
+        assert!(state.dont_know_selected);
+        assert!(
+            state.waiting_for_next,
+            "multi-quiz branch must set waiting_for_next"
+        );
+        assert_eq!(state.pending_rating, Some(Rating::Again));
+        assert!(
+            state.multi_quiz_submitted,
+            "multi-quiz branch must mark multi_quiz_submitted"
+        );
+        assert_eq!(
+            state.multi_result, None,
+            "dont_know never populates multi_result"
+        );
+    }
 }

--- a/origa_ui/src/pages/lesson/on_quiz_select.rs
+++ b/origa_ui/src/pages/lesson/on_quiz_select.rs
@@ -1,15 +1,16 @@
 use super::lesson_state::LessonState;
 use leptos::prelude::*;
-use leptos::task::spawn_local;
-use origa::domain::{CardType, LessonCardView, Rating};
+use origa::domain::{LessonCardView, Rating};
 
-pub fn create_on_quiz_select(
-    lesson_state: RwSignal<LessonState>,
-    on_rate_callback: Callback<Rating>,
-) -> Callback<usize> {
-    let Some(is_disposed) = use_context::<StoredValue<()>>() else {
+pub fn create_on_quiz_select(lesson_state: RwSignal<LessonState>) -> Callback<usize> {
+    // Defensive: without a dispose sentinel in context the handler returns a
+    // no-op callback. The sentinel pattern is shared across all on_* handlers
+    // for consistency with on_rate.rs (which additionally captures and checks
+    // `is_disposed` inside its spawn_local — this handler is fully
+    // synchronous, so only context existence is checked).
+    if use_context::<StoredValue<()>>().is_none() {
         return Callback::new(move |_: usize| {});
-    };
+    }
 
     Callback::new(move |option_index: usize| {
         lesson_state.update(|state| {
@@ -26,7 +27,6 @@ pub fn create_on_quiz_select(
         };
 
         if let Some(lesson_card) = lesson_state.get().cards.get(&card_id) {
-            let is_phrase = CardType::from(lesson_card.card()) == CardType::Phrase;
             let is_correct = match lesson_card.view() {
                 LessonCardView::Quiz(q) | LessonCardView::KanjiReadingQuiz(q) => {
                     Some(q.check_answer(option_index))
@@ -45,22 +45,105 @@ pub fn create_on_quiz_select(
                     Rating::Again
                 };
 
-                if is_phrase {
-                    lesson_state.update(|state| {
-                        state.waiting_for_next = true;
-                        state.pending_rating = Some(rating);
-                    });
-                } else {
-                    let on_rate_clone = on_rate_callback;
-                    spawn_local(async move {
-                        gloo_timers::future::TimeoutFuture::new(1500).await;
-                        if is_disposed.is_disposed() {
-                            return;
-                        }
-                        on_rate_clone.run(rating);
-                    });
-                }
+                // Pure-manual advance (ADR-033): the user dismisses the
+                // feedback card themselves via Space/Enter/click. The previous
+                // 1500ms timer was the source of the "stuck on the answer
+                // window" complaint — replaced uniformly for phrase and
+                // non-phrase quiz branches.
+                lesson_state.update(|state| {
+                    state.waiting_for_next = true;
+                    state.pending_rating = Some(rating);
+                });
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use origa::domain::{
+        Card, LessonCard, LessonCardView, PhraseCard, QuizCard, QuizMode, QuizOption,
+    };
+    use ulid::Ulid;
+
+    fn phrase_card() -> Card {
+        Card::Phrase(PhraseCard::new(Ulid::new()))
+    }
+
+    /// Single-select quiz with 4 options, marking the one at `correct_index`.
+    fn quiz_lesson_card(card: Card, correct_index: usize) -> LessonCard {
+        let options: Vec<QuizOption> = (0..4)
+            .map(|i| {
+                QuizOption::new_simple(
+                    if i == correct_index {
+                        "correct".to_string()
+                    } else {
+                        "wrong".to_string()
+                    },
+                    i == correct_index,
+                )
+            })
+            .collect();
+        let quiz = QuizCard::new(card, options, QuizMode::Single);
+        LessonCard::new(Ulid::new(), LessonCardView::Quiz(quiz), false)
+    }
+
+    fn setup_state(card: LessonCard) -> (RwSignal<LessonState>, Ulid) {
+        let slot_id = Ulid::new();
+        let mut cards = std::collections::HashMap::new();
+        cards.insert(slot_id, card);
+        let state = LessonState {
+            card_ids: vec![slot_id],
+            cards,
+            ..LessonState::default()
+        };
+        (RwSignal::new(state), slot_id)
+    }
+
+    // Phrase branch sets waiting_for_next synchronously — no spawn_local on
+    // this path, so the full post-condition is observable right after run().
+    #[test]
+    fn quiz_select_for_phrase_marks_showing_answer_and_waits_for_next() {
+        let state = Owner::new().with(|| {
+            provide_context(StoredValue::<()>::new(()));
+            let card = quiz_lesson_card(phrase_card(), 0);
+            let (lesson_state, _) = setup_state(card);
+            let on_quiz_select = create_on_quiz_select(lesson_state);
+
+            on_quiz_select.run(0);
+            lesson_state.get()
+        });
+
+        assert!(state.showing_answer);
+        assert_eq!(state.selected_quiz_option, Some(0));
+        assert!(
+            state.waiting_for_next,
+            "phrase branch must set waiting_for_next synchronously"
+        );
+        assert_eq!(state.pending_rating, Some(Rating::Good));
+    }
+
+    // Non-phrase branch was previously gated by a 1500ms spawn_local timer;
+    // pure-manual advance (ADR-033) unified it with the phrase branch. Both
+    // branches now set `waiting_for_next` synchronously; only the synchronous
+    // prefix is observable from native tests, which is why there is no
+    // separate non-phrase characterization test — it would be redundant.
+
+    // Without the dispose sentinel provided in context, the handler is
+    // required to early-return a no-op callback.
+    #[test]
+    fn quiz_select_without_dispose_context_returns_noop_callback() {
+        let state = Owner::new().with(|| {
+            let card = quiz_lesson_card(phrase_card(), 0);
+            let (lesson_state, _) = setup_state(card);
+            let on_quiz_select = create_on_quiz_select(lesson_state);
+
+            on_quiz_select.run(0);
+            lesson_state.get()
+        });
+
+        assert!(!state.showing_answer, "noop callback must not mutate state");
+        assert_eq!(state.selected_quiz_option, None);
+    }
 }

--- a/origa_ui/src/pages/lesson/on_quiz_submit.rs
+++ b/origa_ui/src/pages/lesson/on_quiz_submit.rs
@@ -1,11 +1,8 @@
 use super::lesson_state::LessonState;
 use leptos::prelude::*;
-use origa::domain::{CardType, LessonCardView, QuizMode, Rating};
+use origa::domain::LessonCardView;
 
-pub fn create_on_quiz_submit(
-    lesson_state: RwSignal<LessonState>,
-    on_rate_callback: Callback<Rating>,
-) -> Callback<()> {
+pub fn create_on_quiz_submit(lesson_state: RwSignal<LessonState>) -> Callback<()> {
     Callback::new(move |_: ()| {
         let state = lesson_state.get();
         let selected: Vec<usize> = state.selected_quiz_options.iter().copied().collect();
@@ -24,14 +21,11 @@ pub fn create_on_quiz_submit(
             return;
         };
 
-        let is_phrase = CardType::from(lesson_card.card()) == CardType::Phrase;
-
         let quiz = match lesson_card.view() {
             LessonCardView::KanjiReadingQuiz(q) => q,
             _ => return,
         };
 
-        let is_multi_quiz = quiz.mode() == QuizMode::Multi;
         let multi_result = quiz.check_multi_answers(&selected);
         let rating = multi_result.rating_lenient();
 
@@ -41,17 +35,129 @@ pub fn create_on_quiz_submit(
             state.multi_result = Some(multi_result);
         });
 
-        if is_phrase || is_multi_quiz {
-            lesson_state.update(|state| {
-                state.waiting_for_next = true;
-                state.pending_rating = Some(rating);
-            });
-        } else {
-            let on_rate_clone = on_rate_callback;
-            leptos::task::spawn_local(async move {
-                gloo_timers::future::TimeoutFuture::new(1500).await;
-                on_rate_clone.run(rating);
-            });
-        }
+        // Pure-manual advance (ADR-033): the user dismisses the feedback card
+        // themselves via Space/Enter/click. Replaces the previous 1500ms timer
+        // branch for non-phrase non-multi KanjiReadingQuiz submissions.
+        lesson_state.update(|state| {
+            state.waiting_for_next = true;
+            state.pending_rating = Some(rating);
+        });
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use origa::domain::{Card, LessonCard, LessonCardView, QuizCard, QuizMode, QuizOption};
+    use std::collections::HashSet;
+    use ulid::Ulid;
+
+    fn vocab_card() -> Card {
+        serde_json::from_str(
+            r#"{"Vocabulary":{"word":{"text":"test"},"reverse_side":null,"pos":null}}"#,
+        )
+        .expect("deserialize vocab card")
+    }
+
+    /// Multi-quiz requires `LessonCardView::KanjiReadingQuiz` with `QuizMode::Multi`.
+    fn multi_quiz_lesson_card(card: Card) -> LessonCard {
+        let options = vec![
+            QuizOption::new_simple("a".to_string(), true),
+            QuizOption::new_simple("b".to_string(), false),
+        ];
+        let quiz = QuizCard::new(card, options, QuizMode::Multi);
+        LessonCard::new(Ulid::new(), LessonCardView::KanjiReadingQuiz(quiz), false)
+    }
+
+    fn setup_state_with_selections(
+        card: LessonCard,
+        selections: &[usize],
+    ) -> RwSignal<LessonState> {
+        let slot_id = Ulid::new();
+        let mut cards = std::collections::HashMap::new();
+        cards.insert(slot_id, card);
+        let state = LessonState {
+            card_ids: vec![slot_id],
+            cards,
+            selected_quiz_options: selections.iter().copied().collect::<HashSet<_>>(),
+            ..LessonState::default()
+        };
+        RwSignal::new(state)
+    }
+
+    // Multi-quiz submit always lands on the synchronous waiting_for_next
+    // branch (because `is_multi_quiz == true`), regardless of card type.
+    // This is the behavior Slice-2 must NOT change.
+    #[test]
+    fn quiz_submit_for_multi_quiz_sets_waiting_for_next_synchronously() {
+        let state = Owner::new().with(|| {
+            let card = multi_quiz_lesson_card(vocab_card());
+            let lesson_state = setup_state_with_selections(card, &[0]);
+            let on_submit = create_on_quiz_submit(lesson_state);
+
+            on_submit.run(());
+            lesson_state.get()
+        });
+
+        assert!(state.showing_answer);
+        assert!(state.multi_quiz_submitted);
+        assert!(
+            state.multi_result.is_some(),
+            "multi_result must be populated by submit"
+        );
+        assert!(
+            state.waiting_for_next,
+            "multi-quiz submit must set waiting_for_next"
+        );
+        assert!(
+            state.pending_rating.is_some(),
+            "multi-quiz submit must set pending_rating"
+        );
+    }
+
+    // Defensive: empty selection is a no-op (return early).
+    #[test]
+    fn quiz_submit_with_empty_selection_is_noop() {
+        let state = Owner::new().with(|| {
+            let card = multi_quiz_lesson_card(vocab_card());
+            let lesson_state = setup_state_with_selections(card, &[]);
+            let on_submit = create_on_quiz_submit(lesson_state);
+
+            on_submit.run(());
+            lesson_state.get()
+        });
+
+        assert!(
+            !state.showing_answer,
+            "empty selection must not mutate state"
+        );
+        assert!(!state.multi_quiz_submitted);
+        assert!(state.multi_result.is_none());
+    }
+
+    // Defensive: KanjiReadingQuiz is the only view accepted; other quiz views
+    // (e.g. plain Quiz) early-return without mutating state.
+    #[test]
+    fn quiz_submit_for_non_kanji_reading_quiz_view_is_noop() {
+        let state = Owner::new().with(|| {
+            // Build a plain Quiz view with multi mode — still rejected, since
+            // the matcher accepts only KanjiReadingQuiz.
+            let options = vec![
+                QuizOption::new_simple("a".to_string(), true),
+                QuizOption::new_simple("b".to_string(), false),
+            ];
+            let quiz = QuizCard::new(vocab_card(), options, QuizMode::Multi);
+            let card = LessonCard::new(Ulid::new(), LessonCardView::Quiz(quiz), false);
+            let lesson_state = setup_state_with_selections(card, &[0]);
+            let on_submit = create_on_quiz_submit(lesson_state);
+
+            on_submit.run(());
+            lesson_state.get()
+        });
+
+        assert!(
+            !state.showing_answer,
+            "non-KanjiReadingQuiz view must be rejected"
+        );
+    }
 }

--- a/origa_ui/src/pages/lesson/on_yesno_select.rs
+++ b/origa_ui/src/pages/lesson/on_yesno_select.rs
@@ -1,15 +1,13 @@
 use super::lesson_state::LessonState;
 use leptos::prelude::*;
-use leptos::task::spawn_local;
 use origa::domain::{LessonCardView, Rating};
 
-pub fn create_on_yesno_select(
-    lesson_state: RwSignal<LessonState>,
-    on_rate_callback: Callback<Rating>,
-) -> Callback<bool> {
-    let Some(is_disposed) = use_context::<StoredValue<()>>() else {
+pub fn create_on_yesno_select(lesson_state: RwSignal<LessonState>) -> Callback<bool> {
+    // Defensive: without a dispose sentinel in context the handler returns a
+    // no-op callback. Same pattern as on_quiz_select — see its doc comment.
+    if use_context::<StoredValue<()>>().is_none() {
         return Callback::new(move |_: bool| {});
-    };
+    }
 
     Callback::new(move |answer: bool| {
         lesson_state.update(|state| {
@@ -18,27 +16,27 @@ pub fn create_on_yesno_select(
         });
 
         let state = lesson_state.get();
-        let card_id = state.card_ids.get(state.current_index);
+        let Some(card_id) = state.card_ids.get(state.current_index) else {
+            return;
+        };
+        let Some(lesson_card) = state.cards.get(card_id) else {
+            return;
+        };
+        let LessonCardView::YesNo(yesno) = lesson_card.view() else {
+            return;
+        };
 
-        if let Some(card_id) = card_id
-            && let Some(lesson_card) = state.cards.get(card_id)
-            && let LessonCardView::YesNo(yesno) = lesson_card.view()
-        {
-            let is_correct = yesno.check_answer(answer);
-            let rating = if is_correct {
-                Rating::Good
-            } else {
-                Rating::Again
-            };
+        let rating = if yesno.check_answer(answer) {
+            Rating::Good
+        } else {
+            Rating::Again
+        };
 
-            let on_rate_clone = on_rate_callback;
-            spawn_local(async move {
-                gloo_timers::future::TimeoutFuture::new(1500).await;
-                if is_disposed.is_disposed() {
-                    return;
-                }
-                on_rate_clone.run(rating);
-            });
-        }
+        // Pure-manual advance (ADR-033): the user dismisses the feedback card
+        // themselves via Space/Enter/click. Replaces the previous 1500ms timer.
+        lesson_state.update(|state| {
+            state.waiting_for_next = true;
+            state.pending_rating = Some(rating);
+        });
     })
 }

--- a/origa_ui/src/pages/lesson/phrase_card.rs
+++ b/origa_ui/src/pages/lesson/phrase_card.rs
@@ -1,13 +1,14 @@
 use crate::i18n::*;
 use crate::ui_components::{
-    AudioPlayer, Button, ButtonVariant, Card, MarkdownText, MarkdownVariant, Tag, TagVariant, Text,
-    TextSize, TranslatorText, TypographyVariant,
+    AudioPlayer, Card, MarkdownText, MarkdownVariant, Tag, TagVariant, Text, TextSize,
+    TranslatorText, TypographyVariant,
 };
 use leptos::prelude::*;
 use origa::domain::QuizOption;
 use std::collections::HashSet;
 
 use super::card_type::CardType;
+use super::next_card_button::NextCardButton;
 use super::quiz_result::QuizResult;
 use super::quiz_result_display::QuizResultDisplay;
 
@@ -195,16 +196,7 @@ pub fn PhraseCardView(
                 </Show>
 
                 <Show when=move || waiting_for_next.get() && show_result.get()>
-                    <div class="mt-4 flex justify-center">
-                        <Button
-                            variant=Signal::derive(|| ButtonVariant::Filled)
-                            on_click=Callback::new(move |_| on_next_card.run(()))
-                            test_id=Signal::derive(|| "phrase-next-btn".to_string())
-                        >
-                            <span>{t!(i18n, lesson.next)}</span>
-                            <span class="kbd-hint text-[var(--fg-light)]">{t!(i18n, lesson.space_key)}</span>
-                        </Button>
-                    </div>
+                    <NextCardButton on_next_card=on_next_card />
                 </Show>
             </div>
         </Card>

--- a/origa_ui/src/pages/lesson/quiz_card.rs
+++ b/origa_ui/src/pages/lesson/quiz_card.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use tracing::warn;
 
 use super::card_type::CardType;
+use super::next_card_button::NextCardButton;
 use super::quiz_card_header::QuizCardHeader;
 use super::quiz_options::QuizOptions;
 use super::quiz_options_multi::QuizOptionsMulti;
@@ -297,6 +298,10 @@ pub fn QuizCardView(
 
                     <Show when=move || show_result.get() && quiz_result() != QuizResult::DontKnow>
                         <QuizResultDisplay quiz_result=quiz_result() />
+                    </Show>
+
+                    <Show when=move || waiting_for_next.get() && show_result.get()>
+                        <NextCardButton on_next_card=on_next_card />
                     </Show>
                 </Show>
             </div>

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -1,9 +1,10 @@
 use crate::i18n::*;
-use crate::ui_components::{Button, ButtonVariant, MarkdownText, MarkdownVariant, Text, TextSize};
+use crate::ui_components::{MarkdownText, MarkdownVariant, Text, TextSize};
 use leptos::prelude::*;
 use origa::domain::{MultiQuizResult, QuizOption};
 use std::collections::HashSet;
 
+use super::next_card_button::NextCardButton;
 use super::quiz_result::OptionDisplay;
 
 #[component]
@@ -87,16 +88,7 @@ pub fn QuizOptionsMulti(
         </Show>
 
         <Show when=move || waiting_for_next.get() && multi_submitted.get()>
-            <div class="mt-4 flex justify-center">
-                <Button
-                    variant=Signal::derive(|| ButtonVariant::Filled)
-                    on_click=Callback::new(move |_| on_next_card.run(()))
-                    test_id=Signal::derive(|| "quiz-next-btn".to_string())
-                >
-                    <span>{t!(i18n, lesson.next)}</span>
-                    <span class="kbd-hint text-[var(--fg-light)]">{t!(i18n, lesson.space_key)}</span>
-                </Button>
-            </div>
+            <NextCardButton on_next_card=on_next_card />
         </Show>
     }
 }

--- a/origa_ui/src/pages/lesson/yesno_card_view.rs
+++ b/origa_ui/src/pages/lesson/yesno_card_view.rs
@@ -10,6 +10,7 @@ use tracing::warn;
 
 use super::answer_display::{CardAnswerDisplay, extract_card_answer};
 use super::card_type::CardType;
+use super::next_card_button::NextCardButton;
 use super::quiz_card_header::QuizCardHeader;
 use super::quiz_result::QuizResult;
 
@@ -46,6 +47,8 @@ pub fn YesNoCardView(
     dont_know_selected: Signal<bool>,
     native_language: NativeLanguage,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
+    #[prop(default = Signal::derive(|| false))] waiting_for_next: Signal<bool>,
+    #[prop(default = Callback::new(|_: ()| {}))] on_next_card: Callback<()>,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let card = yesno_card.card().clone();
@@ -308,6 +311,10 @@ pub fn YesNoCardView(
                         text=Signal::derive(move || answer_text_display_stored.get_value())
                         known_kanji=known_kanji
                     />
+                </Show>
+
+                <Show when=move || waiting_for_next.get() && show_result.get()>
+                    <NextCardButton on_next_card=on_next_card />
                 </Show>
             </div>
         </Card>


### PR DESCRIPTION
## What

The lesson feedback card (shown after a quiz/yesno answer is submitted) used to auto-advance after a hardcoded 1500ms timer with no way to skip. This was the source of the **'stuck on the answer window' complaint — roughly 40% of total lesson time**.

## Change

Replace with **pure-manual advance (Anki-like)**: after submitting an answer, the user immediately sees feedback + a unified NextCardButton, and advances by pressing Space/Enter/clicking Next/any digit. No timer, no skip anxiety. Unifies all card types on the same interaction model that phrase/multi-quiz already used.

## Diff highlights

- **4 on_\* handlers** (on_quiz_select, on_yesno_select, on_dont_know, on_quiz_submit): remove spawn_local + TimeoutFuture::new(1500); set waiting_for_next + pending_rating synchronously. Drop dead _on_rate_callback param.
- **keyboard_handler**: extract is_dismiss_key(key) for Space/Enter/single digit (was Space-only).
- **New NextCardButton component** (lesson/next_card_button.rs) — Rule-of-Three extract from phrase_card + quiz_options_multi. 	est_id = 'lesson-card-next-btn' (distinct from completion screen's 'lesson-next-btn').
- **quiz_card single-select branch + yesno_card_view**: gain NextCardButton + new props.
- **lesson_card_container**: wires waiting_for_next + on_next_card into Quiz/GrammarQuiz/YesNo branches (KanjiReadingQuiz already had them).
- **on_next_card**: debug_assert!(pending_rating.is_some()) with release fallback to Rating::Again (conservative SRS choice).
- **E2E**: new lessonCardNextBtn locator + clickNextCard method; completeLessonFlexible advances via NextCardButton instead of waitForTimeout(2000).

## Validation

- ✅ \cargo test -p origa_ui\ — 265 passed (+11 new characterization tests)
- ✅ \cargo clippy --all-targets -- -D warnings\ — clean
- ✅ \cargo fmt --check\ — clean
- ✅ Pre-commit qlty hook — passed
- ⏭️ \cargo build --bin origa_ui_bin\ — timed out locally; CI will cover
- ⏭️ Manual smoke (Tauri dev) — not run locally; CI E2E will cover
- ✅ Code review via @code-quality-reviewer — \equest_changes\ round 1 → all 3 High + 3 Common + relevant Low addressed (test_id collision with complete_screen, E2E helper structural break, dead param cleanup, stale comments, debug_assert fallback → Again, is_dismiss_key → private)

## Out of scope (follow-up PRs)

- **Slice-4** enter-animation fade-in via \key=current_index\ — deferred; needs local verification of Leptos 0.8 keyed-remount syntax + recursion_limit bin-crate check.
- **Slice-5** \get_current_user\ dedup in on_rate — excluded per plan (technically contradictory without touching the primitive use case).

## ADR

Will file ADR-033 (Pure-Manual Lesson Advance) in docs/decisions/ as part of this PR's documentation debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)