### PR TITLE
fix(lesson): audio autoplay unlock + question font-size unification

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -91,6 +91,11 @@
     --text-label-sm: 11px;
     --text-body: 14px;
     --text-lg: 18px;
+
+    /* Shared by .heading-h2 and the lesson-question markdown override so the
+       two question-render paths (FuriganaText and MarkdownText) cannot drift
+       apart in size. */
+    --heading-h2-size: clamp(2.25rem, 5vw, 2.75rem);
 }
 
 * {
@@ -2056,6 +2061,19 @@ rt {
     font-size: var(--text-lg);
 }
 
+/* Lesson question block: raise markdown-text to heading-h2 size and rhythm so
+   the MarkdownText question path (reversed cards) matches the FuriganaText
+   path (non-reversed, inherits heading-h2 clamp). Without this the question
+   font-size jumps ~2× between card directions (markdown 18px vs furigana 36px).
+   Scoped to the lesson question wrapper so global .markdown-text/.prose-lg
+   (grammar, vocabulary, landing) stay untouched. Specificity (0,2,0) beats
+   .prose-lg (0,1,0). Shares --heading-h2-size with .heading-h2 to prevent
+   drift between the two render paths. */
+.lesson-question .markdown-text {
+    font-size: var(--heading-h2-size);
+    line-height: 1.2;
+}
+
 .spinner {
     width: 24px;
     height: 24px;
@@ -3134,7 +3152,7 @@ rt {
 .heading-h2 {
     font-family: var(--font-serif);
     font-weight: 400;
-    font-size: clamp(2.25rem, 5vw, 2.75rem);
+    font-size: var(--heading-h2-size);
     line-height: 1.2;
     word-break: break-words;
 }

--- a/origa_ui/src/app.rs
+++ b/origa_ui/src/app.rs
@@ -55,6 +55,10 @@ pub fn App() -> impl IntoView {
     // (physical keyboard) they reload the WebView instead of leaking the
     // tauri.localhost origin to the system browser. No-op in the browser.
     crate::hooks::keyboard_shortcuts::install_reload_guard();
+    // Unlock HTMLMediaElement/speechSynthesis autoplay on the first user
+    // gesture so lesson-card audio (auto-played from a gesture-less Effect)
+    // is not blocked. See hooks::audio_unlock.
+    crate::hooks::audio_unlock::install_audio_unlock();
 
     let update_info = RwSignal::new(None::<updater::UpdateInfo>);
     let download_progress = RwSignal::new(None::<f32>);

--- a/origa_ui/src/hooks/audio_unlock.rs
+++ b/origa_ui/src/hooks/audio_unlock.rs
@@ -1,0 +1,160 @@
+//! Autoplay policy unlock on first user gesture.
+//!
+//! Browser and Tauri WebView autoplay policies block `HTMLAudioElement.play()`
+//! and `speechSynthesis.speak()` until the page has user activation. Lesson
+//! cards auto-play audio from a reactive `Effect` (no user gesture), so audio
+//! on the question side is frequently silent until the user clicks something.
+//! Manual playback (AudioButtons) and the answer side work because both are
+//! driven by a real gesture. This module unlocks playback once, on the first
+//! `pointerdown` or `keydown`, using two independent mechanisms because the
+//! two playback paths are governed by different policies:
+//!
+//! - **HTMLMediaElement** (CDN phrase/pitch audio): governed by Media
+//!   Engagement Index + user activation. `AudioContext.resume()` does NOT
+//!   unlock it — Origa plays through raw `HTMLAudioElement.play()`, not a Web
+//!   Audio graph. The unlock is a silent `play()`+`pause()` of a real WAV
+//!   inside the gesture.
+//! - **speechSynthesis** (web TTS): unlocked by a silent utterance (`volume
+//!   0.0`) inside the gesture, which also primes the asynchronously-populated
+//!   Chromium voice list.
+//!
+//! Limitation: a deep-link/reload that lands directly on a lesson renders the
+//! first card before any gesture, so that card's audio is skipped — a
+//! fundamental browser restriction. Lessons advance manually, so sticky
+//! activation holds across subsequent cards.
+
+use std::cell::Cell;
+
+use leptos::prelude::*;
+use leptos::task::spawn_local;
+use leptos_use::use_event_listener;
+use tracing::warn;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::SpeechSynthesisUtterance;
+
+/// Minimal valid silent WAV: 44-byte RIFF/WAVE header + a single zero PCM
+/// sample. A real decodable fragment is required — a 0-byte or empty src can
+/// reject `play()` and fail to register user activation for the session.
+const SILENT_WAV_SRC: &str =
+    "data:audio/wav;base64,UklGRiYAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQIAAAAAAA==";
+
+thread_local! {
+    static AUDIO_UNLOCKED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Claim the one-shot unlock against a flag. Returns `true` the first time the
+/// flag is `false` (and flips it), `false` thereafter. Pure logic over a
+/// borrowed flag so the once-semantics is unit-testable without a browser.
+pub(crate) fn claim_audio_unlock(flag: &Cell<bool>) -> bool {
+    if flag.get() {
+        false
+    } else {
+        flag.set(true);
+        true
+    }
+}
+
+/// Register global `pointerdown` and `keydown` listeners (on `window`) that run
+/// the one-shot unlock on the first user gesture. Lesson interaction is often
+/// keyboard-first (Space/Enter to show the answer, key-based rating), so both
+/// events are gated by a single flag: whichever fires first performs the
+/// unlock and the other becomes a no-op. `use_event_listener` auto-cleans up
+/// on the reactive owner; `App()` owns the listeners for the whole app
+/// lifetime.
+pub(crate) fn install_audio_unlock() {
+    let _ = use_event_listener(window(), leptos::ev::pointerdown, move |_| {
+        run_unlock_once();
+    });
+    let _ = use_event_listener(window(), leptos::ev::keydown, move |_| {
+        run_unlock_once();
+    });
+}
+
+fn run_unlock_once() {
+    let claimed = AUDIO_UNLOCKED.with(claim_audio_unlock);
+    if claimed {
+        unlock_html_media_element();
+        warm_up_speech_synthesis();
+    }
+}
+
+/// Silent `play()`+`pause()` of a real WAV inside the gesture to register
+/// media-engagement/user-activation for `HTMLMediaElement` on the session.
+fn unlock_html_media_element() {
+    let Ok(audio) = web_sys::HtmlAudioElement::new_with_src(SILENT_WAV_SRC) else {
+        warn!("audio unlock: HtmlAudioElement creation failed");
+        return;
+    };
+
+    match audio.play() {
+        Ok(promise) => {
+            // play() runs synchronously inside the user gesture — that is what
+            // registers activation. Pause once the promise resolves to keep
+            // the unlock inaudible.
+            spawn_local(async move {
+                if JsFuture::from(promise).await.is_err() {
+                    warn!("audio unlock: silent play() rejected");
+                    return;
+                }
+                let _ = audio.pause();
+                audio.set_src("");
+            });
+        },
+        Err(_) => warn!("audio unlock: play() threw synchronously"),
+    }
+}
+
+/// Speak a silent utterance inside the gesture to unlock `speechSynthesis` and
+/// prime the asynchronously-populated Chromium voice list. Web-build only — in
+/// Tauri, TTS goes through the native `plugin:tts` (not subject to the browser
+/// autoplay policy), so the web `speechSynthesis` path is never used there.
+fn warm_up_speech_synthesis() {
+    if crate::core::tauri::is_tauri() {
+        return;
+    }
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Ok(synthesis) = window.speech_synthesis() else {
+        return;
+    };
+    let Ok(utterance) = SpeechSynthesisUtterance::new() else {
+        warn!("audio unlock: SpeechSynthesisUtterance creation failed");
+        return;
+    };
+    // Non-empty text is required for some engines to register the utterance;
+    // volume 0 keeps it inaudible.
+    utterance.set_text(" ");
+    utterance.set_volume(0.0);
+    utterance.set_lang("ja-JP");
+    synthesis.speak(&utterance);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_claim_returns_true_and_sets_flag() {
+        let flag = Cell::new(false);
+
+        let claimed = claim_audio_unlock(&flag);
+
+        assert!(claimed);
+        assert!(flag.get());
+    }
+
+    #[test]
+    fn subsequent_claims_return_false() {
+        let flag = Cell::new(false);
+
+        let first = claim_audio_unlock(&flag);
+        let second = claim_audio_unlock(&flag);
+        let third = claim_audio_unlock(&flag);
+
+        assert!(first);
+        assert!(!second);
+        assert!(!third);
+        assert!(flag.get());
+    }
+}

--- a/origa_ui/src/hooks/mod.rs
+++ b/origa_ui/src/hooks/mod.rs
@@ -1,2 +1,3 @@
+pub mod audio_unlock;
 pub mod keyboard_shortcuts;
 pub mod phrase_checker;

--- a/origa_ui/src/pages/lesson/lesson_card_question.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_question.rs
@@ -23,7 +23,7 @@ pub fn LessonCardQuestion(
     view! {
         <div class="text-center">
             <Show when=move || kanji_stored.get_value().is_none()>
-                <div class="mb-2 sm:mb-4">
+                <div class="mb-2 sm:mb-4 lesson-question">
                     <Heading level=HeadingLevel::H2>
                         <Show
                             when=move || is_reversed


### PR DESCRIPTION
## Summary

Two lesson-card bug fixes:

1. **Audio autoplay** — frequently silent on the question side (works manually and on the answer side).
2. **Question font-size** — jumps ~2× between card directions (ultra-small vs normal).

Both root causes confirmed via computed-styles inspection + live Playwright debugging on the staging build.

---

## 1. Audio autoplay unlock on first user gesture

**Root cause:** Lesson cards auto-play audio (TTS `speak_word` + CDN phrase audio) from a reactive `Effect` (`lesson_card.rs`) that fires on card change — with no user gesture. Browser/Tauri autoplay policy blocks `HTMLAudioElement.play()` (MEI + user activation) and `speechSynthesis.speak()` until the page has activation. Manual playback (AudioButtons) and the answer side work because both are driven by a real gesture.

**Fix:** One-shot unlock in `App()` (`hooks/audio_unlock.rs`) on the first `pointerdown`/`keydown`:
- **media:** silent `HtmlAudioElement.play()+pause()` inside the gesture. `AudioContext.resume()` does NOT unlock `HTMLMediaElement` — Origa uses raw `HTMLAudioElement.play()`, not a Web Audio graph.
- **TTS:** `speechSynthesis.speak()` with `volume=0` inside the gesture (web build only; Tauri uses native `plugin:tts`, not subject to the policy).

Both listeners gated by a single `thread_local Cell<bool>`; whichever fires first performs the unlock. Pure once-logic (`claim_audio_unlock`) is unit-tested.

**Limitation:** a deep-link/reload landing directly on a lesson renders the first card before any gesture, so that card's audio is skipped (fundamental browser restriction). Lessons advance manually, so sticky activation holds across subsequent cards.

## 2. Unify question font-size between render paths

**Root cause:** The question renders via two paths with different `font-size`:
- `FuriganaText` (non-reversed): `<ruby>` inherits from `h1.heading-h2` = `clamp(2.25rem,5vw,2.75rem)` = 36–44px.
- `MarkdownText` (reversed): `.markdown-text.prose.prose-lg` sets `var(--text-lg)`=18px and does NOT inherit the h1 size; `<ruby>` inside inherits 18px.

~2× difference = the "jumps from ultra-small to normal" symptom.

**Fix:** Scoped rule `.lesson-question .markdown-text` (specificity 0,2,0 > `.prose-lg` 0,1,0) raises markdown-text to heading-h2 size and rhythm, sharing `--heading-h2-size` with `.heading-h2` to prevent drift. Global `.markdown-text`/`.prose-lg` (grammar, vocabulary, landing) untouched. `font-family` (mono/serif) intentionally left as-is — symptom was about size.

**Verified:** Playwright CSS-injection on staging — markdown question computed `font-size` 18px→36px, `line-height` 28.8px→43.2px, matching the FuriganaText path.

---

## Verification

| Check | Status |
|---|---|
| `cargo fmt --check` | OK |
| `cargo clippy -p origa_ui --all-targets -- -D warnings` | clean |
| `cargo test -p origa_ui` | 267 passed (incl. 2 new `audio_unlock` once-guard tests) |
| `cargo test -p origa -p origa_ui` | 1526 + 267 passed (regression) |
| Code review (@code-quality-reviewer) | both approved |
| Prove-It (staging, Playwright) | audio path + CSS-injection confirmed |

`cargo test --workspace` not fully run: disk was full (`no space on device`, target=95GB) during the run; `cargo clean` + `origa`+`origa_ui` run instead. `tauri`/`landing` are unaffected (changes are local to `origa_ui`, `audio_unlock` is `pub(crate)`, no new public API exported).

## Changed files

- `origa_ui/src/hooks/audio_unlock.rs` (new)
- `origa_ui/src/hooks/mod.rs`, `origa_ui/src/app.rs`
- `origa_ui/src/pages/lesson/lesson_card_question.rs`
- `origa_ui/input.css`
