### PR TITLE
fix(ci): BSD sed compat for update-version on macOS runners

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -13,7 +13,12 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
+      # macOS uses BSD sed which requires an explicit backup suffix argument
+      # to `-i` (GNU sed treats the next arg as the script). `-i.bak` works
+      # on both BSD and GNU; the `.bak` file is removed after each edit.
+      # Without this, on macos-* runners sed fails with:
+      #   sed: 1: "Cargo.toml": invalid command code C
       run: |
-          sed -i 's/^version = ".*"/version = "'${VERSION}'"/' Cargo.toml
-          sed -i 's/"version": ".*"/"version": "'${VERSION}'"/' tauri/tauri.conf.json
+          sed -i.bak 's/^version = ".*"/version = "'${VERSION}'"/' Cargo.toml && rm -f Cargo.toml.bak
+          sed -i.bak 's/"version": ".*"/"version": "'${VERSION}'"/' tauri/tauri.conf.json && rm -f tauri/tauri.conf.json.bak
           echo "Updated version to ${VERSION}"


### PR DESCRIPTION
## Summary

Hotfix: the `update-version` composite action fails on macOS runners with BSD sed. Caught on first Apple CI run (workflow_dispatch 30393840232) — both `build-ios` and `build-macos` jobs failed at "Update version in config files" step.

## Root cause

```bash
sed -i 's/^version = ".*"/version = "..."/' Cargo.toml
```

This is GNU sed syntax. BSD sed (default on macOS) requires an explicit backup suffix argument to `-i`. BSD parses the previous form as:
- `-i` with backup suffix = `'s/^version = .../'`
- `Cargo.toml` becomes the script → `sed: 1: "Cargo.toml": invalid command code C`

## Fix

Switch to `sed -i.bak` (portable across BSD and GNU) + remove `.bak` after each edit.

## Why this only surfaced now

`update-version` was previously only called from Linux runners (build-windows uses cargo-zigbuild container, build-linux uses ubuntu, build-android uses ubuntu). The Apple pipeline (`_build-tauri-apple.yml`) is the first caller running on a real `macos-*` runner, exposing the BSD sed divergence.

## Test plan

After merge, `workflow_dispatch` on `tauri.yml` — both `build-ios` and `build-macos` should pass the "Update version in config files" step. (Run 30393840232 hit this exact error; subsequent steps couldn't be tested.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
