### PR TITLE
perf(ui): compress knowledge_set on remote-sync wire (deflate over JSON)

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -13,7 +13,12 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
+      # macOS uses BSD sed which requires an explicit backup suffix argument
+      # to `-i` (GNU sed treats the next arg as the script). `-i.bak` works
+      # on both BSD and GNU; the `.bak` file is removed after each edit.
+      # Without this, on macos-* runners sed fails with:
+      #   sed: 1: "Cargo.toml": invalid command code C
       run: |
-          sed -i 's/^version = ".*"/version = "'${VERSION}'"/' Cargo.toml
-          sed -i 's/"version": ".*"/"version": "'${VERSION}'"/' tauri/tauri.conf.json
+          sed -i.bak 's/^version = ".*"/version = "'${VERSION}'"/' Cargo.toml && rm -f Cargo.toml.bak
+          sed -i.bak 's/"version": ".*"/"version": "'${VERSION}'"/' tauri/tauri.conf.json && rm -f tauri/tauri.conf.json.bak
           echo "Updated version to ${VERSION}"

--- a/docs/decisions/ADR-034-compress-knowledge-set-remote-wire.md
+++ b/docs/decisions/ADR-034-compress-knowledge-set-remote-wire.md
@@ -1,0 +1,220 @@
+# ADR-034: Compress `knowledge_set` on the remote-sync wire (deflate over JSON)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-29
+
+## Context
+
+The `User` aggregate (`origa/src/domain/user.rs`) holds the entire
+`KnowledgeSet` — every `StudyCard` with its FSRS `MemoryState`, `ReviewLog`
+history, `deleted_cards`, and `lesson_history`. For an active learner this set
+grows to multiple megabytes.
+
+`HybridUserRepository::save_sync` (`origa_ui/src/repository/hybrid_repository.rs`)
+serializes the **whole** user to JSON and PUTs it to TrailBase as a single
+`user`-table row on every sync checkpoint: auth, onboarding, imports,
+`toggle_favorite`, create/delete card. The `knowledge_set` field is a plain
+JSON string inside that body. Symptoms, as reported for active users:
+
+- every checkpoint PUT ships ~10 MB;
+- UI blocks while the encode + network round-trip runs;
+- on mobile, the bandwidth cost is paid per request.
+
+TrailBase's default request body limit is **10 MB** (`crates/core/src/server/mod.rs`,
+`request_size_limit_bytes.map_or(10 * 1024 * 1024, ...)`). Active users were
+already on the edge of that limit, so the uncompressed format is not just
+slow — it is one card away from rejected writes.
+
+### Scope of this ADR
+
+This is a **band-aid** that shrinks the wire payload of the existing
+full-snapshot PUT. It does **not** restructure the aggregate (no normalization,
+no delta sync, no per-card rows). Those are tracked as a future "variant C"
+option; this ADR buys the time to do them deliberately. The hot path (rating a
+card during a lesson) already writes local-only (`save`, not `save_sync`), so
+the bandwidth fix targets the checkpoint PUTs only.
+
+## Decision
+
+Compress `knowledge_set` on the remote wire using **deflate over the existing
+serde-JSON serialization**, with a self-describing magic-prefix discriminator.
+The codec lives entirely in the repository layer (`origa_ui/src/repository/
+knowledge_set_codec.rs`); `domain/` is untouched.
+
+### Wire format
+
+- **new:** `"DEFLATE;" + base64(deflate(json_string))`
+- **legacy (existing rows):** plain JSON. JSON objects always start with `{`,
+  and `{` cannot appear at the prefix position, so presence/absence of
+  `DEFLATE;` is an unambiguous, self-describing format discriminator. No
+  companion column is required, so there is no field/value-desync risk.
+
+base64 is unavoidable: the TrailBase column is `TEXT` (`Option<String>`), so
+raw deflate bytes cannot be stored. Its ~33% overhead is more than offset by
+deflate's compression ratio.
+
+### Compression level: 6 (data-driven)
+
+Chosen by a PoC gate (`origa_ui/tests/knowledge_set_format_poc.rs`, run with
+`--ignored`) on a representative ~8 MiB fixture (6000 cards × 8 reviews), in
+release:
+
+| format | wire size | ratio | enc+decode |
+| --- | --- | --- | --- |
+| raw JSON (baseline) | 8.22 MB | 1.00x | 126 ms |
+| bincode + base64 | — | — | **roundtrip FAILED** (see Alternatives) |
+| deflate(JSON) level 1 | 2.60 MB | 3.15x | 143 ms |
+| **deflate(JSON) level 6** | **1.75 MB** | **4.69x** | **197 ms** |
+| deflate(JSON) level 9 | 1.73 MB | 4.75x | 293 ms |
+
+Level 6 is the ratio/latency sweet spot. Level 9 buys +0.06x ratio for +100 ms
+encode; level 1 loses meaningful ratio. WASM projects to ~2x native
+(≈400 ms), within the sync-checkpoint latency budget (≤500 ms; checkpoints are
+not the rating hot-path).
+
+### Error policy: read-recover, write-strict
+
+A single parser (`decode_strict`) underlies both policies, so roundtrip tests
+that exercise strict also cover the recovering path.
+
+- **Read is tolerant.** `decode` never fails: any corruption (truncated base64,
+  bad deflate stream, malformed JSON, unknown prefix) is logged at `warn!` and
+  replaced with an empty `KnowledgeSet`. This **preserves the existing
+  self-heal**: `KnowledgeSet::merge(empty)` is a no-op
+  (`origa/src/domain/knowledge/mod.rs:131`), so a corrupt remote merges as
+  nothing, and the next `save_local_and_sync_remote` overwrites the corrupt
+  row with the device's local data. The user never loses device-local progress.
+- **Write is strict.** `user_to_json` returns `Result`; a serialization failure
+  on any field surfaces as `Err` instead of silently writing a corrupt fallback
+  to the remote. This is a deliberate asymmetry from read: be tolerant of
+  damaged input, strict about damaged output.
+
+### Back-compat
+
+- **Read:** the discriminator selects legacy-JSON or deflated at decode time.
+  No batch migration script; rows are read in either format.
+- **Write:** always deflated after upgrade. **Lazy self-migration** — the first
+  `save_sync` after upgrade rewrites an existing legacy row in the new format.
+- **Pre-deploy:** back up the TrailBase database before release (the project's
+  standing data-loss requirement).
+
+## Alternatives Considered
+
+### A1: rkyv (zero-copy binary) + flate2
+
+The "modular" stack already used for dictionaries. Rejected after
+investigation: `KnowledgeSet` carries `#[serde(flatten)] stats: StatsTracker`
+(`knowledge/mod.rs:76`) and a custom `#[serde(deserialize_with =
+"deserialize_study_cards")]` — neither maps to rkyv without mass-deriving
+`Archive`/`Serialize`/`Deserialize` across ~15 domain types (`StudyCard`, `Card`
+enum, four card types, `MemoryState`, `ReviewLog`, `Stability`, `Difficulty`,
+`StatsTracker`, …). `ulid 1.2` and `chrono 0.4` (current configs) lack rkyv
+features, so they would need wrappers. That turns a band-aid into a deep
+`domain/` invasion (an "Ask First" zone) with real risk to newtype invariants
+(`Stability::new` / `Difficulty::new` validate ranges that rkyv would bypass).
+Out of proportion to the goal.
+
+### A2: bincode (compact binary) + base64
+
+Already in `origa_ui` deps, zero compression CPU cost. The PoC **disqualified**
+it: `bincode 1.x` is incompatible with `serde(flatten)` — `KnowledgeSet`'s
+`#[serde(flatten)] stats` makes `bincode::serialize` fail outright (flatten
+requires self-describing `deserialize_any`). This is exactly why the format
+choice was made data-driven rather than assumed.
+
+### A3: HTTP-level `Content-Encoding: gzip` on the request body
+
+The canonical payload-compression mechanism. Rejected for scope: TrailBase
+(axum) ships **without** `RequestDecompressionLayer` in its default middleware
+stack, so enabling it requires a server-side deployment with access to the
+backend config — outside an app-only band-aid. Application-level codec is
+self-contained and server-agnostic.
+
+### A4: Debounce / delta sync
+
+Debounce `save_sync` to coalesce writes; or send per-card deltas instead of the
+full snapshot. Rejected for this ADR: debounce conflicts with the
+error-returning semantics of the checkpoint use cases (auth/onboarding/imports
+return `Err` on remote failure and must propagate). Delta sync requires
+server-side merge, versioning, and conflict resolution — that is the future
+"variant C" restructure, not a band-aid.
+
+## Consequences
+
+### Positive
+
+- **~4.69x smaller wire payload** on the checkpoint PUT (10 MB → ~2 MB for an
+  active user), well under TrailBase's 10 MB body limit.
+- **Zero new dependencies** — `flate2`, `base64`, `serde_json` are all already
+  in `origa_ui`. `flate2` is already proven in WASM by the dictionary loader
+  (`origa_ui/src/loaders/dictionary.rs`).
+- **`domain/` untouched.** The codec is a repository-layer concern; the
+  aggregate and its invariants are unchanged.
+- **Self-heal preserved.** The read-recover policy keeps the existing
+  corrupt-remote → empty → local-overwrites-remote behavior; corruption is now
+  also surfaced via `tracing::warn!` rather than staying silent.
+- **Write-strict closes a latent silent-fallback bug.** `user_to_json` no longer
+  `unwrap_or_else`s serialize failures into corrupt fallback values written to
+  the remote.
+
+### Negative — downgrade and data-loss windows
+
+Three distinct scenarios, with the mitigation that covers each:
+
+1. **New-client codec bug** (the new code corrupts data on write). Mitigation:
+   local IndexedDB is the authoritative device copy and is untouched by this
+   change; back up the TrailBase DB before release. The local copy lets the
+   device recover.
+2. **Existing device fails to decode a new-format remote** (decode path broken).
+   Mitigation: read-recover resolves to empty, self-heal re-uploads local data.
+   Covered by the regression test in
+   `trailbase_repository_tests.rs::userrow_to_user_self_heals_on_corrupt_knowledge_set`.
+3. **Fresh login on a downgraded (pre-upgrade) client** against a remote already
+   written in the deflated format. The old client has no local copy on that
+   device; it sees a non-JSON `knowledge_set` string, `serde_json::from_str`
+   fails, and the pre-existing `unwrap_or_default` yields an empty
+   `KnowledgeSet`; a subsequent `save_sync` would overwrite the remote with
+   empty. **This is a residual risk that neither local-authoritative nor the
+   codec can mitigate.** The only mitigation is rollout discipline: staged
+   rollout and no rollback past this change (Tauri auto-update / web instant
+   reload keep the version-spread window small). For mobile with app-store
+   updates this is acceptable, but it must be known and not rolled back
+   carelessly.
+
+- **`base64` adds ~33%** over raw deflate bytes. Accepted: the column is `TEXT`,
+  so raw bytes are not storable without a DB migration (out of band-aid scope).
+  The net 4.69x is comfortably above the goal.
+- **CPU on the checkpoint path.** encode + decode ≈ 197 ms (native release) /
+  ≈ 400 ms (projected WASM) on an ~8 MiB set. Acceptable for a non-hot-path
+  checkpoint; if a future user exceeds this and the freeze becomes noticeable,
+  deflate level can be lowered or encode moved to a worker (future work).
+- **Unbounded decompression allocation.** `inflate` decodes into a `Vec<u8>`
+  with no upper bound on the decoded size. On the current trust model this is
+  academic: the `knowledge_set` column is written and read by this same
+  authenticated client, and realistic corruption (a truncated or bit-flipped
+  deflate stream) produces an early decode error rather than a size explosion.
+  If the threat model ever broadens (e.g. the column becomes writable by a path
+  other than this client), a decoded-size cap must be added to `inflate` to
+  prevent a maliciously crafted stream from exhausting WASM client memory.
+
+## Verification
+
+| Check | Command | Result |
+| --- | --- | --- |
+| Format choice gate | `cargo test -p origa_ui --test knowledge_set_format_poc --release -- --nocapture --ignored` | deflate(JSON) L6 chosen; bincode disqualified by roundtrip |
+| Codec unit tests | `cargo test -p origa_ui repository::knowledge_set_codec` | 5 functions / 7 cases passed (roundtrip, legacy-decode, carries-prefix, smaller-than-json, recovering-`#[rstest]`×3: corrupt-legacy / corrupt-prefixed / unknown-prefix) |
+| Wire roundtrip + self-heal | `cargo test -p origa_ui repository::trailbase_repository` | 2 passed (UserRow roundtrip, corrupt self-heal) |
+| Lint | `cargo clippy -p origa_ui --all-targets -- -D warnings` | 0 warnings |
+| Format | `cargo fmt -p origa_ui -- --check` | clean |
+
+## References
+
+- `origa_ui/src/repository/knowledge_set_codec.rs` — the codec
+- `origa_ui/src/repository/trailbase_repository.rs` — `user_to_json` (write-strict), `to_user` (read-recover)
+- `origa_ui/tests/knowledge_set_format_poc.rs` — the data-driven PoC gate
+- ADR scope note: "variant C" (aggregate normalization / delta sync) deferred — see plan v3 review record.

