### PR TITLE
fix(apple): smart PEM decode + --config flag for updater removal

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -123,21 +123,50 @@ jobs:
                   #    ~/.appstoreconnect/private_keys/, or $API_PRIVATE_KEYS_DIR.
                   #    altool does NOT honor APPLE_API_KEY_PATH.
                   # Solution: write the .p8 to ./private_keys/ so both consumers
-                  # can find it, and set APPLE_API_KEY_PATH to the same file
-                  # for cargo-mobile2.
+                  #    can find it, and set APPLE_API_KEY_PATH to the same file
+                  #    for cargo-mobile2.
                   #
-                  # Whitespace tolerance: GitHub secret may contain folded
-                  # newlines / CRLF if pasted via web UI. Strip ALL whitespace
-                  # before decoding — base64 alphabet is strict ASCII, and
-                  # any embedded whitespace makes xcodebuild reject the .p8
-                  # with `CryptoKitASN1Error.invalidPEMDocument`.
+                  # The APPLE_API_KEY_CONTENT secret may hold either:
+                  # (a) base64-encoded .p8 contents (from `base64 -i AuthKey.p8`
+                  #     or `[Convert]::ToBase64String(...)` in PowerShell)
+                  # (b) raw PEM contents pasted directly into the secret field.
+                  # Detect at runtime by checking whether the value starts with
+                  # the PEM header. Both paths strip ALL whitespace to avoid
+                  # xcodebuild `CryptoKitASN1Error.invalidPEMDocument` errors
+                  # caused by CRLF/CR/LF pollution from web UI paste.
                   KEY_PATH="private_keys/AuthKey_${APPLE_API_KEY}.p8"
                   mkdir -p private_keys
-                  printf '%s' "$APPLE_API_KEY_CONTENT" | tr -d '[:space:]' | base64 --decode > "$KEY_PATH"
+
+                  # Normalize: strip ALL whitespace; this collapses both the
+                  # base64 case (newlines folded in web UI) and the raw-PEM
+                  # case (CRLF line endings) into a single contiguous string
+                  # for the format test below.
+                  NORMALIZED=$(printf '%s' "$APPLE_API_KEY_CONTENT" | tr -d '[:space:]')
+
+                  if [[ "$NORMALIZED" == -----BEGINPRIVATEKEY* ]]; then
+                      # Raw PEM pasted directly. Re-wrap at 64 chars per line
+                      # with proper PEM headers (PKCS#8 format Apple uses).
+                      # The normalized string is `-----BEGINPRIVATEKEY-----<base64>-----ENDPRIVATEKEY-----`
+                      # — split by markers, then fold the inner base64.
+                      INNER=$(printf '%s' "$NORMALIZED" \
+                              | sed 's/^-----BEGINPRIVATEKEY-----//' \
+                              | sed 's/-----ENDPRIVATEKEY-----$//')
+                      {
+                          echo "-----BEGIN PRIVATE KEY-----"
+                          printf '%s' "$INNER" | fold -w 64
+                          echo ""
+                          echo "-----END PRIVATE KEY-----"
+                      } > "$KEY_PATH"
+                  else
+                      # base64-encoded .p8 file. Decode to original PEM.
+                      printf '%s' "$NORMALIZED" | base64 --decode > "$KEY_PATH"
+                  fi
+
                   echo "APPLE_API_KEY_PATH=$(pwd)/$KEY_PATH" >> "$GITHUB_ENV"
+
                   # Sanity check: file must contain PEM markers and be ~200-250 bytes.
                   if [ ! -s "$KEY_PATH" ]; then
-                    echo "::error::Decoded .p8 is empty — base64 secret malformed"
+                    echo "::error::Decoded .p8 is empty — secret malformed"
                     exit 1
                   fi
                   file_size=$(wc -c < "$KEY_PATH")
@@ -146,7 +175,8 @@ jobs:
                     echo "::error::Decoded .p8 is suspiciously small ($file_size bytes) — secret may be truncated"
                     exit 1
                   fi
-                  head -1 "$KEY_PATH"
+                  # Show the PEM header line (safe — not sensitive).
+                  echo "PEM header: $(head -1 "$KEY_PATH")"
                   echo "API key decoded to $KEY_PATH"
 
             - name: Update version in config files
