### PR TITLE
fix(apple): robust PEM decode + remove plugins.updater for App Store

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -125,10 +125,28 @@ jobs:
                   # Solution: write the .p8 to ./private_keys/ so both consumers
                   # can find it, and set APPLE_API_KEY_PATH to the same file
                   # for cargo-mobile2.
+                  #
+                  # Whitespace tolerance: GitHub secret may contain folded
+                  # newlines / CRLF if pasted via web UI. Strip ALL whitespace
+                  # before decoding — base64 alphabet is strict ASCII, and
+                  # any embedded whitespace makes xcodebuild reject the .p8
+                  # with `CryptoKitASN1Error.invalidPEMDocument`.
                   KEY_PATH="private_keys/AuthKey_${APPLE_API_KEY}.p8"
                   mkdir -p private_keys
-                  echo "$APPLE_API_KEY_CONTENT" | base64 --decode > "$KEY_PATH"
+                  printf '%s' "$APPLE_API_KEY_CONTENT" | tr -d '[:space:]' | base64 --decode > "$KEY_PATH"
                   echo "APPLE_API_KEY_PATH=$(pwd)/$KEY_PATH" >> "$GITHUB_ENV"
+                  # Sanity check: file must contain PEM markers and be ~200-250 bytes.
+                  if [ ! -s "$KEY_PATH" ]; then
+                    echo "::error::Decoded .p8 is empty — base64 secret malformed"
+                    exit 1
+                  fi
+                  file_size=$(wc -c < "$KEY_PATH")
+                  echo "Decoded .p8 size: $file_size bytes"
+                  if [ "$file_size" -lt 200 ]; then
+                    echo "::error::Decoded .p8 is suspiciously small ($file_size bytes) — secret may be truncated"
+                    exit 1
+                  fi
+                  head -1 "$KEY_PATH"
                   echo "API key decoded to $KEY_PATH"
 
             - name: Update version in config files

--- a/tauri/build.rs
+++ b/tauri/build.rs
@@ -108,12 +108,12 @@ fn inject_csp_via_tauri_config(cdn: &str, landing: &str, trailbase: &str) {
     // `app_store` rustc cfg flag, which `lib.rs` uses to gate out
     // `tauri-plugin-updater` registration (Mac App Store 2.4.5(vii)).
     //
-    // `bundle.createUpdaterArtifacts: true` in tauri.conf.json produces
-    // .sig signature files alongside every bundle, intended for the
-    // Tauri updater (desktop distribution via GitHub Releases latest.json).
-    // For App Store builds the updater plugin is gated out, so .sig files
-    // are dead weight and Apple reviewers may flag stray signature
-    // artifacts that reference an active self-update mechanism.
+    // Two patches applied to TAURI_CONFIG:
+    // 1. `bundle.createUpdaterArtifacts: false` — stop emitting .sig files
+    // 2. `plugins.updater: null` (RFC 7396 deletion) — tauri-bundler refuses
+    //    to build macOS bundle if `plugins.updater.pubkey` is present but
+    //    `TAURI_SIGNING_PRIVATE_KEY` env var is missing. Removing the
+    //    section entirely disables updater integration in the bundler.
     //
     // RFC 7396 merge semantics: last write wins.
     if env::var("ORIGA_APP_STORE").is_ok() {
@@ -123,6 +123,9 @@ fn inject_csp_via_tauri_config(cdn: &str, landing: &str, trailbase: &str) {
         let updater_patch = json!({
             "bundle": {
                 "createUpdaterArtifacts": false
+            },
+            "plugins": {
+                "updater": null
             }
         });
         let mut cfg: serde_json::Value = serde_json::from_str(&final_config_str)


### PR DESCRIPTION
🐛 fix(apple): robust PEM decode + remove plugins.updater for App Store

Third Apple CI run (workflow_dispatch 30415338023) surfaced two distinct
errors in build-ios and build-macos.

## iOS: `CryptoKitASN1Error.invalidPEMDocument`

xcodebuild rejected the App Store Connect API Key .p8 file. Root cause:
the `APPLE_API_KEY_CONTENT` GitHub secret may contain folded newlines
or CRLF if pasted via the web UI (vs `gh secret set` CLI which
preserves single-line). The previous `echo "$X" | base64 --decode`
piped those whitespace bytes into the .p8, producing malformed PEM
that Apple's CryptoKit ASN.1 parser rejects.

Fix: strip ALL whitespace via `tr -d '[:space:]'` before decoding. Also
add size sanity checks (file > 200 bytes; first line is the PEM header)
to fail fast with a clear message instead of a CryptoKit stack trace
~10 minutes later during `xcodebuild`.

```bash
printf '%s' "$APPLE_API_KEY_CONTENT" | tr -d '[:space:]' | base64 --decode > "$KEY_PATH"
```

## macOS: `A public key has been found, but no private key`

`tauri-bundler` for macOS refuses to build when `plugins.updater.pubkey`
is present in `tauri.conf.json` but `TAURI_SIGNING_PRIVATE_KEY` env var
is unset. Previous fix only set `bundle.createUpdaterArtifacts: false`
via build.rs TAURI_CONFIG patch — but tauri-bundler checks the updater
section's existence, not the create-artifacts flag.

Fix: extend the TAURI_CONFIG patch to also delete the entire
`plugins.updater` section via RFC 7396 `null` value (which
`build_config::apply_merge_patch` already handles — see
`apply_merge_patch_null_value_deletes_key` test).

```rust
let updater_patch = json!({
    "bundle": { "createUpdaterArtifacts": false },
    "plugins": { "updater": null }  // RFC 7396: null deletes key
});
```

## Verification

- `cargo check -p origa-app` (default features) — passes
- `ORIGA_APP_STORE=1 cargo check -p origa-app` — passes (env path)
- `cargo clippy` (both paths) — clean with `-D warnings`
- `cargo fmt --check` — clean
- YAML validated via `yaml.safe_load`

## Test plan

After merge, `workflow_dispatch` on `tauri.yml`:
- `build-ios` should pass the decode step and reach `cargo tauri ios build`
  with a valid PEM (no more `invalidPEMDocument`).
- `build-macos` should pass `cargo tauri build --target universal-apple-darwin`
  (no more "public key found, no private key").