--- a/origa_ui/src/repository/knowledge_set_codec.rs
+++ b/origa_ui/src/repository/knowledge_set_codec.rs
@@ -1,0 +1,123 @@
+//! Wire-format codec for `KnowledgeSet` on the TrailBase remote path.
+//!
+//! The remote `user` table stores `knowledge_set` in a single `TEXT`
+//! column. Previously this was a plain JSON string; an active user's set
+//! grows to multiple megabytes and every checkpoint PUT shipped the full
+//! blob uncompressed. This codec compresses it.
+//!
+//! Wire format (self-describing, discriminated by a magic prefix):
+//!
+//! - new:   `"DEFLATE;" + base64(deflate(json_string))`
+//! - legacy (existing rows, untouched): plain JSON, which always starts
+//!   with `{`. The prefix can never be a prefix of a valid JSON object,
+//!   so the discriminator is unambiguous and does not depend on a
+//!   sibling column staying in sync.
+//!
+//! base64 is unavoidable: the column is `TEXT`, so raw deflate bytes
+//! cannot be stored directly. Its ~33% overhead is more than offset by
+//! deflate's compression ratio (measured 4.69x on a representative
+//! fixture — see `tests/knowledge_set_format_poc.rs`).
+//!
+//! Error policy (see ADR for the full rationale):
+//!
+//! - **Read is tolerant.** `decode` never fails: any corruption
+//!   (truncated base64, bad deflate stream, malformed JSON, unknown
+//!   prefix) is logged and replaced with an empty `KnowledgeSet`. This
+//!   preserves the existing self-heal: a corrupt remote merges as a
+//!   no-op, then the next `save_local_and_sync_remote` overwrites the
+//!   corrupt row with the device's local data.
+//! - **Write is strict.** `encode` returns `Result`. A serialization
+//!   failure surfaces as an error instead of silently writing a
+//!   corrupt fallback to the remote.
+//!
+//! Both policies share a single parser: `decode` delegates to
+//! `decode_strict`, so bugs in the parse path are caught by the
+//! roundtrip tests that exercise the strict variant.
+
+use std::io::Read;
+use std::io::Write;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use flate2::Compression;
+use flate2::read::DeflateDecoder;
+use flate2::write::DeflateEncoder;
+use origa::domain::{KnowledgeSet, OrigaError};
+
+#[cfg(test)]
+#[path = "knowledge_set_codec_tests.rs"]
+mod tests;
+
+/// Marks a deflated wire string. JSON objects start with `{`, which this
+/// prefix cannot collide with, so presence/absence is an unambiguous
+/// format discriminator that needs no companion field.
+const DEFLATE_PREFIX: &str = "DEFLATE;";
+
+/// Deflate compression level for the encode path. Chosen from the PoC
+/// gate (see `tests/knowledge_set_format_poc.rs`): on a representative
+/// ~8 MiB fixture, level 6 reaches a 4.69x wire-size reduction at ~197ms
+/// encode+decode (native release, ~400ms projected WASM) — well within
+/// the sync-checkpoint latency budget. Level 9 buys only +0.06x ratio
+/// for a disproportionate encode cost; level 1 loses meaningful ratio.
+const DEFLATE_LEVEL: u32 = 6;
+
+pub fn encode(ks: &KnowledgeSet) -> Result<String, OrigaError> {
+    let json = serde_json::to_string(ks).map_err(|e| OrigaError::RepositoryError {
+        reason: format!("knowledge_set json encode failed: {e}"),
+    })?;
+    let deflated = deflate(json.as_bytes())?;
+    Ok(format!("{DEFLATE_PREFIX}{}", BASE64.encode(&deflated)))
+}
+
+pub fn decode(raw: &str) -> KnowledgeSet {
+    decode_strict(raw).unwrap_or_else(|e| {
+        tracing::warn!(
+            error = %e,
+            "knowledge_set remote decode failed; self-heal via empty KnowledgeSet"
+        );
+        KnowledgeSet::default()
+    })
+}
+
+/// Single parse path. `decode` wraps this with the recovering policy;
+/// roundtrip tests call it directly to assert correctness (not recovery).
+pub fn decode_strict(raw: &str) -> Result<KnowledgeSet, OrigaError> {
+    if let Some(b64) = raw.strip_prefix(DEFLATE_PREFIX) {
+        let deflated = BASE64
+            .decode(b64)
+            .map_err(|e| OrigaError::RepositoryError {
+                reason: format!("knowledge_set base64 decode failed: {e}"),
+            })?;
+        let json_bytes = inflate(&deflated)?;
+        serde_json::from_slice(&json_bytes).map_err(|e| OrigaError::RepositoryError {
+            reason: format!("knowledge_set json decode failed: {e}"),
+        })
+    } else {
+        serde_json::from_str(raw).map_err(|e| OrigaError::RepositoryError {
+            reason: format!("knowledge_set legacy json decode failed: {e}"),
+        })
+    }
+}
+
+fn deflate(input: &[u8]) -> Result<Vec<u8>, OrigaError> {
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::new(DEFLATE_LEVEL));
+    encoder
+        .write_all(input)
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("knowledge_set deflate write failed: {e}"),
+        })?;
+    encoder.finish().map_err(|e| OrigaError::RepositoryError {
+        reason: format!("knowledge_set deflate finish failed: {e}"),
+    })
+}
+
+fn inflate(input: &[u8]) -> Result<Vec<u8>, OrigaError> {
+    let mut decoder = DeflateDecoder::new(input);
+    let mut out = Vec::new();
+    decoder
+        .read_to_end(&mut out)
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("knowledge_set inflate failed: {e}"),
+        })?;
+    Ok(out)
+}

