### PR TITLE
feat(ui): JLPT grouping on /grammar and /kanji (reactive GroupedGrid)

### DIFF
--- a/origa_ui/src/pages/grammar/content.rs
+++ b/origa_ui/src/pages/grammar/content.rs
@@ -3,7 +3,7 @@ use super::grammar_card_item::GrammarCardItem;
 use crate::i18n::{t_string, use_i18n};
 use crate::repository::HybridUserRepository;
 use leptos::prelude::*;
-use origa::domain::Card;
+use origa::domain::{Card, CardType};
 
 #[component]
 pub fn GrammarContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
@@ -21,11 +21,7 @@ pub fn GrammarContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
     let ctx_for_render = ctx.clone();
     let empty_message = Signal::derive(move || t_string!(i18n, grammar_page.not_found).to_string());
 
-    // S2 (JLPT grouping) is temporarily disabled — the grouped render path
-    // needs a reactive GroupedGrid (current buckets snapshot goes stale when
-    // cards prop changes after a favorite toggle + reload). Tracked in a
-    // follow-up; Flat mode keeps the page fully functional.
-    card_list_view(ctx, ListGrouping::Flat, true, "grammar", empty_message, Some("grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4 items-start"), move |card| {
+    card_list_view(ctx, ListGrouping::ByJlptLevel { card_type: CardType::Grammar }, true, "grammar", empty_message, Some("grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4 items-start"), move |card| {
         let ctx = ctx_for_render.clone();
         let card_id = *card.card_id();
         view! {

--- a/origa_ui/src/pages/kanji/content.rs
+++ b/origa_ui/src/pages/kanji/content.rs
@@ -3,7 +3,7 @@ use super::kanji_card_item::KanjiCardItem;
 use crate::i18n::{t_string, use_i18n};
 use crate::repository::HybridUserRepository;
 use leptos::prelude::*;
-use origa::domain::Card;
+use origa::domain::{Card, CardType};
 
 #[component]
 pub fn KanjiContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
@@ -21,11 +21,7 @@ pub fn KanjiContent(refresh_trigger: RwSignal<u32>) -> impl IntoView {
     let ctx_for_render = ctx.clone();
     let empty_message = Signal::derive(move || t_string!(i18n, kanji_page.not_found).to_string());
 
-    // S2 (JLPT grouping) is temporarily disabled — the grouped render path
-    // needs a reactive GroupedGrid (current buckets snapshot goes stale when
-    // cards prop changes after a favorite toggle + reload). Tracked in a
-    // follow-up; Flat mode keeps the page fully functional.
-    card_list_view(ctx, ListGrouping::Flat, true, "kanji", empty_message, Some("grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 items-start"), move |card| {
+    card_list_view(ctx, ListGrouping::ByJlptLevel { card_type: CardType::Kanji }, true, "kanji", empty_message, Some("grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 items-start"), move |card| {
         let ctx = ctx_for_render.clone();
         let card_id = *card.card_id();
         view! {

--- a/origa_ui/src/pages/shared/card_list_page.rs
+++ b/origa_ui/src/pages/shared/card_list_page.rs
@@ -262,9 +262,6 @@ where
     let load_more_id = Signal::derive(move || format!("{test_id_prefix}-load-more-btn"));
     let render_card = StoredValue::new(render_card);
 
-    // Snapshot the grouped index once per visible_cards change so GroupedGrid
-    // receives an owned HashMap it can read without re-tracking the memo.
-    let visible_index = Memo::new(move |_| level_index.get());
     let flat_grid_classes = grid_classes.unwrap_or(
         "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 items-start",
     );
@@ -335,8 +332,8 @@ where
                                     let render = render_card.with_value(|r| r.clone());
                                     Either::Right(view! {
                                         <GroupedGrid
-                                            cards=visible_cards.get()
-                                            level_index=visible_index.get()
+                                            cards=visible_cards
+                                            level_index=level_index
                                             grid_classes=flat_grid_classes
                                             test_id_prefix=test_id_prefix
                                             render_card=render

--- a/origa_ui/src/pages/shared/grouped_grid.rs
+++ b/origa_ui/src/pages/shared/grouped_grid.rs
@@ -5,10 +5,16 @@ use crate::ui_components::{Heading, HeadingLevel};
 use leptos::prelude::*;
 use origa::domain::{JapaneseLevel, StudyCard};
 
-use super::grouping::group_rank;
+use super::grouping::{LevelIndex, group_rank};
 
 /// Renders a list of study cards split into JLPT-level groups (N5 first,
 /// "Other" last). Each group has a `Heading` followed by a grid of cards.
+///
+/// Takes `cards` and `level_index` as `Memo`s so a favorite-toggle + reload
+/// cycle that produces a new `cards` snapshot re-runs `bucket_by_group` and
+/// updates every group's `<For>` via keyed diff. The previous version took
+/// owned snapshots, which Leptos diffs in place without re-running setup —
+/// leaving `buckets` stale after the parent's reactive closure re-evaluates.
 ///
 /// Lives in the lib crate (which has `recursion_limit = 512`) so adding the
 /// nested `<For>` over groups does not tip the bin crate over its 128-query
@@ -16,8 +22,8 @@ use super::grouping::group_rank;
 /// ADR-027 §B3 for the bin-vs-lib trade-off.
 #[component]
 pub fn GroupedGrid<F>(
-    cards: Vec<StudyCard>,
-    level_index: HashMap<ulid::Ulid, Option<JapaneseLevel>>,
+    cards: Memo<Vec<StudyCard>>,
+    level_index: Memo<LevelIndex>,
     grid_classes: &'static str,
     test_id_prefix: &'static str,
     render_card: F,
@@ -25,29 +31,30 @@ pub fn GroupedGrid<F>(
 where
     F: Fn(StudyCard) -> AnyView + Clone + Send + Sync + 'static,
 {
-    // Snapshot the cards once — they're already in group/card_id order coming
-    // out of `card_list_view`. We bucket them by `group_rank` for the per-group
-    // `<For>` loops below.
-    let buckets = bucket_by_group(cards, &level_index);
+    let render_card_stored = StoredValue::new(render_card);
 
-    // The per-group rendering is delegated to a sub-component (GroupSection)
-    // because `<For children>` requires a `Fn` closure, and a `view! { ... }`
-    // block with nested `<Show>`/`<For>` inside the children closure degrades
-    // to `FnOnce`. Splitting it lets Leptos see each `GroupSection` invocation
-    // as a plain function call rather than a captured view-construction closure.
+    // Reactive buckets — re-bucket every time `cards` or `level_index`
+    // changes. The downstream `<For>` over GROUP_ORDER is itself reactive on
+    // `buckets`, so each group's section re-renders only when its bucket
+    // contents change (keyed by card_id + is_favorite).
+    let buckets = Memo::new(move |_| bucket_by_group(cards.get().as_slice(), &level_index.get()));
+
     view! {
         <For
             each=move || GROUP_ORDER.into_iter()
             key=|group| group.testid_suffix
             children=move |group| {
-                let bucket = buckets[group.rank as usize].clone();
+                let bucket_for_group = Memo::new(move |_| {
+                    buckets.with(|b| b[group.rank as usize].clone())
+                });
+                let render = render_card_stored.with_value(|r| r.clone());
                 view! {
                     <GroupSection
                         group=group
-                        bucket=bucket
+                        bucket=bucket_for_group
                         grid_classes=grid_classes
                         test_id_prefix=test_id_prefix
-                        render_card=render_card.clone()
+                        render_card=render
                     />
                 }
             }
@@ -58,7 +65,7 @@ where
 #[component]
 fn GroupSection<F>(
     group: GroupMeta,
-    bucket: Vec<StudyCard>,
+    bucket: Memo<Vec<StudyCard>>,
     grid_classes: &'static str,
     test_id_prefix: &'static str,
     render_card: F,
@@ -66,47 +73,41 @@ fn GroupSection<F>(
 where
     F: Fn(StudyCard) -> AnyView + Clone + Send + Sync + 'static,
 {
-    // Skip empty groups entirely — no heading, no empty grid. Returning early
-    // also keeps the macro-generated children closure for the surrounding
-    // `<For>` (in GroupedGrid) a plain `Fn` rather than `FnOnce`.
-    if bucket.is_empty() {
-        return ().into_any();
-    }
-
     let i18n = use_i18n();
-
-    // Render the bucket once into a static Vec<AnyView>. `bucket` is a snapshot
-    // taken at mount time (no per-card reactivity needed), so a plain iterator
-    // is both simpler and avoids the Fn/FnOnce dance that `<For children>`
-    // would force on a captured `render_card`.
-    let rendered_cards: Vec<AnyView> = bucket
-        .into_iter()
-        .map(|card| render_card.clone()(card))
-        .collect();
+    let render_card_stored = StoredValue::new(render_card);
 
     view! {
-        <section
-            class="grouped-section"
-            data-testid=format!("{}-grid-{}", test_id_prefix, group.testid_suffix)
-        >
-            <div class="border-b border-[var(--border-dark)] mb-4">
-                <Heading
-                    level=Signal::derive(|| HeadingLevel::H3)
-                    class=Signal::derive(|| "mb-2 font-mono text-xs uppercase tracking-[0.18em] text-[var(--fg-muted)]".to_string())
-                >
-                    {group.label(&i18n)}
-                </Heading>
-            </div>
-            <div class=grid_classes>
-                {rendered_cards}
-            </div>
-        </section>
+        <Show when=move || !bucket.with(Vec::is_empty)>
+            <section
+                class="grouped-section"
+                data-testid=format!("{}-grid-{}", test_id_prefix, group.testid_suffix)
+            >
+                <div class="border-b border-[var(--border-dark)] mb-4">
+                    <Heading
+                        level=Signal::derive(|| HeadingLevel::H3)
+                        class=Signal::derive(|| "mb-2 font-mono text-xs uppercase tracking-[0.18em] text-[var(--fg-muted)]".to_string())
+                    >
+                        {group.label(&i18n)}
+                    </Heading>
+                </div>
+                <div class=grid_classes>
+                    <For
+                        each=move || bucket.get()
+                        key=|card| format!("{}-{}", card.card_id(), card.is_favorite())
+                        children=move |card| {
+                            let render = render_card_stored.with_value(|r| r.clone());
+                            render(card)
+                        }
+                    />
+                </div>
+            </section>
+        </Show>
     }
     .into_any()
 }
 
 fn bucket_by_group(
-    cards: Vec<StudyCard>,
+    cards: &[StudyCard],
     level_index: &HashMap<ulid::Ulid, Option<JapaneseLevel>>,
 ) -> Vec<Vec<StudyCard>> {
     let mut buckets: Vec<Vec<StudyCard>> = (0..6).map(|_| Vec::new()).collect();
@@ -116,7 +117,7 @@ fn bucket_by_group(
             .get(card.card_id())
             .map_or(5usize, |l| group_rank(l) as usize)
             .min(5);
-        buckets[idx].push(card);
+        buckets[idx].push(card.clone());
     }
     buckets
 }

--- a/origa_ui/src/pages/shared/grouping.rs
+++ b/origa_ui/src/pages/shared/grouping.rs
@@ -5,20 +5,10 @@ use ulid::Ulid;
 
 /// Controls whether `card_list_view` renders a flat list or splits cards into
 /// JLPT-level groups (N5 first, Other last).
-///
-/// `ByJlptLevel` is currently unused at call sites — JLPT grouping was reverted
-/// from `/grammar` and `/kanji` because the `GroupedGrid` snapshot pattern
-/// goes stale on a favorite-toggle + reload cycle. The variant and the
-/// surrounding infrastructure (this file, `grouped_grid.rs`, the `ByJlptLevel`
-/// branch in `card_list_view`) are kept so a follow-up PR can ship a reactive
-/// `GroupedGrid` without rebuilding the scaffolding.
 #[derive(Clone, Copy)]
 pub enum ListGrouping {
     Flat,
-    #[allow(dead_code)]
-    ByJlptLevel {
-        card_type: CardType,
-    },
+    ByJlptLevel { card_type: CardType },
 }
 
 /// Stable sort rank for a card's JLPT level. Lower rank renders first.


### PR DESCRIPTION
## Summary

Re-enable JLPT grouping on `/grammar` and `/kanji`. This is the S2 follow-up to PR #300 — that PR shipped Favorite filter, ghost progress and kanji difficulty sort, but reverted grouping because the snapshot-based `GroupedGrid` went stale on a favorite-toggle + reload cycle.

### Fix

`GroupedGrid` now takes reactive primitives instead of owned snapshots:

```rust
// Before (PR #300, broken):
#[component]
pub fn GroupedGrid(
    cards: Vec<StudyCard>,                     // snapshot
    level_index: HashMap<Ulid, Option<...>>,   // snapshot
    ...
)

// After (this PR):
#[component]
pub fn GroupedGrid(
    cards: Memo<Vec<StudyCard>>,               // reactive
    level_index: Memo<LevelIndex>,             // reactive
    ...
)
```

Internally `GroupedGrid` derives a `Memo<Vec<Vec<StudyCard>>>` for buckets and each per-group `<For>` reads its bucket through another `Memo`. A card prop change now re-runs the bucket builder and feeds the new bucket into the keyed `<For>` (key = `card_id + is_favorite`, matching the rest of the card list). The favorite toggle + reload flow no longer depends on the parent's `move ||` closure recreating `GroupedGrid`.

`GroupSection` now uses a `StoredValue` for `render_card` (same pattern as `card_list_view`) so the children closure satisfies `Fn + Clone`.

The temporary `#[allow(dead_code)]` on `ListGrouping::ByJlptLevel` is removed.

### Pages affected

- `/grammar` — `ListGrouping::ByJlptLevel { card_type: CardType::Grammar }`
- `/kanji` — `ListGrouping::ByJlptLevel { card_type: CardType::Kanji }`

`/words` and `/phrases` stay `Flat` (per the original scope decision — no reliable JLPT-assignment for arbitrary vocabulary).

## Test plan
- [x] `cargo clippy -p origa_ui --lib --tests -- -D warnings`
- [x] `cargo test -p origa --lib` — 1537 passed
- [x] `cargo test -p origa_ui --lib` — 276 passed
- [x] `npm --prefix end2end run typecheck`
- [ ] CI: existing `Сохранение избранного кандзи после перезагрузки` and `Сохранение избранного после перезагрузки` E2E scenarios must still pass (these were the canaries that caught the original bug)
- [ ] Manual smoke (`cargo tauri dev`):
  - [ ] `/grammar` shows N5 → N4 → ... → Other groups in order with separators
  - [ ] `/kanji` shows the same
  - [ ] Toggle favorite → reload → favorite persists within its group
