### PR TITLE
feat(apple): iOS + macOS App Store CI/CD pipeline with auto-upload

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -43,6 +43,12 @@ on:
             ios-upload-status:
                 description: "iOS App Store Connect upload result: success|failure|skipped"
                 value: ${{ jobs.build-ios.outputs.upload-status }}
+            macos-build-status:
+                description: "macOS .app build result: success|failure|skipped"
+                value: ${{ jobs.build-macos.outputs.build-status }}
+            macos-upload-status:
+                description: "macOS App Store Connect upload result: success|failure|skipped"
+                value: ${{ jobs.build-macos.outputs.upload-status }}
 
 env:
     CARGO_TERM_COLOR: always
@@ -199,3 +205,272 @@ jobs:
               run: |
                   rm -f /tmp/AuthKey_*.p8
                   echo "API key cleaned up"
+
+    build-macos:
+        name: Build macOS (Universal Binary)
+        if: github.actor != 'dependabot[bot]' && inputs.skip_apple != true
+        runs-on: macos-15
+        permissions:
+            contents: read
+        outputs:
+            build-status: ${{ steps.build-report.outputs.status }}
+            upload-status: ${{ steps.upload-report.outputs.status }}
+        env:
+            ORIGA_VERSION: ${{ inputs.version }}
+            ORIGA_COMMIT: ${{ inputs.commit_sha }}
+            ORIGA_BUILD_DATE: ${{ inputs.build_date }}
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Select latest Xcode
+              shell: bash
+              run: |
+                  LATEST_XCODE=$(ls -d /Applications/Xcode*.app | sort -V | tail -1)
+                  if [ -z "$LATEST_XCODE" ]; then
+                    echo "::error::No Xcode found in /Applications"
+                    exit 1
+                  fi
+                  echo "Selected Xcode: $LATEST_XCODE"
+                  sudo xcode-select -s "$LATEST_XCODE"
+
+            - name: Download WASM artifact
+              uses: actions/download-artifact@v8
+              with:
+                  name: ${{ inputs.wasm_artifact_name }}
+                  path: origa_ui/dist/
+
+            - name: Import Mac signing certificates
+              env:
+                  APPLE_MAC_APP_CERT_P12: ${{ secrets.apple-mac-app-cert-p12 }}
+                  APPLE_MAC_INSTALLER_CERT_P12: ${{ secrets.apple-mac-installer-cert-p12 }}
+                  APPLE_MAC_CERT_PASSWORD: ${{ secrets.apple-mac-cert-password }}
+              run: |
+                  # macOS desktop signing via tauri-bundler calls `codesign`
+                  # directly (NOT xcodebuild auto-provisioning like iOS).
+                  # The signing identity (cert + private key) must be in
+                  # login.keychain before the build starts. We import the
+                  # .p12 into a dedicated build.keychain to isolate from
+                  # the runner's default keychain and avoid races with
+                  # concurrent jobs.
+                  #
+                  # Requires 2 Mac Distribution certs from Apple Developer
+                  # Portal: "Mac App Distribution" (signs .app) and
+                  # "Mac Installer Distribution" (signs .pkg).
+                  if [ -z "$APPLE_MAC_APP_CERT_P12" ] || [ -z "$APPLE_MAC_INSTALLER_CERT_P12" ]; then
+                    echo "::error::Mac certificates not configured. Set APPLE_MAC_APP_CERT_P12 and APPLE_MAC_INSTALLER_CERT_P12 secrets."
+                    exit 1
+                  fi
+
+                  echo "$APPLE_MAC_APP_CERT_P12" | base64 --decode > /tmp/mac_app.p12
+                  echo "$APPLE_MAC_INSTALLER_CERT_P12" | base64 --decode > /tmp/mac_installer.p12
+
+                  KEYCHAIN=build.keychain
+                  security create-keychain -p "$APPLE_MAC_CERT_PASSWORD" "$KEYCHAIN"
+                  security default-keychain -s "$KEYCHAIN"
+                  security unlock-keychain -p "$APPLE_MAC_CERT_PASSWORD" "$KEYCHAIN"
+                  # Allow codesign/productbuild to access keys without per-call prompt
+                  security set-keychain-settings -t 3600 -u "$KEYCHAIN"
+                  security import /tmp/mac_app.p12 -k "$KEYCHAIN" \
+                    -P "$APPLE_MAC_CERT_PASSWORD" -T /usr/bin/codesign
+                  security import /tmp/mac_installer.p12 -k "$KEYCHAIN" \
+                    -P "$APPLE_MAC_CERT_PASSWORD" -T /usr/bin/productbuild
+                  # Without set-key-partition-list codesign fails with
+                  # errSecInternalComponent — the tool cannot access the
+                  # private key even though the cert is visible.
+                  security set-key-partition-list -S apple-tool:,apple: \
+                    -s -k "$APPLE_MAC_CERT_PASSWORD" "$KEYCHAIN"
+                  # Append to keychain list so tools can search both
+                  security list-keychains -d user -s "$KEYCHAIN" login.keychain
+
+                  rm -f /tmp/mac_app.p12 /tmp/mac_installer.p12
+                  echo "Mac certificates imported into $KEYCHAIN"
+
+                  # Discover the signing identity CN for tauri-bundler.
+                  # tauri-bundler expects APPLE_SIGNING_IDENTITY env var
+                  # to be the exact CN as shown by `security find-identity`.
+                  APP_IDENTITY=$(security find-identity -v -p codesigning | grep "3rd Party Mac Developer Application" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+                  if [ -z "$APP_IDENTITY" ]; then
+                    echo "::error::3rd Party Mac Developer Application identity not found after import"
+                    security find-identity -v -p codesigning
+                    exit 1
+                  fi
+                  echo "APPLE_SIGNING_IDENTITY=$APP_IDENTITY" >> "$GITHUB_ENV"
+                  echo "Signing identity: $APP_IDENTITY"
+
+            - name: Decode Apple API Key
+              env:
+                  APPLE_API_KEY_CONTENT: ${{ secrets.apple-api-key-content }}
+                  APPLE_API_KEY: ${{ secrets.apple-api-key }}
+              run: |
+                  # API key is used by `xcrun altool` upload later; the same
+                  # .p8 file works for both iOS and macOS App Store Connect.
+                  KEY_PATH="/tmp/AuthKey_${APPLE_API_KEY}.p8"
+                  echo "$APPLE_API_KEY_CONTENT" | base64 --decode > "$KEY_PATH"
+                  echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+            - name: Update version in config files
+              uses: ./.github/actions/update-version
+              with:
+                  version: ${{ inputs.version }}
+
+            - name: Setup Rust with caching
+              uses: ./.github/actions/setup-rust
+              with:
+                  targets: aarch64-apple-darwin,x86_64-apple-darwin
+                  shared-key: origa-macos-v1
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
+
+            - name: Setup frontend tools
+              uses: ./.github/actions/setup-frontend
+              with:
+                  tools: tauri-cli
+
+            - name: Build macOS Universal Binary (.app)
+              id: build
+              working-directory: tauri
+              env:
+                  APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+              run: |
+                  # Universal Binary requires both arm64 and x86_64 targets;
+                  # tauri-bundler combines them via lipo automatically when
+                  # --target universal-apple-darwin is used.
+                  # --bundles app produces a signed .app (no .dmg), sufficient
+                  # for productbuild .pkg generation in the next step.
+                  cargo tauri build \
+                    --no-default-features --features app-store \
+                    --target universal-apple-darwin \
+                    --bundles app
+
+            - name: Verify Universal Binary
+              run: |
+                  APP_PATH=$(find target/universal-apple-darwin/release/bundle/macos -name "*.app" -type d | head -1)
+                  if [ -z "$APP_PATH" ] || [ ! -d "$APP_PATH" ]; then
+                    echo "::error::No .app found under bundle/macos/"
+                    find target/universal-apple-darwin/release/bundle -type d 2>/dev/null || true
+                    exit 1
+                  fi
+                  echo "APP_PATH=$APP_PATH" >> "$GITHUB_ENV"
+
+                  BIN_PATH="$APP_PATH/Contents/MacOS/origa"
+                  if [ ! -f "$BIN_PATH" ]; then
+                    # Try alternative binary names ( productName lowercase )
+                    BIN_PATH=$(find "$APP_PATH/Contents/MacOS" -type f | head -1)
+                  fi
+                  echo "Binary: $BIN_PATH"
+                  lipo -info "$BIN_PATH"
+                  if ! lipo -info "$BIN_PATH" | grep -q "arm64.*x86_64\|x86_64.*arm64"; then
+                    echo "::error::Binary is not Universal (arm64 + x86_64)"
+                    exit 1
+                  fi
+                  echo "✅ Universal Binary verified"
+
+            - name: Verify entitlements
+              run: |
+                  codesign -d --entitlements - "$APP_PATH" 2>&1 | tee /tmp/entitlements.txt
+                  for KEY in com.apple.security.app-sandbox \
+                             com.apple.security.network.client \
+                             com.apple.security.device.camera \
+                             com.apple.security.device.microphone \
+                             com.apple.security.files.user-selected.read-write; do
+                    if ! grep -q "$KEY" /tmp/entitlements.txt; then
+                      echo "::error::Missing entitlement: $KEY"
+                      exit 1
+                    fi
+                  done
+                  echo "✅ All 5 entitlements present"
+                  rm -f /tmp/entitlements.txt
+
+            - name: Re-codesign with --requirements (Tauri #15230 workaround)
+              # Tauri-bundler prior to fix for https://github.com/tauri-apps/tauri/issues/15230
+              # omits --requirements on codesign, causing productbuild to fail
+              # the Requirement check for Mac App Store distribution. Re-sign
+              # the top-level bundle with --requirements to inject the
+              # designated requirement. --deep is intentionally NOT used:
+              # Apple deprecated it ("does not sign nested code correctly"),
+              # and Tauri already signed nested helpers/frameworks with
+              # correct per-component entitlements during `cargo tauri build`.
+              env:
+                  APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+              run: |
+                  codesign --force --options runtime \
+                    --entitlements tauri/Entitlements.plist \
+                    --sign "$APPLE_SIGNING_IDENTITY" \
+                    --requirements 'designated => anchor apple generic and identifier "net.uwuwu.origa"' \
+                    "$APP_PATH"
+                  codesign --verify --verbose=4 "$APP_PATH"
+
+            - name: Build .pkg via productbuild
+              id: pkg
+              env:
+                  APPLE_MAC_CERT_PASSWORD: ${{ secrets.apple-mac-cert-password }}
+              run: |
+                  # productbuild signs the .pkg with Mac Installer
+                  # Distribution cert (separate from Application cert).
+                  INSTALLER_IDENTITY=$(security find-identity -v -p basic | grep "3rd Party Mac Developer Installer" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+                  if [ -z "$INSTALLER_IDENTITY" ]; then
+                    echo "::error::3rd Party Mac Developer Installer identity not found"
+                    security find-identity -v -p basic
+                    exit 1
+                  fi
+                  echo "Installer identity: $INSTALLER_IDENTITY"
+
+                  PKG_PATH="$RUNNER_TEMP/Origa.pkg"
+                  productbuild --component "$APP_PATH" /Applications \
+                    --sign "$INSTALLER_IDENTITY" \
+                    "$PKG_PATH"
+                  echo "path=$PKG_PATH" >> "$GITHUB_OUTPUT"
+                  ls -la "$PKG_PATH"
+
+            - name: Upload .pkg artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: macos-pkg-build
+                  path: ${{ steps.pkg.outputs.path }}
+                  retention-days: 7
+
+            - name: Upload to App Store Connect
+              id: upload
+              continue-on-error: true
+              env:
+                  APPLE_API_ISSUER: ${{ secrets.apple-api-issuer }}
+                  APPLE_API_KEY: ${{ secrets.apple-api-key }}
+              run: |
+                  xcrun altool --upload-app --type mac \
+                    --file "${{ steps.pkg.outputs.path }}" \
+                    --apiKey "$APPLE_API_KEY" \
+                    --apiIssuer "$APPLE_API_ISSUER"
+
+            - name: Report build result
+              id: build-report
+              if: always()
+              shell: bash
+              run: |
+                  if [ "${{ steps.build.outcome }}" = "success" ]; then
+                    echo "status=success" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "status=failure" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Report upload result
+              id: upload-report
+              if: always()
+              shell: bash
+              run: |
+                  if [ "${{ steps.upload.outcome }}" = "success" ]; then
+                    echo "status=success" >> "$GITHUB_OUTPUT"
+                    echo "✅ macOS build uploaded to App Store Connect"
+                  else
+                    echo "status=failure" >> "$GITHUB_OUTPUT"
+                    echo "::warning::xcrun altool upload failed. Download the macos-pkg-build artifact and upload manually via Transporter.app"
+                  fi
+
+            - name: Cleanup API key and keychain
+              if: always()
+              shell: bash
+              run: |
+                  rm -f /tmp/AuthKey_*.p8
+                  # Delete build.keychain to avoid leaking identity across jobs
+                  security delete-keychain build.keychain 2>/dev/null || true
+                  echo "Cleanup complete"

--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -1,0 +1,201 @@
+name: Build Tauri Apple Apps
+
+on:
+    workflow_call:
+        inputs:
+            version:
+                type: string
+                required: true
+            version_base:
+                type: string
+                required: true
+            version_type:
+                type: string
+                required: true
+            commit_sha:
+                type: string
+                required: true
+            build_date:
+                type: string
+                required: true
+            wasm_artifact_name:
+                type: string
+                required: true
+            skip_apple:
+                type: boolean
+                default: false
+        secrets:
+            apple-api-issuer:
+                required: false
+            apple-api-key:
+                required: false
+            apple-api-key-content:
+                required: false
+            apple-team-id:
+                required: false
+            apple-mac-app-cert-p12:
+                required: false
+            apple-mac-installer-cert-p12:
+                required: false
+            apple-mac-cert-password:
+                required: false
+        outputs:
+            ios-upload-status:
+                description: "iOS App Store Connect upload result: success|failure|skipped"
+                value: ${{ jobs.build-ios.outputs.upload-status }}
+
+env:
+    CARGO_TERM_COLOR: always
+
+# Apple builds are gated on:
+#   - Not Dependabot (no access to repo secrets)
+#   - Not explicitly skipped via `skip_apple` input
+# This keeps macOS runner minutes free for tag-driven releases and
+# manual workflow_dispatch runs, where the Apple secrets are available.
+
+jobs:
+    build-ios:
+        name: Build iOS
+        if: github.actor != 'dependabot[bot]' && inputs.skip_apple != true
+        runs-on: macos-15
+        permissions:
+            contents: read
+        outputs:
+            upload-status: ${{ steps.upload-report.outputs.status }}
+        env:
+            ORIGA_VERSION: ${{ inputs.version }}
+            ORIGA_COMMIT: ${{ inputs.commit_sha }}
+            ORIGA_BUILD_DATE: ${{ inputs.build_date }}
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Select latest Xcode with iOS 26 SDK
+              shell: bash
+              run: |
+                  # deploymentTarget.iOS: 26.0 requires Xcode 26 with iOS 26 SDK.
+                  # GitHub macos-15 runner ships multiple Xcode versions; pick the
+                  # newest one and verify it has iphoneos26 SDK before continuing.
+                  LATEST_XCODE=$(ls -d /Applications/Xcode*.app | sort -V | tail -1)
+                  if [ -z "$LATEST_XCODE" ]; then
+                    echo "::error::No Xcode found in /Applications"
+                    exit 1
+                  fi
+                  echo "Selected Xcode: $LATEST_XCODE"
+                  sudo xcode-select -s "$LATEST_XCODE"
+                  if ! xcodebuild -showsdks | grep -q "iphoneos26"; then
+                    echo "::error::iOS 26 SDK not found in $LATEST_XCODE"
+                    echo "--- Available SDKs ---"
+                    xcodebuild -showsdks
+                    exit 1
+                  fi
+                  echo "iOS 26 SDK verified"
+
+            - name: Download WASM artifact
+              uses: actions/download-artifact@v8
+              with:
+                  name: ${{ inputs.wasm_artifact_name }}
+                  path: origa_ui/dist/
+
+            - name: Decode Apple API Key
+              env:
+                  APPLE_API_KEY_CONTENT: ${{ secrets.apple-api-key-content }}
+                  APPLE_API_KEY: ${{ secrets.apple-api-key }}
+              run: |
+                  # Tauri iOS build uses xcodebuild -allowProvisioningUpdates with
+                  # -authenticationKeyPath/ID/IssuerID to auto-create cert and
+                  # provisioning profile via App Store Connect API. The .p8 must
+                  # be on disk; GitHub secret holds base64 of the original .p8.
+                  KEY_PATH="/tmp/AuthKey_${APPLE_API_KEY}.p8"
+                  echo "$APPLE_API_KEY_CONTENT" | base64 --decode > "$KEY_PATH"
+                  echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+                  echo "API key decoded to $KEY_PATH"
+
+            - name: Update version in config files
+              uses: ./.github/actions/update-version
+              with:
+                  version: ${{ inputs.version }}
+
+            - name: Setup Rust with caching
+              uses: ./.github/actions/setup-rust
+              with:
+                  targets: aarch64-apple-ios
+                  shared-key: origa-ios-v1
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
+
+            - name: Setup frontend tools
+              uses: ./.github/actions/setup-frontend
+              with:
+                  tools: tauri-cli
+
+            - name: Build iOS .ipa (App Store export)
+              working-directory: tauri
+              env:
+                  APPLE_API_ISSUER: ${{ secrets.apple-api-issuer }}
+                  APPLE_API_KEY: ${{ secrets.apple-api-key }}
+                  APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
+                  APPLE_TEAM_ID: ${{ secrets.apple-team-id }}
+              run: |
+                  # --no-default-features --features app-store disables updater,
+                  # single-instance, and release-devtools for App Store compliance
+                  # (Mac App Store 2.4.5(vii), 2.5.1).
+                  cargo tauri ios build \
+                    --no-default-features --features app-store \
+                    --export-method app-store-connect
+
+            - name: Locate .ipa
+              id: ipa
+              shell: bash
+              run: |
+                  IPA_PATH=$(find target -name "*.ipa" -type f | head -1)
+                  if [ -z "$IPA_PATH" ] || [ ! -f "$IPA_PATH" ]; then
+                    echo "::error::No .ipa produced by cargo tauri ios build"
+                    find target -type f -name "*.ipa" 2>/dev/null || true
+                    exit 1
+                  fi
+                  echo "path=$IPA_PATH" >> "$GITHUB_OUTPUT"
+                  ls -la "$IPA_PATH"
+
+            - name: Upload .ipa artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ios-build
+                  path: ${{ steps.ipa.outputs.path }}
+                  retention-days: 7
+
+            - name: Upload to App Store Connect
+              id: upload
+              continue-on-error: true
+              env:
+                  APPLE_API_ISSUER: ${{ secrets.apple-api-issuer }}
+                  APPLE_API_KEY: ${{ secrets.apple-api-key }}
+              run: |
+                  # xcrun altool handles App Store Connect upload using the same
+                  # API key as signing. continue-on-error: true so a failed
+                  # upload does not block the workflow — the .ipa is preserved
+                  # as artifact for manual upload via Transporter.app.
+                  xcrun altool --upload-app --type ios \
+                    --file "${{ steps.ipa.outputs.path }}" \
+                    --apiKey "$APPLE_API_KEY" \
+                    --apiIssuer "$APPLE_API_ISSUER"
+
+            - name: Report upload result
+              id: upload-report
+              if: always()
+              shell: bash
+              run: |
+                  if [ "${{ steps.upload.outcome }}" = "success" ]; then
+                    echo "status=success" >> "$GITHUB_OUTPUT"
+                    echo "✅ iOS build uploaded to App Store Connect"
+                  else
+                    echo "status=failure" >> "$GITHUB_OUTPUT"
+                    echo "::warning::xcrun altool upload failed. Download the ios-build artifact and upload manually via Transporter.app (https://apps.apple.com/us/app/transporter/id1450874784)"
+                  fi
+
+            - name: Cleanup API key
+              if: always()
+              shell: bash
+              run: |
+                  rm -f /tmp/AuthKey_*.p8
+                  echo "API key cleaned up"

--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -321,11 +321,17 @@ jobs:
                   APPLE_API_KEY_CONTENT: ${{ secrets.apple-api-key-content }}
                   APPLE_API_KEY: ${{ secrets.apple-api-key }}
               run: |
-                  # API key is used by `xcrun altool` upload later; the same
-                  # .p8 file works for both iOS and macOS App Store Connect.
-                  KEY_PATH="/tmp/AuthKey_${APPLE_API_KEY}.p8"
+                  # Same pattern as build-ios: write to ./private_keys/ so
+                  # xcrun altool finds the key (it searches ./private_keys/,
+                  # ~/private_keys/, ~/.private_keys/, ~/.appstoreconnect/
+                  # private_keys/, or $API_PRIVATE_KEYS_DIR — NOT /tmp/).
+                  # APPLE_API_KEY_PATH is unused by macOS build (codesign uses
+                  # keychain identity, not API key), but set for consistency.
+                  KEY_PATH="private_keys/AuthKey_${APPLE_API_KEY}.p8"
+                  mkdir -p private_keys
                   echo "$APPLE_API_KEY_CONTENT" | base64 --decode > "$KEY_PATH"
-                  echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+                  echo "APPLE_API_KEY_PATH=$(pwd)/$KEY_PATH" >> "$GITHUB_ENV"
+                  echo "API key decoded to $KEY_PATH"
 
             - name: Update version in config files
               uses: ./.github/actions/update-version

--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -6,6 +6,11 @@ on:
             version:
                 type: string
                 required: true
+            # version_base and version_type are retained for caller
+            # compatibility (ci.yml and tauri.yml pass them) but are not
+            # consumed inside this workflow. Kept as required to avoid a
+            # contract-breaking change to the workflow_call signature,
+            # mirroring the same pattern in _build-tauri.yml.
             version_base:
                 type: string
                 required: true
@@ -109,13 +114,21 @@ jobs:
                   APPLE_API_KEY_CONTENT: ${{ secrets.apple-api-key-content }}
                   APPLE_API_KEY: ${{ secrets.apple-api-key }}
               run: |
-                  # Tauri iOS build uses xcodebuild -allowProvisioningUpdates with
-                  # -authenticationKeyPath/ID/IssuerID to auto-create cert and
-                  # provisioning profile via App Store Connect API. The .p8 must
-                  # be on disk; GitHub secret holds base64 of the original .p8.
-                  KEY_PATH="/tmp/AuthKey_${APPLE_API_KEY}.p8"
+                  # Two consumers need the .p8 file:
+                  # 1. Tauri iOS build (cargo-mobile2 → xcodebuild auto-provisioning)
+                  #    reads it via APPLE_API_KEY_PATH env var (any path).
+                  # 2. `xcrun altool --upload-app` (App Store Connect upload)
+                  #    searches for `AuthKey_<key>.p8` ONLY in these dirs:
+                  #    ./private_keys/, ~/private_keys/, ~/.private_keys/,
+                  #    ~/.appstoreconnect/private_keys/, or $API_PRIVATE_KEYS_DIR.
+                  #    altool does NOT honor APPLE_API_KEY_PATH.
+                  # Solution: write the .p8 to ./private_keys/ so both consumers
+                  # can find it, and set APPLE_API_KEY_PATH to the same file
+                  # for cargo-mobile2.
+                  KEY_PATH="private_keys/AuthKey_${APPLE_API_KEY}.p8"
+                  mkdir -p private_keys
                   echo "$APPLE_API_KEY_CONTENT" | base64 --decode > "$KEY_PATH"
-                  echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+                  echo "APPLE_API_KEY_PATH=$(pwd)/$KEY_PATH" >> "$GITHUB_ENV"
                   echo "API key decoded to $KEY_PATH"
 
             - name: Update version in config files
@@ -203,7 +216,7 @@ jobs:
               if: always()
               shell: bash
               run: |
-                  rm -f /tmp/AuthKey_*.p8
+                  rm -rf private_keys
                   echo "API key cleaned up"
 
     build-macos:
@@ -290,9 +303,13 @@ jobs:
                   # Discover the signing identity CN for tauri-bundler.
                   # tauri-bundler expects APPLE_SIGNING_IDENTITY env var
                   # to be the exact CN as shown by `security find-identity`.
-                  APP_IDENTITY=$(security find-identity -v -p codesigning | grep "3rd Party Mac Developer Application" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+                  # Apple renamed cert CNs after Xcode 11 (2019):
+                  #   old: "3rd Party Mac Developer Application: ..."
+                  #   new: "Mac App Distribution: ..."
+                  # Match both to support certs created in any era.
+                  APP_IDENTITY=$(security find-identity -v -p codesigning | grep -E "Mac App Distribution|3rd Party Mac Developer Application" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
                   if [ -z "$APP_IDENTITY" ]; then
-                    echo "::error::3rd Party Mac Developer Application identity not found after import"
+                    echo "::error::Mac App Distribution / 3rd Party Mac Developer Application identity not found after import"
                     security find-identity -v -p codesigning
                     exit 1
                   fi
@@ -408,10 +425,11 @@ jobs:
               run: |
                   # productbuild signs the .pkg with Mac Installer
                   # Distribution cert (separate from Application cert).
-                  INSTALLER_IDENTITY=$(security find-identity -v -p basic | grep "3rd Party Mac Developer Installer" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+                  # Match both old (pre-Xcode 11) and new CN naming.
+                  INSTALLER_IDENTITY=$(security find-identity -v -p codesigning | grep -E "Mac Installer Distribution|3rd Party Mac Developer Installer" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
                   if [ -z "$INSTALLER_IDENTITY" ]; then
-                    echo "::error::3rd Party Mac Developer Installer identity not found"
-                    security find-identity -v -p basic
+                    echo "::error::Mac Installer Distribution / 3rd Party Mac Developer Installer identity not found"
+                    security find-identity -v -p codesigning
                     exit 1
                   fi
                   echo "Installer identity: $INSTALLER_IDENTITY"
@@ -470,7 +488,7 @@ jobs:
               if: always()
               shell: bash
               run: |
-                  rm -f /tmp/AuthKey_*.p8
+                  rm -rf private_keys
                   # Delete build.keychain to avoid leaking identity across jobs
                   security delete-keychain build.keychain 2>/dev/null || true
                   echo "Cleanup complete"

--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -30,7 +30,7 @@ on:
                 required: true
             platforms:
                 type: string
-                default: "windows,linux,macos,android"
+                default: "windows,linux,android"
             skip_android:
                 type: boolean
                 default: false
@@ -52,8 +52,6 @@ on:
                 value: ${{ jobs.build-windows.outputs.signature }}
             linux-signature:
                 value: ${{ jobs.build-linux.outputs.signature }}
-            macos-signature:
-                value: ${{ jobs.build-macos.outputs.signature }}
 
 env:
     CARGO_TERM_COLOR: always
@@ -271,115 +269,6 @@ jobs:
                       **/bundle/appimage/*.AppImage
                       **/bundle/appimage/*.sig
                       **/bundle/deb/*.deb
-                  retention-days: 7
-
-    build-macos:
-        name: Build macOS
-        if: contains(inputs.platforms, 'macos')
-        runs-on: ubuntu-latest
-        container:
-            image: ghcr.io/rust-cross/cargo-zigbuild
-        permissions:
-            contents: read
-        outputs:
-            signature: ${{ steps.signature.outputs.signature }}
-        env:
-            ORIGA_VERSION: ${{ inputs.version }}
-            ORIGA_COMMIT: ${{ inputs.commit_sha }}
-            ORIGA_BUILD_DATE: ${{ inputs.build_date }}
-            # Skip updater signing for Dependabot PRs — see build-windows for
-            # the full rationale.
-            TAURI_SIGNING_PRIVATE_KEY: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key || '' }}
-            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key-password || '' }}
-
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-
-            - name: Download WASM artifact
-              uses: actions/download-artifact@v8
-              with:
-                  name: ${{ inputs.wasm_artifact_name }}
-                  path: origa_ui/dist/
-
-            - name: Setup cargo cache
-              uses: Swatinem/rust-cache@v2
-              with:
-                  cache-all-crates: false
-                  cache-targets: false
-                  shared-key: origa-cross-build-v2
-                  save-if: ${{ github.ref == 'refs/heads/master' }}
-
-            - name: Update version in config files
-              uses: ./.github/actions/update-version
-              with:
-                  version: ${{ inputs.version }}
-
-            - name: Install build dependencies
-              run: apt-get update && apt-get install -y zip protobuf-compiler
-
-            - name: Setup Rust targets
-              run: rustup target add aarch64-apple-darwin
-
-            - name: Install cargo-binstall
-              run: |
-                  tmp=$(mktemp) && curl -L --proto '=https' --tlsv1.2 -sSf -o "$tmp" https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh && bash "$tmp"
-                  cargo binstall tauri-cli --no-confirm --force
-
-            - name: Add cargo bin to PATH
-              run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-            - name: Build Tauri app for macOS
-              working-directory: tauri
-              run:
-                  cargo tauri build --runner cargo-zigbuild --target aarch64-apple-darwin
-                  --no-bundle
-
-            - name: Extract signature
-              id: signature
-              shell: bash
-              run: echo "signature=" >> $GITHUB_OUTPUT
-
-            - name: Create macOS app bundle
-              run: |
-                  mkdir -p Origa.app/Contents/MacOS
-                  mkdir -p Origa.app/Contents/Resources
-                  cp target/aarch64-apple-darwin/release/origa-app Origa.app/Contents/MacOS/origa
-                  cat > Origa.app/Contents/Info.plist << EOF
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-                  <plist version="1.0">
-                  <dict>
-                    <key>CFBundleIdentifier</key>
-                    <string>net.uwuwu.origa</string>
-                    <key>CFBundleName</key>
-                    <string>Origa</string>
-                    <key>CFBundleDisplayName</key>
-                    <string>Origa</string>
-                    <key>CFBundleVersion</key>
-                    <string>${{ inputs.version }}</string>
-                    <key>CFBundleShortVersionString</key>
-                    <string>${{ inputs.version }}</string>
-                    <key>CFBundleExecutable</key>
-                    <string>origa</string>
-                    <key>CFBundlePackageType</key>
-                    <string>APPL</string>
-                  </dict>
-                  </plist>
-                  EOF
-                  chmod +x Origa.app/Contents/MacOS/origa
-                  # Single fixed-name archive for the landing page's
-                  # /releases/latest/download/Origa_macos-arm64.zip link, and as
-                  # the only macOS asset in the release (no versioned duplicate)
-                  # per ADR-025 addendum.
-                  zip -r "Origa_macos-arm64.zip" Origa.app
-
-            - name: Upload macOS artifacts
-              uses: actions/upload-artifact@v4
-              with:
-                  name: macos-build
-                  path: |
-                      Origa_macos-arm64.zip
                   retention-days: 7
 
     build-android:

--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -30,7 +30,7 @@ on:
                 required: true
             platforms:
                 type: string
-                default: "windows,linux,android"
+                default: "windows,linux,macos,android"
             skip_android:
                 type: boolean
                 default: false
@@ -52,6 +52,8 @@ on:
                 value: ${{ jobs.build-windows.outputs.signature }}
             linux-signature:
                 value: ${{ jobs.build-linux.outputs.signature }}
+            macos-signature:
+                value: ${{ jobs.build-macos.outputs.signature }}
 
 env:
     CARGO_TERM_COLOR: always
@@ -269,6 +271,119 @@ jobs:
                       **/bundle/appimage/*.AppImage
                       **/bundle/appimage/*.sig
                       **/bundle/deb/*.deb
+                  retention-days: 7
+
+    build-macos:
+        # Desktop-distribution macOS build via cargo-zigbuild (cross-compile on
+        # Linux, fast, free runner minutes). Produces the unsigned
+        # Origa_macos-arm64.zip used by the landing page's direct download
+        # link (`/releases/latest/download/Origa_macos-arm64.zip`, ADR-025).
+        #
+        # The signed Mac App Store .pkg comes from _build-tauri-apple.yml's
+        # build-macos job on a real macos-15 runner — completely separate
+        # distribution channel.
+        #
+        # Dynamic cleanup in tauri.yml's release job drops this asset when
+        # the App Store pipeline has confirmed-successfully uploaded; until
+        # then it remains as fallback.
+        name: Build macOS (desktop fallback)
+        if: contains(inputs.platforms, 'macos')
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/rust-cross/cargo-zigbuild
+        permissions:
+            contents: read
+        outputs:
+            signature: ${{ steps.signature.outputs.signature }}
+        env:
+            ORIGA_VERSION: ${{ inputs.version }}
+            ORIGA_COMMIT: ${{ inputs.commit_sha }}
+            ORIGA_BUILD_DATE: ${{ inputs.build_date }}
+            TAURI_SIGNING_PRIVATE_KEY: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key || '' }}
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key-password || '' }}
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Download WASM artifact
+              uses: actions/download-artifact@v8
+              with:
+                  name: ${{ inputs.wasm_artifact_name }}
+                  path: origa_ui/dist/
+
+            - name: Setup cargo cache
+              uses: Swatinem/rust-cache@v2
+              with:
+                  cache-all-crates: false
+                  cache-targets: false
+                  shared-key: origa-cross-build-v2
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
+
+            - name: Update version in config files
+              uses: ./.github/actions/update-version
+              with:
+                  version: ${{ inputs.version }}
+
+            - name: Install build dependencies
+              run: apt-get update && apt-get install -y zip protobuf-compiler
+
+            - name: Setup Rust targets
+              run: rustup target add aarch64-apple-darwin
+
+            - name: Install cargo-binstall
+              run: |
+                  tmp=$(mktemp) && curl -L --proto '=https' --tlsv1.2 -sSf -o "$tmp" https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh && bash "$tmp"
+                  cargo binstall tauri-cli --no-confirm --force
+
+            - name: Add cargo bin to PATH
+              run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+            - name: Build Tauri app for macOS (desktop)
+              working-directory: tauri
+              run: cargo tauri build --runner cargo-zigbuild --target aarch64-apple-darwin --no-bundle
+
+            - name: Extract signature
+              id: signature
+              shell: bash
+              run: echo "signature=" >> $GITHUB_OUTPUT
+
+            - name: Create macOS app bundle
+              run: |
+                  mkdir -p Origa.app/Contents/MacOS
+                  mkdir -p Origa.app/Contents/Resources
+                  cp target/aarch64-apple-darwin/release/origa-app Origa.app/Contents/MacOS/origa
+                  cat > Origa.app/Contents/Info.plist << EOF
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                  <plist version="1.0">
+                  <dict>
+                    <key>CFBundleIdentifier</key>
+                    <string>net.uwuwu.origa</string>
+                    <key>CFBundleName</key>
+                    <string>Origa</string>
+                    <key>CFBundleDisplayName</key>
+                    <string>Origa</string>
+                    <key>CFBundleVersion</key>
+                    <string>${{ inputs.version }}</string>
+                    <key>CFBundleShortVersionString</key>
+                    <string>${{ inputs.version }}</string>
+                    <key>CFBundleExecutable</key>
+                    <string>origa</string>
+                    <key>CFBundlePackageType</key>
+                    <string>APPL</string>
+                  </dict>
+                  </plist>
+                  EOF
+                  chmod +x Origa.app/Contents/MacOS/origa
+                  zip -r "Origa_macos-arm64.zip" Origa.app
+
+            - name: Upload macOS artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: macos-build
+                  path: |
+                      Origa_macos-arm64.zip
                   retention-days: 7
 
     build-android:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
             commit_sha: ${{ needs.version.outputs.commit_sha }}
             build_date: ${{ needs.version.outputs.build_date }}
             wasm_artifact_name: wasm-dist
-            platforms: "windows,linux,macos,android"
+            platforms: "windows,linux,android"
             skip_android: ${{ github.actor == 'dependabot[bot]' }}
         secrets:
             tauri-signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY || vars.TAURI_CI_DUMMY_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
             commit_sha: ${{ needs.version.outputs.commit_sha }}
             build_date: ${{ needs.version.outputs.build_date }}
             wasm_artifact_name: wasm-dist
-            platforms: "windows,linux,android"
+            platforms: "windows,linux,macos,android"
             skip_android: ${{ github.actor == 'dependabot[bot]' }}
         secrets:
             tauri-signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY || vars.TAURI_CI_DUMMY_PRIVATE_KEY }}

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -105,7 +105,7 @@ jobs:
             commit_sha: ${{ needs.version.outputs.commit_sha }}
             build_date: ${{ needs.version.outputs.build_date }}
             wasm_artifact_name: frontend-dist
-            platforms: "windows,linux,android"
+            platforms: "windows,linux,macos,android"
             skip_android: ${{ github.actor == 'dependabot[bot]' }}
         secrets:
             tauri-signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY || vars.TAURI_CI_DUMMY_PRIVATE_KEY }}

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -105,7 +105,7 @@ jobs:
             commit_sha: ${{ needs.version.outputs.commit_sha }}
             build_date: ${{ needs.version.outputs.build_date }}
             wasm_artifact_name: frontend-dist
-            platforms: "windows,linux,macos,android"
+            platforms: "windows,linux,android"
             skip_android: ${{ github.actor == 'dependabot[bot]' }}
         secrets:
             tauri-signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY || vars.TAURI_CI_DUMMY_PRIVATE_KEY }}
@@ -114,6 +114,27 @@ jobs:
             android-keystore-password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
             android-key-password: ${{ secrets.ANDROID_KEY_PASSWORD }}
             android-key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+
+    build-apple:
+        name: Build Apple (iOS + macOS)
+        needs: [version, build-frontend]
+        uses: ./.github/workflows/_build-tauri-apple.yml
+        with:
+            version: ${{ needs.version.outputs.version }}
+            version_base: ${{ needs.version.outputs.version_base }}
+            version_type: ${{ needs.version.outputs.version_type }}
+            commit_sha: ${{ needs.version.outputs.commit_sha }}
+            build_date: ${{ needs.version.outputs.build_date }}
+            wasm_artifact_name: frontend-dist
+            skip_apple: ${{ github.actor == 'dependabot[bot]' }}
+        secrets:
+            apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
+            apple-api-key: ${{ secrets.APPLE_API_KEY }}
+            apple-api-key-content: ${{ secrets.APPLE_API_KEY_CONTENT }}
+            apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+            apple-mac-app-cert-p12: ${{ secrets.APPLE_MAC_APP_CERT_P12 }}
+            apple-mac-installer-cert-p12: ${{ secrets.APPLE_MAC_INSTALLER_CERT_P12 }}
+            apple-mac-cert-password: ${{ secrets.APPLE_MAC_CERT_PASSWORD }}
 
     generate-latest-json:
         name: Generate latest.json
@@ -188,6 +209,7 @@ jobs:
             [
                 version,
                 build-tauri,
+                build-apple,
                 generate-latest-json,
             ]
         runs-on: ubuntu-latest
@@ -200,6 +222,8 @@ jobs:
                   path: artifacts
 
             - name: Prepare release assets
+              env:
+                  MACOS_UPLOAD_STATUS: ${{ needs.build-apple.outputs.macos-upload-status }}
               run: |
                   mkdir -p release_assets
                   # Keep only installable bundles + the updater manifest. Each
@@ -220,6 +244,20 @@ jobs:
                       -name '*.aab' -o \
                       -name 'latest.json' \
                   \) -exec cp -f {} release_assets/ \;
+
+                  # Dynamic cleanup: drop the legacy `Origa_macos-arm64.zip`
+                  # fallback ONLY when the new macOS App Store pipeline has
+                  # confirmed-successfully uploaded a build. If Apple builds
+                  # are skipped (e.g. Dependabot), secrets missing, or upload
+                  # failed, the fallback zip stays so macOS users always have
+                  # a downloadable artifact.
+                  if [ "$MACOS_UPLOAD_STATUS" = "success" ]; then
+                    rm -f release_assets/Origa_macos-arm64.zip
+                    echo "Apple macOS upload succeeded — Origa_macos-arm64.zip excluded from release"
+                  else
+                    echo "Apple macOS upload did not succeed (status: '$MACOS_UPLOAD_STATUS') — keeping Origa_macos-arm64.zip as fallback"
+                  fi
+
                   echo "Release assets content:"
                   ls -la release_assets/
 
@@ -241,7 +279,10 @@ jobs:
                       - `Origa_amd64.deb` — Debian/Ubuntu
 
                       ## macOS
-                      - `Origa_macos-arm64.zip` — Apple Silicon
+                      ${{ needs.build-apple.outputs.macos-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- `Origa_macos-arm64.zip` — Apple Silicon (fallback; App Store build pending)' }}
+
+                      ## iOS
+                      ${{ needs.build-apple.outputs.ios-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- iOS build pending (Apple pipeline did not upload)' }}
 
                       ## Android
                       - `origa.apk`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5475,6 +5475,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-haptics",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
@@ -8270,6 +8271,20 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-haptics"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b167d598ada05c599f4460595108c8d1aa636030a97d19796c1bcda97d881d"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-store = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-haptics = "2"
 tauri-build = { version = "2", features = [] }
 
 # Dev Dependencies

--- a/docs/decisions/ADR-033-apple-platforms-distribution-channels-and-dynamic-fallback.md
+++ b/docs/decisions/ADR-033-apple-platforms-distribution-channels-and-dynamic-fallback.md
@@ -1,0 +1,217 @@
+# ADR-033: Apple Platforms — Separate Distribution Channels + Dynamic Fallback Cleanup
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-28
+
+## Context
+
+Origa ships on five platforms (Windows, Linux, macOS, iOS, Android) via
+two fundamentally different distribution models:
+
+1. **Direct download** (Windows, Linux, macOS desktop) — GitHub Releases
+   host fixed-name aliases (`Origa_x64-setup.exe`,
+   `Origa_amd64.AppImage`, `Origa_macos-arm64.zip`) that the landing
+   page links via `/releases/latest/download/<alias>` (ADR-025). Builds
+   are unsigned or self-signed; users install at their own risk.
+2. **Curated stores** (iOS App Store, Mac App Store, Google Play,
+   RuStore) — Apple and Google require signed builds, review process,
+   and per-store metadata. Builds are uploaded to App Store Connect /
+   Play Console via `xcrun altool` / RuStore API; users install from
+   the store app.
+
+macOS is unique: it appears in **both** channels simultaneously.
+Desktop-distribution macOS users (Apple Silicon direct-download via
+`Origa_macos-arm64.zip`) and Mac App Store users (sandboxed, signed
+.pkg) get different binaries. The legacy desktop macOS pipeline
+(`cargo-zigbuild` on Linux runner, unsigned) is **incompatible** with
+Mac App Store requirements (sandbox entitlements, Mac Distribution
+certificate signing, Universal Binary).
+
+Apple CI/CD pipeline was added in PR #299 (`feat/apple-ci-cd-app-store`)
+as a new reusable workflow `_build-tauri-apple.yml` running on
+`macos-15` GitHub runner. It produces:
+
+- iOS `.ipa` — App Store export, uploaded via `xcrun altool --type ios`
+- macOS `.pkg` — Universal Binary (arm64 + x86_64), App Sandbox
+  entitlements, signed with Mac Distribution certs, uploaded via
+  `xcrun altool --type mac`
+
+The legacy `_build-tauri.yml` `build-macos` job (cargo-zigbuild on
+Linux runner) continues to produce the unsigned desktop-distribution
+`Origa_macos-arm64.zip`. The two pipelines are **completely
+independent** — different runners, different signing, different
+distribution channels.
+
+## Decision
+
+### 1. Two macOS distribution channels coexist
+
+- `_build-tauri.yml` `build-macos` job — desktop-distribution
+  `Origa_macos-arm64.zip` for direct download (landing page link,
+  ADR-025). Unsigned, fast, free Linux runner.
+- `_build-tauri-apple.yml` `build-macos` job — Mac App Store signed
+  `.pkg` via TestFlight. Signed, sandboxed, slow (`macos-15` runner,
+  ~30 min).
+
+### 2. Dynamic fallback cleanup in release job
+
+`tauri.yml` release job copies ALL platform assets including the legacy
+`Origa_macos-arm64.zip`. After copy, a conditional step removes it
+based on Apple pipeline success:
+
+```bash
+if [ "$MACOS_UPLOAD_STATUS" = "success" ]; then
+  rm -f release_assets/Origa_macos-arm64.zip
+fi
+```
+
+`MACOS_UPLOAD_STATUS` is propagated from `_build-tauri-apple.yml`
+outputs (`macos-upload-status`).
+
+**Self-healing semantics:**
+
+- Apple upload succeeded → legacy zip dropped, users install via App
+  Store only (cleaner release UI, single source of truth).
+- Apple upload failed/skipped (secrets missing, Dependabot, signing
+  error) → legacy zip retained as fallback, landing page link still
+  resolves.
+- No manual `confirm_apple_working` flag — the pipeline decides
+  automatically on every release.
+
+### 3. `build-apple` does NOT gate `release` job
+
+`tauri.yml` release job `if:` keeps `always() && needs.build-tauri.result
+== 'success'`. Apple build failure does not block GitHub Release for
+other platforms. `needs: build-apple` is included solely to make
+`needs.build-apple.outputs.*` available for the dynamic cleanup
+conditional.
+
+This isolation is deliberate: Apple pipeline is new (introduced
+2026-07-28), runs on slow `macos-15` runner, requires external secrets
+that may be absent on forks. Coupling release publishing to Apple
+success would block every Windows/Linux/Android release whenever Apple
+has an issue.
+
+### 4. App Store `app-store` cargo feature
+
+To comply with Mac App Store Guidelines:
+
+- **2.4.5(vii)**: "They must use the Mac App Store to distribute
+  updates; other update mechanisms are not allowed." Self-update plugin
+  (`tauri-plugin-updater`) must be disabled.
+- **2.5.1**: "Apps may not access or claim to access any private user
+  data without permission." Debug code (release-devtools) is grounds
+  for rejection.
+
+The `app-store` cargo feature gates out these via `#[cfg(not(feature =
+"app-store"))]` on plugin registration in `tauri/src/lib.rs`. App Store
+builds use `--no-default-features --features app-store`.
+
+**Compromise:** `tauri-plugin-updater` and `tauri-plugin-single-instance`
+remain in the Cargo dependency tree (non-optional) because Tauri's
+capability schema validation in `tauri::generate_context!()` requires
+the `updater:default` permission entry to resolve even when the plugin
+is unregistered at runtime. Symbols stay in the binary; runtime
+self-update behavior is fully disabled. Apple's review process tests
+runtime behavior, not static symbol presence — so this complies with
+the guidelines.
+
+### 5. Privacy manifest (`PrivacyInfo.xcprivacy`)
+
+Required since spring 2024 for both iOS and macOS App Store submission
+(ITMS-91053 rejection without it). Declares 3 accessed API categories
+with reason codes per Apple TN3183:
+
+- `UserDefaults CA92.1` — tauri-plugin-store account settings
+- `FileTimestamp C617.1` — FSRS database in `app_data_dir`
+- `SystemBootTime 35F9.1` — FSRS scheduling intervals
+
+The file lives at `tauri/gen/apple/PrivacyInfo.xcprivacy` (canonical
+location for iOS Xcode project sources). macOS bundle picks it up via
+`tauri.conf.json` `bundle.resources` map form
+(`{"gen/apple/PrivacyInfo.xcprivacy": "PrivacyInfo.xcprivacy"}`).
+
+### 6. iOS Info.plist source-of-truth = `project.yml info.properties`
+
+iOS Info.plist usage descriptions (`NSCameraUsageDescription`,
+`NSMicrophoneUsageDescription`, `NSPhotoLibraryUsageDescription`,
+`CFBundleDisplayName`, `ITSAppUsesNonExemptEncryption`,
+`LSApplicationCategoryType`) are declared in
+`tauri/gen/apple/project.yml` `info.properties`, NOT edited directly
+into `Info.plist`. XcodeGen applies `info.properties` as an overlay
+over the file during project generation, so keys declared in
+`project.yml` survive `cargo tauri ios build` regeneration.
+
+### 7. macOS signing requires both API Key + Mac Distribution certs
+
+iOS signing path: `cargo tauri ios build` → `xcodebuild
+-allowProvisioningUpdates -authenticationKeyPath/ID/IssuerID` → API
+key auto-creates iOS Distribution cert + Provisioning Profile, identity
+installed in keychain. **4 API Key secrets sufficient.**
+
+macOS signing path: `cargo tauri build --target universal-apple-darwin
+--bundles app` → `tauri-bundler` calls `codesign --sign "..."` directly
+(**NOT** via xcodebuild). API key not involved. Identity (cert +
+private key) must be in keychain before build starts. **3 additional
+Mac cert secrets required.**
+
+Total: **7 secrets** for full Apple pipeline:
+
+- `APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_CONTENT`
+  (base64 of `.p8`), `APPLE_TEAM_ID` — iOS + upload (both platforms)
+- `APPLE_MAC_APP_CERT_P12` (base64 of "Mac App Distribution" `.p12`),
+  `APPLE_MAC_INSTALLER_CERT_P12` (base64 of "Mac Installer
+  Distribution" `.p12`), `APPLE_MAC_CERT_PASSWORD` — macOS signing
+
+## Consequences
+
+### Positive
+
+- macOS users can install via Mac App Store (sandboxed, signed,
+  auto-updated) — preferred UX for non-technical users.
+- iOS users get TestFlight → App Store distribution.
+- Landing page direct-download link remains valid (no broken UX) even
+  when Apple pipeline has issues.
+- PR-level macOS smoke test preserved (cargo-zigbuild cross-compile on
+  Linux, free) — catches macOS-incompatible Rust regressions before
+  they reach a release tag.
+- No coupling between Apple pipeline success and Windows/Linux/Android
+  release publishing.
+- Self-healing dynamic cleanup: no manual `confirm_apple_working` flag
+  to remember.
+
+### Negative
+
+- Two macOS pipelines to maintain (legacy cargo-zigbuild + new
+  macos-15 App Store). Cleanup of legacy deferred indefinitely — the
+  fallback semantics are useful.
+- 7 Apple secrets to manage (vs 4 for iOS-only or 0 for non-Apple).
+- `tauri-plugin-updater` symbols present in App Store binary despite
+  runtime gating (Tauri capability validation constraint).
+- `bundle.createUpdaterArtifacts: true` remains unconditional in
+  `tauri.conf.json` — App Store bundle contains `.sig` files that
+  nothing references. Future work: gate via `build.rs` TAURI_CONFIG
+  merge patch when feature `app-store` is active.
+- macOS runner minutes cost (~10x Linux). Mitigated by Apple
+  builds running only on tag pushes and manual dispatch, not on PRs.
+
+### Risks
+
+- **Tauri #15230** (codesign Requirement check failure for Mac App
+  Store) workaround via manual `codesign --requirements` may break if
+  Tauri upstream fixes the bug differently. Mitigation: workaround
+  documented in `_build-tauri-apple.yml` step comments with link to
+  the issue.
+- **macOS runner image** with iOS 26 SDK required (`deploymentTarget.iOS:
+  26.0`). GitHub Actions `macos-15` runner ships Xcode 26 by July 2026;
+  if absent, `xcodebuild -showsdks | grep iphoneos26` check fails fast
+  with a clear error.
+- **Mac cert creation** requires Mac access (Keychain Access → CSR →
+  Portal → export `.p12`). CI cannot generate these — user must
+  pre-create and store as GitHub secrets. Blocks first macOS run until
+  user does the manual setup.

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -750,7 +750,7 @@ input[type="submit"],
         bottom: 0;
         left: 0;
         right: 0;
-        height: 80vh;
+        height: 80%;
         border-bottom: none;
         animation: drawerSlideInBottom 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
         padding-bottom: env(safe-area-inset-bottom, 0px);
@@ -770,7 +770,7 @@ input[type="submit"],
         top: 0;
         right: 0;
         bottom: 0;
-        width: 80vw;
+        width: 80%;
         max-width: 800px;
         border-right: none;
         animation: drawerSlideInRight 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
@@ -1553,7 +1553,7 @@ input[type="submit"],
     top: 0;
     left: 0;
     width: 220px;
-    height: 100vh;
+    height: 100%;
     background-color: var(--bg-cream);
     border-right: 1px solid var(--border-dark);
     z-index: 40;

--- a/origa_ui/src/core/haptics.rs
+++ b/origa_ui/src/core/haptics.rs
@@ -1,0 +1,58 @@
+//! Haptic feedback for FSRS rating actions via Tauri plugin.
+//!
+//! Maps each `Rating` variant to a Tauri haptics JS call:
+//! - `Again` → notification(Error) — strong negative signal
+//! - `Hard`  → impact(Medium)     — moderate friction
+//! - `Good`  → impact(Light)      — gentle confirmation
+//! - `Easy`  → notification(Success) — positive reward
+//!
+//! On desktop (no haptic hardware) and on browsers (not running in Tauri
+//! WebView) the calls silently no-op: `window.__TAURI__` is undefined or the
+//! haptics module is absent (e.g. plugin not registered on this platform).
+//!
+//! JS bridge follows the same pattern as `core::tauri::opener_open_url_fn`:
+//! resolve `window.__TAURI__.haptics.<fn>` via Reflect, call with one string
+//! arg, ignore the returned Promise (fire-and-forget — the user feels the
+//! haptic immediately, no need to await completion).
+
+use js_sys::{Function, Reflect};
+use leptos::wasm_bindgen::{JsCast, JsValue};
+use origa::domain::Rating;
+
+use super::tauri::{is_tauri, tauri_object};
+
+const HAPTICS_MODULE: &str = "haptics";
+
+fn haptics_fn(name: &str) -> Option<Function> {
+    let obj = tauri_object()?;
+    let haptics = Reflect::get(&obj, &JsValue::from_str(HAPTICS_MODULE)).ok()?;
+    Reflect::get(&haptics, &JsValue::from_str(name))
+        .ok()
+        .and_then(|v| v.dyn_into::<Function>().ok())
+}
+
+/// Trigger haptic feedback appropriate for the given FSRS rating.
+///
+/// Must be called synchronously from the click/keyboard handler (before
+/// `spawn_local` for the actual rating persistence) so the user feels the
+/// haptic at the moment of contact, not after the network round-trip.
+pub fn rating_feedback(rating: Rating) {
+    if !is_tauri() {
+        return;
+    }
+
+    let (fn_name, style) = match rating {
+        Rating::Again => ("notification", "Error"),
+        Rating::Hard => ("impact", "Medium"),
+        Rating::Good => ("impact", "Light"),
+        Rating::Easy => ("notification", "Success"),
+    };
+
+    let Some(f) = haptics_fn(fn_name) else {
+        return;
+    };
+
+    if let Err(e) = f.call1(&JsValue::UNDEFINED, &JsValue::from_str(style)) {
+        tracing::warn!("[haptics] {fn_name}({style}) call failed: {e:?}");
+    }
+}

--- a/origa_ui/src/core/mod.rs
+++ b/origa_ui/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod haptics;
 pub mod tauri;
 pub mod updater;
 pub mod version;

--- a/origa_ui/src/pages/lesson/on_rate.rs
+++ b/origa_ui/src/pages/lesson/on_rate.rs
@@ -1,4 +1,5 @@
 use super::lesson_state::LessonContext;
+use crate::core::haptics;
 use crate::hooks::phrase_checker;
 use leptos::prelude::*;
 use leptos::task::spawn_local;
@@ -104,6 +105,11 @@ pub fn create_on_rate_callback(
     };
 
     Callback::new(move |rating: Rating| {
+        // Fire haptic feedback immediately on the synchronous call stack so
+        // the user feels it at the moment of contact, before the async rating
+        // persistence begins. No-op on desktop and in plain browsers.
+        haptics::rating_feedback(rating);
+
         let state = lesson_state.get_untracked();
 
         let Some(slot_id) = state.card_ids.get(state.current_index) else {

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -35,6 +35,7 @@ tauri-plugin-single-instance.workspace = true
 tauri-plugin-store.workspace = true
 tauri-plugin-updater.workspace = true
 tauri-plugin-process.workspace = true
+tauri-plugin-haptics.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -35,8 +35,13 @@ tauri-plugin-single-instance.workspace = true
 tauri-plugin-store.workspace = true
 tauri-plugin-updater.workspace = true
 tauri-plugin-process.workspace = true
-tauri-plugin-haptics.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+
+# Mobile-only plugins — desktop compilation excludes them via target cfg.
+# Per Tauri plugin docs: haptics supports only Android/iOS (no desktop stubs
+# in the public API). Target-scoping keeps the desktop binary clean.
+[target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
+tauri-plugin-haptics.workspace = true

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -17,6 +17,10 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [features]
 default = ["release-devtools"]
 release-devtools = ["tauri/devtools"]
+# App Store builds: disables self-updater + single-instance + devtools for
+# Mac App Store compliance (Guideline 2.4.5(vii) — no self-update mechanisms,
+# 2.5.1 — no debug code). Use with `--no-default-features --features app-store`.
+app-store = []
 
 [build-dependencies]
 tauri-build.workspace = true

--- a/tauri/Entitlements.plist
+++ b/tauri/Entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.microphone</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
+</plist>

--- a/tauri/build.rs
+++ b/tauri/build.rs
@@ -95,22 +95,58 @@ fn inject_csp_via_tauri_config(cdn: &str, landing: &str, trailbase: &str) {
     };
     let final_config_str = final_config.to_string();
 
-    // SAFETY: build scripts are single-threaded by Cargo's contract — exactly
-    // one `main()` runs per build script invocation, with no spawned threads.
-    // `tauri_build::build()` is a synchronous API (`pub fn build()`, no async,
-    // no `std::thread::spawn`) that reads `TAURI_CONFIG` via `env::var()` on
-    // the same thread as this `main()` — see `tauri-build/src/lib.rs::try_build()`.
-    // `set_var` is marked `unsafe` since Rust edition 2024 due to potential data
-    // races in multi-threaded contexts, which do not apply here. This is a
-    // sanctioned exception to the AGENTS.md "no unsafe" rule,
-    // with full rationale in ADR-009 ("Consequences → Negative").
-    // `tauri_build::build()` reads `TAURI_CONFIG` in-process, so this MUST be
-    // set BEFORE the call below.
-    unsafe {
-        env::set_var("TAURI_CONFIG", &final_config_str);
+    // App Store builds: disable updater artifact generation entirely.
+    // `bundle.createUpdaterArtifacts: true` in tauri.conf.json produces
+    // .sig signature files alongside every bundle, intended for the Tauri
+    // updater (desktop distribution via GitHub Releases latest.json).
+    // For App Store builds the updater plugin is gated out at compile time
+    // via the `app-store` cargo feature, so .sig files are dead weight in
+    // the bundle — and Apple reviewers may flag stray signature artifacts
+    // that reference an active self-update mechanism.
+    //
+    // This patch is applied AFTER the CSP patch (which may itself have
+    // merged into an externally-provided TAURI_CONFIG from `cargo tauri
+    // build --config <merge>`). RFC 7396 merge semantics: last write wins,
+    // so the `false` here overrides any earlier `true`.
+    #[cfg(feature = "app-store")]
+    {
+        let updater_patch = json!({
+            "bundle": {
+                "createUpdaterArtifacts": false
+            }
+        });
+        let mut cfg: serde_json::Value = serde_json::from_str(&final_config_str)
+            .expect("TAURI_CONFIG must be valid JSON for app-store patch");
+        build_config::apply_merge_patch(&mut cfg, updater_patch);
+        let patched = cfg.to_string();
+
+        // SAFETY: same single-threaded build-script contract as below.
+        unsafe {
+            env::set_var("TAURI_CONFIG", &patched);
+        }
+        println!("cargo:rustc-env=TAURI_CONFIG={patched}");
     }
 
-    println!("cargo:rustc-env=TAURI_CONFIG={final_config_str}");
+    // When NOT app-store: emit final_config_str unchanged (CSP-merged,
+    // createUpdaterArtifacts still true per tauri.conf.json — needed for
+    // desktop distribution via GitHub Releases updater manifest).
+    #[cfg(not(feature = "app-store"))]
+    {
+        // SAFETY: build scripts are single-threaded by Cargo's contract —
+        // exactly one `main()` runs per build script invocation, with no
+        // spawned threads. `tauri_build::build()` is a synchronous API
+        // (no async, no `std::thread::spawn`) that reads `TAURI_CONFIG`
+        // via `env::var()` on the same thread as this `main()`. `set_var`
+        // is marked `unsafe` since Rust edition 2024 due to potential data
+        // races in multi-threaded contexts, which do not apply here. This
+        // is a sanctioned exception to AGENTS.md "no unsafe" rule, with
+        // full rationale in ADR-009 ("Consequences → Negative").
+        unsafe {
+            env::set_var("TAURI_CONFIG", &final_config_str);
+        }
+        println!("cargo:rustc-env=TAURI_CONFIG={final_config_str}");
+    }
+
     println!("cargo:rerun-if-env-changed=ORIGA_CDN_BASE_URL");
     println!("cargo:rerun-if-env-changed=TRAILBASE_URL");
     println!("cargo:rerun-if-env-changed=ORIGA_LANDING_BASE_URL");

--- a/tauri/capabilities/mobile.json
+++ b/tauri/capabilities/mobile.json
@@ -8,6 +8,7 @@
 		"core:event:default",
 		"tts:default",
 		"deep-link:default",
+		"haptics:default",
 		{
 			"identifier": "opener:default",
 			"allow": [

--- a/tauri/gen/apple/PrivacyInfo.xcprivacy
+++ b/tauri/gen/apple/PrivacyInfo.xcprivacy
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/tauri/gen/apple/project.yml
+++ b/tauri/gen/apple/project.yml
@@ -32,6 +32,7 @@ targets:
       - path: Assets.xcassets
       - path: Externals
       - path: origa-app_iOS
+      - path: PrivacyInfo.xcprivacy
       - path: assets
         buildPhase: resources
         type: folder
@@ -53,6 +54,12 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
         CFBundleVersion: "0.1.0"
+        CFBundleDisplayName: Origa
+        LSApplicationCategoryType: public.app-category.education
+        ITSAppUsesNonExemptEncryption: false
+        NSCameraUsageDescription: "Origa uses the camera to capture Japanese text for OCR."
+        NSPhotoLibraryUsageDescription: "Origa reads photos to extract Japanese text via OCR."
+        NSMicrophoneUsageDescription: "Origa records audio to transcribe Japanese speech."
     entitlements:
       path: origa-app_iOS/origa-app_iOS.entitlements
     scheme:

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -1,11 +1,13 @@
 mod auth_store;
-#[cfg(desktop)]
+#[cfg(all(desktop, not(feature = "app-store")))]
 mod updater_commands;
 
 use auth_store::{auth_store_delete, auth_store_get, auth_store_set};
-use tauri::{Emitter, Listener, Manager};
+use tauri::{Emitter, Listener};
+#[cfg(any(feature = "release-devtools", all(desktop, not(feature = "app-store"))))]
+use tauri::Manager;
 use tauri_plugin_deep_link::DeepLinkExt;
-#[cfg(desktop)]
+#[cfg(all(desktop, not(feature = "app-store")))]
 use updater_commands::{PendingUpdate, check_for_update, install_update};
 
 /// Returns the deep-link URL that launched (or last targeted) the current
@@ -30,7 +32,7 @@ pub fn run() {
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default();
 
-    #[cfg(desktop)]
+    #[cfg(all(desktop, not(feature = "app-store")))]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             tracing::info!("[deep-link] single-instance activated (app was already running)");
@@ -54,9 +56,9 @@ pub fn run() {
             auth_store_get,
             auth_store_set,
             auth_store_delete,
-            #[cfg(desktop)]
+            #[cfg(all(desktop, not(feature = "app-store")))]
             check_for_update,
-            #[cfg(desktop)]
+            #[cfg(all(desktop, not(feature = "app-store")))]
             install_update
         ])
         .setup(|app| {

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -46,12 +46,16 @@ pub fn run() {
         builder = builder.manage(PendingUpdate::new());
     }
 
+    #[cfg(mobile)]
+    {
+        builder = builder.plugin(tauri_plugin_haptics::init());
+    }
+
     builder
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_tts::init())
-        .plugin(tauri_plugin_haptics::init())
         .invoke_handler(tauri::generate_handler![
             get_current_deep_link,
             auth_store_get,

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -3,9 +3,9 @@ mod auth_store;
 mod updater_commands;
 
 use auth_store::{auth_store_delete, auth_store_get, auth_store_set};
-use tauri::{Emitter, Listener};
 #[cfg(any(feature = "release-devtools", all(desktop, not(feature = "app-store"))))]
 use tauri::Manager;
+use tauri::{Emitter, Listener};
 use tauri_plugin_deep_link::DeepLinkExt;
 #[cfg(all(desktop, not(feature = "app-store")))]
 use updater_commands::{PendingUpdate, check_for_update, install_update};

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -51,6 +51,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_tts::init())
+        .plugin(tauri_plugin_haptics::init())
         .invoke_handler(tauri::generate_handler![
             get_current_deep_link,
             auth_store_get,

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -36,9 +36,16 @@
             "icons/icon.icns",
             "icons/icon.ico"
         ],
+        "resources": {
+            "gen/apple/PrivacyInfo.xcprivacy": "PrivacyInfo.xcprivacy"
+        },
         "android": {},
         "iOS": {
             "minimumSystemVersion": "26.0"
+        },
+        "macOS": {
+            "entitlements": "Entitlements.plist",
+            "minimumSystemVersion": "13.0"
         }
     },
     "plugins": {


### PR DESCRIPTION
## Summary

Adds end-to-end Apple platforms (iOS + macOS) CI/CD pipeline with auto-upload to App Store Connect via App Store Connect API Key. First green pipeline will land both `.ipa` and `.pkg` builds in TestFlight for internal testing.

Bundle ID `net.uwuwu.origa` (1:1 with Android). App record already created in App Store Connect.

## Architecture

Two parallel pipelines coexist (see `docs/decisions/ADR-033-apple-platforms-distribution-channels-and-dynamic-fallback.md`):

- **`_build-tauri.yml` `build-macos`** — cargo-zigbuild desktop-distribution `Origa_macos-arm64.zip` for landing page direct download link (ADR-025). Unsigned, Linux runner, fallback.
- **`_build-tauri-apple.yml`** (new) — `_build-tauri-apple.yml` on `macos-15` runner with signed `.ipa` (iOS) + `.pkg` (macOS Universal Binary). Auto-uploads to App Store Connect via `xcrun altool`.

**Dynamic cleanup gate**: legacy `Origa_macos-arm64.zip` is automatically dropped from GitHub Release when Apple macOS upload succeeds, retained as fallback otherwise. No manual flag — pipeline self-heals.

## Slices

1. **`app-store` cargo feature** — gates out `tauri-plugin-updater` / `single-instance` / `release-devtools` from App Store builds (Mac App Store 2.4.5(vii), 2.5.1 compliance)
2. **`tauri-plugin-haptics` scaffold** — registered on mobile only (target-scoped dep + `#[cfg(mobile)]`)
3. **iOS project config** — Info.plist usage descriptions via `project.yml info.properties` (XcodeGen overlay source-of-truth), `PrivacyInfo.xcprivacy` with 3 reason codes (TN3183)
4. **macOS App Store config** — `tauri.conf.json` `bundle.macOS` (entitlements + minSystemVersion), `Entitlements.plist` (5 sandbox entitlements)
5. **CSS vw/vh fix** — 3 unbounded viewport units replaced with `%` (WKWebView freeze workaround, `position: fixed` semantic equivalence)
6. **`_build-tauri-apple.yml`** — new reusable workflow with `build-ios` + `build-macos` jobs (Universal Binary, Tauri #15230 codesign workaround via `--requirements`, productbuild `.pkg`, altool upload)
7. **`tauri.yml` wiring** — `build-apple` job added, dynamic cleanup in release step, Apple builds don't gate GitHub Release (separate channels)

## Required Secrets (7)

User configures these in repo settings before first CI run — see detailed instructions in commit messages:

| Secret | Purpose |
|---|---|
| `APPLE_API_ISSUER` | App Store Connect API Key issuer ID |
| `APPLE_API_KEY` | App Store Connect API Key ID |
| `APPLE_API_KEY_CONTENT` | base64 of `.p8` file |
| `APPLE_TEAM_ID` | Apple Developer Team ID |
| `APPLE_MAC_APP_CERT_P12` | base64 of Mac App Distribution `.p12` |
| `APPLE_MAC_INSTALLER_CERT_P12` | base64 of Mac Installer Distribution `.p12` |
| `APPLE_MAC_CERT_PASSWORD` | password for `.p12` files |

iOS-only setup needs first 4; macOS requires all 7.

## Verification

- ✅ `cargo check` + `cargo clippy --all-targets -- -D warnings` on default features
- ✅ `cargo check` + `cargo clippy` on `--no-default-features --features app-store`
- ✅ `cargo fmt --check`
- ✅ `trunk build --release`
- ✅ All YAML validated via `yaml.safe_load`
- ✅ All plists validated via `plistlib`
- ⏭️ Runtime CI verification pending Apple secrets configuration by user

## Code Review

2 cycles with `@code-quality-reviewer`. Cycle 1 caught 4 High (landing link regression, macOS PR coverage, altool key path, cert names) + 5 Common. Cycle 2 caught 1 remaining High (altool fix applied only to build-ios). All addressed.

## Out of Scope (follow-up tasks)

- Device testing checklist (10 iOS + 11 macOS points) — separate QA task
- App Store submission (screenshots, video preview, review info) — after device testing
- Frontend haptics integration (calls from Leptos/WASM on rating buttons) — `mobile-haptics-ui-integration`
- `bundle.createUpdaterArtifacts: true` unconditional in tauri.conf.json — gate via build.rs TAURI_CONFIG merge patch when feature `app-store` active
- Parallel macOS jobs cost optimization (shared cargo cache between iOS + macOS targets)
- iOS 26.0 deployment target review (business decision — may want to lower to 18+ for broader adoption)

## Test Plan

After user configures Apple secrets:

1. `workflow_dispatch` on `tauri.yml` → both `build-ios` and `build-macos` jobs green
2. App Store Connect → My Apps → Origa → TestFlight → both builds visible after Apple processing (~5-15 min)
3. Add self as Internal Tester, install via TestFlight app on iPhone
4. First smoke: app launches, no immediate crash, OCR/STT prompts appear
5. Tag `v0.2.0-rc1` → GitHub Release published with `Origa_macos-arm64.zip` dropped (since Apple upload succeeds) OR retained (if upload failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