--- a/origa_ui/src/repository/knowledge_set_codec_tests.rs
+++ b/origa_ui/src/repository/knowledge_set_codec_tests.rs
@@ -1,0 +1,109 @@
+use super::*;
+use origa::domain::{Card, NativeLanguage, PhraseCard, RateMode, Rating, User};
+use rstest::rstest;
+use ulid::Ulid;
+
+fn fixture_knowledge_set() -> KnowledgeSet {
+    let mut user = User::new(
+        "codec-test@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    );
+    let ratings = [Rating::Easy, Rating::Good, Rating::Hard, Rating::Again];
+    for i in 0..6 {
+        let study_card = user
+            .create_card(Card::Phrase(PhraseCard::new(Ulid::new())))
+            .expect("create_card");
+        let card_id = *study_card.card_id();
+        user.rate_card(
+            card_id,
+            ratings[i % ratings.len()],
+            RateMode::StandardLesson,
+        )
+        .expect("rate_card");
+    }
+    user.knowledge_set().clone()
+}
+
+#[test]
+fn encode_then_decode_strict_preserves_knowledge_set() {
+    // Arrange
+    let original = fixture_knowledge_set();
+
+    // Act
+    let wire = encode(&original).expect("encode");
+    let restored = decode_strict(&wire).expect("decode_strict");
+
+    // Assert — structural equality: the wire format is lossless.
+    assert_eq!(original, restored);
+}
+
+#[test]
+fn encode_output_carries_deflate_prefix() {
+    // Arrange
+    let ks = fixture_knowledge_set();
+
+    // Act
+    let wire = encode(&ks).expect("encode");
+
+    // Assert — wire-format contract: the self-describing magic prefix is
+    // present so the read path can discriminate the format unambiguously.
+    assert!(
+        wire.starts_with(DEFLATE_PREFIX),
+        "wire must carry the deflate prefix"
+    );
+}
+
+#[test]
+fn encode_output_is_smaller_than_raw_json() {
+    // Arrange
+    let ks = fixture_knowledge_set();
+    let raw_json = serde_json::to_string(&ks).expect("json");
+
+    // Act
+    let wire = encode(&ks).expect("encode");
+
+    // Assert — compression effectiveness: the deflated wire string is
+    // smaller than the uncompressed JSON it replaces.
+    assert!(
+        wire.len() < raw_json.len(),
+        "deflated wire ({}) must be smaller than raw json ({})",
+        wire.len(),
+        raw_json.len()
+    );
+}
+
+#[test]
+fn decode_legacy_plain_json_returns_knowledge_set() {
+    // Arrange — a pre-upgrade remote row stores plain JSON, no prefix.
+    let ks = fixture_knowledge_set();
+    let legacy_wire = serde_json::to_string(&ks).expect("json");
+
+    // Act
+    let restored = decode_strict(&legacy_wire).expect("decode_strict legacy");
+
+    // Assert — back-compat: existing rows are readable by the new client.
+    assert_eq!(ks, restored);
+}
+
+// The recovering policy (`decode`) is the self-heal contract: anything the
+// codec cannot parse resolves to an empty KnowledgeSet, never panics, never
+// returns partial data. Every corruption class shares that contract, so they
+// collapse into one parameterized test — each `#[case]` documents a distinct
+// corruption shape the contract must absorb.
+#[rstest]
+#[case::corrupt_legacy_json(
+    r#"{"study_cards":{"broken":"truncated;#[unterminated"#.to_string()
+)]
+#[case::corrupt_deflated_payload(format!(
+    "{DEFLATE_PREFIX}!!!not-valid-base64-or-deflate!!!"
+))]
+#[case::unknown_prefix("ZSTD;some-future-format-payload".to_string())]
+fn decode_recovering_returns_empty_on_unparseable_input(#[case] corrupt: String) {
+    // Act
+    let restored = decode(&corrupt);
+
+    // Assert — self-heal: corrupt remote resolves to empty so the subsequent
+    // merge is a no-op and local data overwrites remote.
+    assert_eq!(restored, KnowledgeSet::default());
+}