@@ -384,9 +414,22 @@ jobs:
                   # --target universal-apple-darwin is used.
                   # --bundles app produces a signed .app (no .dmg), sufficient
                   # for productbuild .pkg generation in the next step.
+                  #
+                  # --config applies an RFC 7396 JSON Merge Patch that tauri-cli
+                  # natively merges onto tauri.conf.json. The build.rs
+                  # TAURI_CONFIG env var mechanism is NOT visible to tauri-cli
+                  # (it re-reads tauri.conf.json directly), so we have to pass
+                  # the patch via --config. The patch:
+                  #   - bundle.createUpdaterArtifacts: false (no .sig files)
+                  #   - plugins.updater: null (RFC 7396 delete — without this
+                  #     tauri-bundler fails "public key found, but no private
+                  #     key" because the bundler sees `plugins.updater.pubkey`
+                  #     in tauri.conf.json and expects TAURI_SIGNING_PRIVATE_KEY).
+                  APP_STORE_CONFIG='{"bundle":{"createUpdaterArtifacts":false},"plugins":{"updater":null}}'
                   cargo tauri build \
                     --target universal-apple-darwin \
-                    --bundles app
+                    --bundles app \
+                    --config "$APP_STORE_CONFIG"
 
             - name: Verify Universal Binary
               run: |


### PR DESCRIPTION
🐛 fix(apple): smart PEM decode + --config flag for updater removal

Fourth Apple CI run (workflow_dispatch 30418334176) showed the previous
fix did not fully resolve both errors.

## iOS: still `invalidPEMDocument`

The previous whitespace-strip fix did not help. Root cause hypothesis:
the `APPLE_API_KEY_CONTENT` GitHub secret may contain **raw PEM**
directly (e.g., `-----BEGIN PRIVATE KEY-----\n...`), not base64-encoded
.p8 contents. If you base64-decode raw PEM, you get random bytes that
xcodebuild parses as invalid PEM.

Fix: smart decode in the workflow. Normalize whitespace first, then
check whether the value starts with `-----BEGIN PRIVATE KEY-----`. If
yes → re-wrap as proper PEM with 64-char folded lines. If no → base64
decode as before. Both paths now produce a clean PEM file.

Additionally: emit `PEM header: $(head -1 file)` to the log so the
next failure (if any) is diagnosable without re-running.

## macOS: still "public key found, but no private key"

The previous fix added a TAURI_CONFIG env var patch via build.rs
(`plugins.updater: null`). This does NOT work because `tauri-cli`
reads `tauri.conf.json` **directly** — it does not honor the
TAURI_CONFIG env var for its own bundler invocations. The env var is
only consumed by the in-process `tauri::generate_context!()` macro.

Fix: use the **`--config` CLI flag** instead. This is the official
tauri-cli merge-patch mechanism (RFC 7396 JSON over tauri.conf.json)
and is respected by both cargo build (via tauri-cli env propagation)
and tauri-bundler.

```bash
APP_STORE_CONFIG='{"bundle":{"createUpdaterArtifacts":false},"plugins":{"updater":null}}'
cargo tauri build --target universal-apple-darwin --bundles app --config "$APP_STORE_CONFIG"
```

`ORIGA_APP_STORE=1` env var is still set for the build.rs to emit the
`app_store` rustc cfg flag (lib.rs gating of updater registration).
The two mechanisms are complementary:
- env var → cargo:rustc-cfg=app_store → lib.rs gates Builder::plugin() at runtime
- --config flag → tauri-cli merge patch → tauri-bundler skips updater artifacts

## Verification

- `cargo check -p origa-app` (default features) — passes
- `ORIGA_APP_STORE=1 cargo check -p origa-app` — passes (env path)
- `cargo clippy` — clean
- YAML validated

## Test plan

After merge, `workflow_dispatch` on `tauri.yml`:
- `build-ios` should pass the decode step (now handles both PEM and
  base64 forms) and reach `xcodebuild` with a valid PEM.
- `build-macos` should pass `cargo tauri build --target universal-apple-darwin`
  (no more "public key found, no private key" — updater section now
  removed via --config).
