### PR TITLE
fix(apple): switch app-store gate from cargo feature to env var

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -155,12 +155,15 @@ jobs:
                   APPLE_API_KEY: ${{ secrets.apple-api-key }}
                   APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
                   APPLE_TEAM_ID: ${{ secrets.apple-team-id }}
+                  # ORIGA_APP_STORE signals tauri/build.rs to emit the
+                  # `app_store` rustc cfg, which gates out updater /
+                  # single-instance / release-devtools for Mac App Store
+                  # compliance (2.4.5(vii), 2.5.1). Env-var path is used
+                  # because `cargo tauri ios build` does NOT propagate
+                  # `--no-default-features --features` to cargo.
+                  ORIGA_APP_STORE: "1"
               run: |
-                  # --no-default-features --features app-store disables updater,
-                  # single-instance, and release-devtools for App Store compliance
-                  # (Mac App Store 2.4.5(vii), 2.5.1).
                   cargo tauri ios build \
-                    --no-default-features --features app-store \
                     --export-method app-store-connect
 
             - name: Locate .ipa
@@ -355,6 +358,8 @@ jobs:
               working-directory: tauri
               env:
                   APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+                  # See build-ios job for rationale on ORIGA_APP_STORE.
+                  ORIGA_APP_STORE: "1"
               run: |
                   # Universal Binary requires both arm64 and x86_64 targets;
                   # tauri-bundler combines them via lipo automatically when
@@ -362,7 +367,6 @@ jobs:
                   # --bundles app produces a signed .app (no .dmg), sufficient
                   # for productbuild .pkg generation in the next step.
                   cargo tauri build \
-                    --no-default-features --features app-store \
                     --target universal-apple-darwin \
                     --bundles app
 