--- a/origa_ui/src/repository/mod.rs
+++ b/origa_ui/src/repository/mod.rs
@@ -3,6 +3,7 @@ pub mod cdn_provider;
 mod dictionary_cache;
 mod file_repository;
 mod hybrid_repository;
+mod knowledge_set_codec;
 pub(crate) mod legacy_migration;
 mod session;
 pub mod trailbase_auth;

--- a/origa_ui/src/repository/trailbase_repository.rs
+++ b/origa_ui/src/repository/trailbase_repository.rs
@@ -2,11 +2,17 @@ use super::session::{TrailBaseSession, get_session, set_session_async};
 use super::trailbase_client::{AuthError, TrailBaseClient};
 use super::trailbase_id::uuid_to_ulid;
 use chrono::{DateTime, Utc};
-use origa::domain::{DailyLoad, NativeLanguage, OrigaError, User};
+use origa::domain::{DailyLoad, KnowledgeSet, NativeLanguage, OrigaError, User};
 use origa::traits::UserRepository;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use ulid::Ulid;
+
+use super::knowledge_set_codec;
+
+#[cfg(test)]
+#[path = "trailbase_repository_tests.rs"]
+mod tests;
 
 #[derive(Clone)]
 pub struct TrailBaseUserRepository {
@@ -117,10 +123,14 @@ impl UserRow {
             .and_then(|s| serde_json::from_str(s).ok())
             .unwrap_or_default();
 
-        let knowledge_set = self
+        // knowledge_set is the only field that switches wire format
+        // (plain JSON -> deflated). Its decode is recovering: a corrupt or
+        // legacy value resolves to an empty KnowledgeSet so the existing
+        // self-heal (merge no-op -> local overwrites remote) is preserved.
+        let knowledge_set: KnowledgeSet = self
             .knowledge_set
-            .as_ref()
-            .and_then(|s| serde_json::from_str(s).ok())
+            .as_deref()
+            .map(knowledge_set_codec::decode)
             .unwrap_or_default();
 
         let imported_sets: HashSet<String> = self
@@ -153,15 +163,18 @@ impl UserRow {
     }
 }
 
-fn user_to_json(user: &User, trailbase_id: &str) -> serde_json::Value {
+fn user_to_json(user: &User, trailbase_id: &str) -> Result<serde_json::Value, OrigaError> {
     let jlpt_progress_json =
-        serde_json::to_string(user.jlpt_progress()).unwrap_or_else(|_| "null".to_string());
-    let knowledge_set_json = serde_json::to_string(user.knowledge_set())
-        .unwrap_or_else(|_| "{\"study_cards\":{},\"lesson_history\":[]}".to_string());
+        serde_json::to_string(user.jlpt_progress()).map_err(|e| OrigaError::RepositoryError {
+            reason: format!("jlpt_progress encode failed: {e}"),
+        })?;
+    let knowledge_set_wire = knowledge_set_codec::encode(user.knowledge_set())?;
     let imported_sets_json =
-        serde_json::to_string(user.imported_sets()).unwrap_or_else(|_| "[]".to_string());
+        serde_json::to_string(user.imported_sets()).map_err(|e| OrigaError::RepositoryError {
+            reason: format!("imported_sets encode failed: {e}"),
+        })?;
 
-    serde_json::json!({
+    Ok(serde_json::json!({
         "trailbase_id": trailbase_id,
         "username": user.username(),
         "email": user.email(),
@@ -169,12 +182,12 @@ fn user_to_json(user: &User, trailbase_id: &str) -> serde_json::Value {
         "current_japanese_level": i32::from(user.current_japanese_level()),
         "jlpt_progress": jlpt_progress_json,
         "telegram_user_id": user.telegram_user_id().copied().map(|id| id as i64),
-        "knowledge_set": knowledge_set_json,
+        "knowledge_set": knowledge_set_wire,
         "updated_at": user.updated_at().to_rfc3339(),
         "imported_sets": imported_sets_json,
         "daily_load": i32::from(*user.daily_load()),
         "known_vocab_hash": user.known_vocab_hash() as i32,
-    })
+    }))
 }
 
 impl UserRepository for TrailBaseUserRepository {
@@ -196,7 +209,7 @@ impl UserRepository for TrailBaseUserRepository {
         }
 
         let api = self.client.records(&self.table_name);
-        let body = user_to_json(user, &session.trailbase_id);
+        let body = user_to_json(user, &session.trailbase_id)?;
 
         if let Some((_, record_id)) = self.find_current().await? {
             api.update(&record_id.to_string(), &body)

--- a/origa_ui/src/repository/trailbase_repository_tests.rs
+++ b/origa_ui/src/repository/trailbase_repository_tests.rs
@@ -1,0 +1,70 @@
+use super::*;
+use origa::domain::{Card, PhraseCard, RateMode, Rating};
+use ulid::Ulid;
+
+fn fixture_user() -> User {
+    let mut user = User::new(
+        "row-test@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    );
+    let study_card = user
+        .create_card(Card::Phrase(PhraseCard::new(Ulid::new())))
+        .expect("create_card");
+    user.rate_card(
+        *study_card.card_id(),
+        Rating::Good,
+        RateMode::StandardLesson,
+    )
+    .expect("rate_card");
+    user
+}
+
+#[test]
+fn user_to_json_then_userrow_roundtrip_preserves_knowledge_set() {
+    // Arrange
+    let user = fixture_user();
+
+    // Act — encode to the wire body, then deserialize back as a UserRow
+    // (the shape TrailBase returns), and rebuild the User exactly as the
+    // production read path does.
+    let body = user_to_json(&user, "00000000-0000-0000-0000-000000000001").expect("user_to_json");
+    let row: UserRow = serde_json::from_value(body).expect("UserRow deserialize from wire body");
+    let restored = row.to_user();
+
+    // Assert — the deflated wire format is lossless end-to-end: what the
+    // write path produces, the read path reconstructs.
+    assert_eq!(
+        user.knowledge_set(),
+        restored.knowledge_set(),
+        "knowledge_set must survive the full encode -> wire -> decode roundtrip"
+    );
+    assert_eq!(user.email(), restored.email());
+    assert_eq!(user.username(), restored.username());
+}
+
+#[test]
+fn userrow_to_user_self_heals_on_corrupt_knowledge_set() {
+    // Arrange — a valid wire body, but the knowledge_set field is replaced
+    // with an unparseable deflated payload. This models a corrupt remote
+    // row (truncated write, bit flip in the BLOB, a partial column write).
+    let user = fixture_user();
+    let mut body =
+        user_to_json(&user, "00000000-0000-0000-0000-000000000002").expect("user_to_json");
+    body["knowledge_set"] = serde_json::Value::String("DEFLATE;!!!corrupt-base64!!!".to_string());
+
+    // Act
+    let row: UserRow = serde_json::from_value(body).expect("UserRow deserialize from wire body");
+    let restored = row.to_user();
+
+    // Assert — self-heal: the read path resolves a corrupt knowledge_set
+    // to empty (not panic, not Err, not partial garbage). The subsequent
+    // merge_current_user + save_local_and_sync_remote then overwrites the
+    // corrupt remote with the device's local data — the device never
+    // loses its own progress.
+    assert_eq!(
+        restored.knowledge_set(),
+        &KnowledgeSet::default(),
+        "corrupt knowledge_set must self-heal to empty, never panic"
+    );
+}

--- a/origa_ui/tests/knowledge_set_format_poc.rs
+++ b/origa_ui/tests/knowledge_set_format_poc.rs
@@ -1,0 +1,256 @@
+//! Slice 1 — blocking PoC-gate: choose the wire format for `knowledge_set`
+//! by measurement, not by postulate.
+//!
+//! Compares four candidate formats on a representative fixture:
+//!   1. raw JSON (current wire format, the baseline we must beat)
+//!   2. bincode-only (compact binary, zero compression CPU cost)
+//!   3. deflate(JSON) — gzip-style compression over JSON text
+//!   4. deflate(bincode) — compression over compact binary
+//!
+//! Each compressed variant is measured as the FINAL wire string
+//! (magic-prefix + base64), because the TrailBase column is `TEXT`
+//! (`Option<String>`), so raw deflate bytes cannot be stored directly and
+//! base64's ~33% overhead is unavoidable. The gate compares the real
+//! on-the-wire length.
+//!
+//! Critical check: `KnowledgeSet` carries `#[serde(flatten)] stats` and a
+//! custom `deserialize_study_cards`. bincode 1.x has a known incompatibility
+//! with `serde(flatten)` (flatten needs self-describing `deserialize_any`).
+//! This PoC explicitly tests bincode roundtrip and records failure rather
+//! than assuming compatibility — a failing roundtrip disqualifies the
+//! bincode variants regardless of size.
+//!
+//! Format choice rule (per the approved plan v3):
+//!
+//! - latency budget: encode + decode on the fixture <= 500 ms
+//!   (sync-checkpoint path, not the rating hot-path)
+//! - pick the variant with the smallest wire string that passes the budget
+//! - bincode variants are valid only if their roundtrip succeeds; a
+//!   serde(flatten) incompatibility disqualifies them regardless of size
+//!
+//! Outcome (release, ~8 MiB fixture): bincode disqualified by roundtrip
+//! failure; deflate(JSON) level 6 chosen — 4.69x ratio at ~197ms
+//! encode+decode. See `knowledge_set_codec::DEFLATE_LEVEL`.
+//!
+//! This is a `#[test]`; run with `cargo test -p origa_ui --test
+//! knowledge_set_format_poc -- --nocapture --ignored` to read the table.
+
+use std::io::Read;
+use std::io::Write;
+use std::time::Instant;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use flate2::Compression;
+use flate2::read::DeflateDecoder;
+use flate2::write::DeflateEncoder;
+use origa::domain::{Card, KnowledgeSet, NativeLanguage, PhraseCard, RateMode, Rating, User};
+use ulid::Ulid;
+
+const MAGIC_PREFIX: &str = "DEFLATE;";
+const N_CARDS: usize = 6000;
+const REVIEWS_PER_CARD: usize = 8;
+
+fn build_fixture(n_cards: usize, reviews_per_card: usize) -> User {
+    let mut user = User::new("poc@test".to_string(), NativeLanguage::Russian, None);
+    let ratings = [Rating::Easy, Rating::Good, Rating::Hard, Rating::Again];
+    for _ in 0..n_cards {
+        let card = Card::Phrase(PhraseCard::new(Ulid::new()));
+        let study_card = match user.create_card(card) {
+            Ok(sc) => sc,
+            Err(e) => panic!("create_card failed: {e:?}"),
+        };
+        let card_id = *study_card.card_id();
+        for r in 0..reviews_per_card {
+            let rating = ratings[r % ratings.len()];
+            user.rate_card(card_id, rating, RateMode::StandardLesson)
+                .expect("rate_card");
+        }
+    }
+    user
+}
+
+fn deflate_encode(data: &[u8], level: u32) -> Vec<u8> {
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::new(level));
+    encoder.write_all(data).expect("deflate write");
+    encoder.finish().expect("deflate finish")
+}
+
+fn deflate_decode(data: &[u8]) -> Vec<u8> {
+    let mut decoder = DeflateDecoder::new(data);
+    let mut out = Vec::new();
+    decoder.read_to_end(&mut out).expect("deflate decode");
+    out
+}
+
+struct VariantResult {
+    name: &'static str,
+    wire_len: usize,
+    encode_us: u128,
+    decode_us: u128,
+    roundtrip_ok: bool,
+    note: &'static str,
+}
+
+impl VariantResult {
+    fn print_row(&self, baseline_json_len: usize) {
+        let ratio = if baseline_json_len == 0 {
+            0.0
+        } else {
+            baseline_json_len as f64 / self.wire_len as f64
+        };
+        println!(
+            "{:<18} wire={:>8}B  ratio={:>5.2}x  enc={:>6}us  dec={:>6}us  roundtrip={}  {}",
+            self.name,
+            self.wire_len,
+            ratio,
+            self.encode_us,
+            self.decode_us,
+            if self.roundtrip_ok { "OK" } else { "FAIL" },
+            self.note,
+        );
+    }
+}
+
+#[test]
+#[ignore = "PoC-gate: run explicitly with --ignored to read the decision table"]
+fn compare_knowledge_set_wire_formats() {
+    let user = build_fixture(N_CARDS, REVIEWS_PER_CARD);
+    let ks: &KnowledgeSet = user.knowledge_set();
+
+    // Baseline: current wire format — plain JSON string in a TEXT column.
+    let json_encode_start = Instant::now();
+    let json_string = serde_json::to_string(ks).expect("serde_json encode");
+    let json_encode_us = json_encode_start.elapsed().as_micros();
+    let json_bytes = json_string.into_bytes();
+
+    let json_decode_start = Instant::now();
+    let _json_roundtrip: KnowledgeSet =
+        serde_json::from_slice(&json_bytes).expect("serde_json decode");
+    let json_decode_us = json_decode_start.elapsed().as_micros();
+
+    let baseline_json_len = json_bytes.len();
+    let raw_json = VariantResult {
+        name: "raw-JSON",
+        wire_len: baseline_json_len,
+        encode_us: json_encode_us,
+        decode_us: json_decode_us,
+        roundtrip_ok: true,
+        note: "current baseline",
+    };
+
+    println!();
+    println!(
+        "fixture: {N_CARDS} cards × {REVIEWS_PER_CARD} reviews; raw JSON = {baseline_json_len} bytes ({:.2} MiB)",
+        baseline_json_len as f64 / (1024.0 * 1024.0)
+    );
+    println!("------------------------------------------------------------------");
+    raw_json.print_row(baseline_json_len);
+
+    // Variant 2: bincode-only. Note: TEXT column forces base64 even here.
+    let bincode_result = match bincode::serialize(ks) {
+        Ok(bincode_bytes) => {
+            let bincode_roundtrip_ok = bincode::deserialize::<KnowledgeSet>(&bincode_bytes).is_ok();
+
+            let b64 = BASE64.encode(&bincode_bytes);
+            let wire = format!("BINCODE;{b64}");
+
+            // decode latency only meaningful if roundtrip is sound
+            let decode_us = if bincode_roundtrip_ok {
+                let start = Instant::now();
+                let raw = BASE64
+                    .decode(wire.strip_prefix("BINCODE;").unwrap())
+                    .expect("b64 decode");
+                let _ks: KnowledgeSet = bincode::deserialize(&raw).expect("bincode decode");
+                start.elapsed().as_micros()
+            } else {
+                0
+            };
+
+            VariantResult {
+                name: "bincode+base64",
+                wire_len: wire.len(),
+                encode_us: 0,
+                decode_us,
+                roundtrip_ok: bincode_roundtrip_ok,
+                note: if bincode_roundtrip_ok {
+                    ""
+                } else {
+                    "DISQUALIFIED: roundtrip failed (serde(flatten) incompatible)"
+                },
+            }
+        },
+        Err(_e) => VariantResult {
+            name: "bincode+base64",
+            wire_len: 0,
+            encode_us: 0,
+            decode_us: 0,
+            roundtrip_ok: false,
+            note: "DISQUALIFIED: serialize failed (serde(flatten) incompatible)",
+        },
+    };
+    bincode_result.print_row(baseline_json_len);
+
+    // Variants 3 & 4: deflate over JSON and over bincode, levels 1 / 6 / 9.
+    for level in [1u32, 6, 9] {
+        // deflate(JSON) + base64 + magic prefix
+        let enc_start = Instant::now();
+        let deflated_json = deflate_encode(&json_bytes, level);
+        let wire_json = format!("{MAGIC_PREFIX}{}", BASE64.encode(&deflated_json));
+        let enc_us = enc_start.elapsed().as_micros();
+
+        let dec_start = Instant::now();
+        let raw = BASE64
+            .decode(wire_json.strip_prefix(MAGIC_PREFIX).unwrap())
+            .expect("b64 decode");
+        let inflated = deflate_decode(&raw);
+        let _ks: KnowledgeSet =
+            serde_json::from_slice(&inflated).expect("json decode after deflate");
+        let dec_us = dec_start.elapsed().as_micros();
+
+        VariantResult {
+            name: "deflate(JSON)",
+            wire_len: wire_json.len(),
+            encode_us: enc_us,
+            decode_us: dec_us,
+            roundtrip_ok: true,
+            note: "",
+        }
+        .print_row(baseline_json_len);
+
+        // Only test deflate(bincode) if bincode roundtrip itself is sound;
+        // otherwise compressing an un-decodable payload is pointless.
+        if bincode_result.roundtrip_ok {
+            if let Ok(bincode_bytes) = bincode::serialize(ks) {
+                let enc_start = Instant::now();
+                let deflated_bincode = deflate_encode(&bincode_bytes, level);
+                let wire_bincode = format!("DEFBINCODE;{}", BASE64.encode(&deflated_bincode));
+                let enc_us = enc_start.elapsed().as_micros();
+
+                let dec_start = Instant::now();
+                let raw = BASE64
+                    .decode(wire_bincode.strip_prefix("DEFBINCODE;").unwrap())
+                    .expect("b64 decode");
+                let inflated = deflate_decode(&raw);
+                let _ks: KnowledgeSet =
+                    bincode::deserialize(&inflated).expect("bincode decode after deflate");
+                let dec_us = dec_start.elapsed().as_micros();
+
+                VariantResult {
+                    name: "deflate(bincode)",
+                    wire_len: wire_bincode.len(),
+                    encode_us: enc_us,
+                    decode_us: dec_us,
+                    roundtrip_ok: true,
+                    note: "",
+                }
+                .print_row(baseline_json_len);
+            }
+        }
+    }
+    println!("------------------------------------------------------------------");
+    println!("latency budget: encode+decode <= 500ms (sync checkpoint path)");
+    println!(
+        "decision: smallest wire_len passing budget; bincode variants valid only if roundtrip OK"
+    );
+}


### PR DESCRIPTION
## Problem

Active users hit ~10MB per checkpoint PUT to TrailBase (auth, onboarding, `toggle_favorite`, create/delete card) — near TrailBase's 10MB body limit and painful on mobile bandwidth + UI responsiveness.

## Solution (band-aid)

Compress `knowledge_set` on the remote wire using **deflate over the existing serde-JSON serialization**:

- **Wire format:** `"DEFLATE;" + base64(deflate(json))`, discriminated from legacy plain JSON by a self-describing magic prefix (JSON starts with `{`, no collision).
- **Format chosen by data-driven PoC gate** (`tests/knowledge_set_format_poc.rs`, `#[ignore]`):
  - raw JSON: 8.22 MB, ratio 1.00x
  - **deflate(JSON) level 6: 1.75 MB, ratio 4.69x, ~197ms native / ~400ms projected WASM** ← chosen
  - deflate(JSON) level 9: 4.75x for +100ms encode (not worth it)
  - **bincode: DISQUALIFIED** — `bincode 1.x` incompatible with `#[serde(flatten)] stats` on `KnowledgeSet` (serialize fails). Caught by PoC, not assumed.

## Error policy

- **Read-recover** (`decode`): never fails — any corruption → `warn!` + empty `KnowledgeSet`. **Preserves the existing self-heal**: corrupt remote → empty KS → `merge` no-op → `save_local_and_sync_remote` overwrites remote with local data. Device never loses its own progress.
- **Write-strict** (`encode`/`user_to_json` → `Result`): serialize failure surfaces as `Err` instead of silently writing a corrupt fallback. Closes a latent silent-fallback bug.
- **Single parser** underlies both policies (`decode` delegates to `decode_strict`).

## Scope

- ✅ Zero `domain/` changes (codec lives in repository layer).
- ✅ Zero new dependencies (`flate2` + `base64` + `serde_json` already in `origa_ui`; `flate2` proven in WASM by the dictionary loader).
- ✅ Lazy self-migration (first `save_sync` after upgrade rewrites legacy row in new format). No batch script.
- ⚠️ **Back up TrailBase DB before deploy** (data-loss-risk requirement).
- ⚠️ Downgrade unsupported (residual: fresh-login on pre-upgrade client loses cross-device sync, not local data) — see ADR-034.

## Out of scope (future "variant C")

Aggregate normalization / per-card rows / delta sync — this band-aid buys time to do those deliberately.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| PoC gate (release) | `cargo test -p origa_ui --test knowledge_set_format_poc --release -- --nocapture --ignored` | deflate(JSON) L6 chosen; bincode disqualified |
| Codec unit | `cargo test -p origa_ui repository::knowledge_set_codec` | 5 fns / 7 cases passed |
| Wire roundtrip + self-heal | `cargo test -p origa_ui repository::trailbase_repository` | 2 passed |
| Lint | `cargo clippy -p origa_ui --all-targets -- -D warnings` | 0 warnings |
| Format | `cargo fmt -p origa_ui -- --check` | clean |

## Plan review

Plan validated through 3 rounds by `@code-quality-reviewer` (`readiness: ready`). Implementation reviewed: `approve` (0 high, 0 common). See ADR-034 for full rationale, alternatives (rkyv / bincode / HTTP Content-Encoding / debounce-delta), and downgrade-scenario analysis.