--- a/tauri/build.rs
+++ b/tauri/build.rs
@@ -25,6 +25,12 @@ use std::env;
 use serde_json::json;
 
 fn main() {
+    // Declare custom cfg so rustc's check-cfg pass (Rust 2024+) recognizes
+    // it as expected and doesn't emit "unexpected cfg condition name" errors
+    // when clippy runs with `-D warnings`. The cfg is set below when the
+    // `ORIGA_APP_STORE` env var is present.
+    println!("cargo::rustc-check-cfg=cfg(app_store)");
+
     let cdn = build_config::resolve_env(
         env::var("ORIGA_CDN_BASE_URL").ok().as_deref(),
         build_config::DEFAULT_CDN,
@@ -96,20 +102,24 @@ fn inject_csp_via_tauri_config(cdn: &str, landing: &str, trailbase: &str) {
     let final_config_str = final_config.to_string();
 
     // App Store builds: disable updater artifact generation entirely.
-    // `bundle.createUpdaterArtifacts: true` in tauri.conf.json produces
-    // .sig signature files alongside every bundle, intended for the Tauri
-    // updater (desktop distribution via GitHub Releases latest.json).
-    // For App Store builds the updater plugin is gated out at compile time
-    // via the `app-store` cargo feature, so .sig files are dead weight in
-    // the bundle — and Apple reviewers may flag stray signature artifacts
-    // that reference an active self-update mechanism.
+    // Triggered by the `ORIGA_APP_STORE` env var (NOT a cargo feature —
+    // tauri-cli does not propagate `--features`/`--no-default-features`
+    // to cargo). The env var is also used by build.rs to emit the
+    // `app_store` rustc cfg flag, which `lib.rs` uses to gate out
+    // `tauri-plugin-updater` registration (Mac App Store 2.4.5(vii)).
     //
-    // This patch is applied AFTER the CSP patch (which may itself have
-    // merged into an externally-provided TAURI_CONFIG from `cargo tauri
-    // build --config <merge>`). RFC 7396 merge semantics: last write wins,
-    // so the `false` here overrides any earlier `true`.
-    #[cfg(feature = "app-store")]
-    {
+    // `bundle.createUpdaterArtifacts: true` in tauri.conf.json produces
+    // .sig signature files alongside every bundle, intended for the
+    // Tauri updater (desktop distribution via GitHub Releases latest.json).
+    // For App Store builds the updater plugin is gated out, so .sig files
+    // are dead weight and Apple reviewers may flag stray signature
+    // artifacts that reference an active self-update mechanism.
+    //
+    // RFC 7396 merge semantics: last write wins.
+    if env::var("ORIGA_APP_STORE").is_ok() {
+        // Emit cfg for lib.rs to consume.
+        println!("cargo:rustc-cfg=app_store");
+
         let updater_patch = json!({
             "bundle": {
                 "createUpdaterArtifacts": false
@@ -125,28 +135,24 @@ fn inject_csp_via_tauri_config(cdn: &str, landing: &str, trailbase: &str) {
             env::set_var("TAURI_CONFIG", &patched);
         }
         println!("cargo:rustc-env=TAURI_CONFIG={patched}");
-    }
-
-    // When NOT app-store: emit final_config_str unchanged (CSP-merged,
-    // createUpdaterArtifacts still true per tauri.conf.json — needed for
-    // desktop distribution via GitHub Releases updater manifest).
-    #[cfg(not(feature = "app-store"))]
-    {
+    } else {
+        // Desktop distribution path: emit final_config_str unchanged
+        // (CSP-merged, createUpdaterArtifacts still true per tauri.conf.json
+        // — needed for updater manifest on GitHub Releases).
         // SAFETY: build scripts are single-threaded by Cargo's contract —
         // exactly one `main()` runs per build script invocation, with no
         // spawned threads. `tauri_build::build()` is a synchronous API
         // (no async, no `std::thread::spawn`) that reads `TAURI_CONFIG`
         // via `env::var()` on the same thread as this `main()`. `set_var`
         // is marked `unsafe` since Rust edition 2024 due to potential data
-        // races in multi-threaded contexts, which do not apply here. This
-        // is a sanctioned exception to AGENTS.md "no unsafe" rule, with
-        // full rationale in ADR-009 ("Consequences → Negative").
+        // races in multi-threaded contexts, which do not apply here.
         unsafe {
             env::set_var("TAURI_CONFIG", &final_config_str);
         }
         println!("cargo:rustc-env=TAURI_CONFIG={final_config_str}");
     }
 
+    println!("cargo:rerun-if-env-changed=ORIGA_APP_STORE");
     println!("cargo:rerun-if-env-changed=ORIGA_CDN_BASE_URL");
     println!("cargo:rerun-if-env-changed=TRAILBASE_URL");
     println!("cargo:rerun-if-env-changed=ORIGA_LANDING_BASE_URL");

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -1,13 +1,21 @@
 mod auth_store;
-#[cfg(all(desktop, not(feature = "app-store")))]
+// `app_store` cfg is set by `tauri/build.rs` when the `ORIGA_APP_STORE`
+// env var is present. `feature = "app-store"` covers local `cargo check
+// --features app-store` invocations. The OR allows either mechanism:
+// tauri-cli does NOT pass `--features` through to cargo, so the env-var
+// path is the only way to gate during `cargo tauri ios build`.
+#[cfg(all(desktop, not(any(feature = "app-store", app_store))))]
 mod updater_commands;
 
 use auth_store::{auth_store_delete, auth_store_get, auth_store_set};
-#[cfg(any(feature = "release-devtools", all(desktop, not(feature = "app-store"))))]
+#[cfg(any(
+    feature = "release-devtools",
+    all(desktop, not(any(feature = "app-store", app_store)))
+))]
 use tauri::Manager;
 use tauri::{Emitter, Listener};
 use tauri_plugin_deep_link::DeepLinkExt;
-#[cfg(all(desktop, not(feature = "app-store")))]
+#[cfg(all(desktop, not(any(feature = "app-store", app_store))))]
 use updater_commands::{PendingUpdate, check_for_update, install_update};
 
 /// Returns the deep-link URL that launched (or last targeted) the current
@@ -32,7 +40,7 @@ pub fn run() {
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default();
 
-    #[cfg(all(desktop, not(feature = "app-store")))]
+    #[cfg(all(desktop, not(any(feature = "app-store", app_store))))]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             tracing::info!("[deep-link] single-instance activated (app was already running)");
@@ -61,9 +69,9 @@ pub fn run() {
             auth_store_get,
             auth_store_set,
             auth_store_delete,
-            #[cfg(all(desktop, not(feature = "app-store")))]
+            #[cfg(all(desktop, not(any(feature = "app-store", app_store))))]
             check_for_update,
-            #[cfg(all(desktop, not(feature = "app-store")))]
+            #[cfg(all(desktop, not(any(feature = "app-store", app_store))))]
             install_update
         ])
         .setup(|app| {


### PR DESCRIPTION
🐛 fix(apple): switch app-store gate from cargo feature to env var

tauri-cli does NOT propagate `--no-default-features --features` to cargo.
Both `cargo tauri ios build` and `cargo tauri build` reject unknown
flags with:

  error: unexpected argument '--no-default-features' found

Caught on second Apple CI run (workflow_dispatch 30412432062) — both
build-ios and build-macos failed at the build step.

## Solution

Switch the App Store gate mechanism from cargo feature to env var:

1. **`tauri/build.rs`**: when `ORIGA_APP_STORE` env var is present:
   - Emit `cargo:rustc-cfg=app_store` (consumed by `lib.rs`)
   - Apply `bundle.createUpdaterArtifacts: false` to TAURI_CONFIG
2. **`tauri/src/lib.rs`**: replace `#[cfg(not(feature = "app-store"))]`
   with `#[cfg(not(any(feature = "app-store", app_store)))]` — OR
   of both mechanisms so `cargo check --features app-store` still works
   for local dev.
3. **`.github/workflows/_build-tauri-apple.yml`**: remove
   `--no-default-features --features app-store` from `cargo tauri`
   invocations, add `env: ORIGA_APP_STORE: "1"` instead.
4. **`tauri/build.rs`**: declare `cargo::rustc-check-cfg=cfg(app_store)`
   so clippy `-D warnings` recognizes the custom cfg (Rust 2024+).

The env-var path is the only mechanism that works through tauri-cli.
The cargo feature path is kept for local `cargo check --features
app-store` verification only.

## Verification

- `cargo check -p origa-app` (default features) — passes
- `ORIGA_APP_STORE=1 cargo check -p origa-app` — passes (env path)
- `cargo check -p origa-app --no-default-features --features app-store`
  — passes (feature path, local dev only)
- `cargo clippy` (both env and feature paths) — clean with `-D warnings`
- `cargo fmt --check` — clean

## Test plan

After merge, `workflow_dispatch` on `tauri.yml`:
- `build-ios` should reach `cargo tauri ios build` step (previously
  failed at the cargo feature flag parse).
- `build-macos` should reach `cargo tauri build --target universal-apple-darwin`
  (same).
