### PR TITLE
fix(apple): codesign requirements quoting + openssl PEM validation

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -146,8 +146,6 @@ jobs:
                   if [[ "$NORMALIZED" == -----BEGINPRIVATEKEY* ]]; then
                       # Raw PEM pasted directly. Re-wrap at 64 chars per line
                       # with proper PEM headers (PKCS#8 format Apple uses).
-                      # The normalized string is `-----BEGINPRIVATEKEY-----<base64>-----ENDPRIVATEKEY-----`
-                      # — split by markers, then fold the inner base64.
                       INNER=$(printf '%s' "$NORMALIZED" \
                               | sed 's/^-----BEGINPRIVATEKEY-----//' \
                               | sed 's/-----ENDPRIVATEKEY-----$//')
@@ -177,6 +175,23 @@ jobs:
                   fi
                   # Show the PEM header line (safe — not sensitive).
                   echo "PEM header: $(head -1 "$KEY_PATH")"
+
+                  # Validate the key parses as a real EC private key. Catches
+                  # truncation/corruption that produces a valid-looking PEM
+                  # envelope but an invalid ASN.1 key body inside. Without
+                  # this check, xcodebuild fails ~10 min later with
+                  # `CryptoKitASN1Error.invalidPEMDocument` after cargo build.
+                  if ! openssl pkey -in "$KEY_PATH" -noout 2>/dev/null; then
+                    echo "::error::Decoded .p8 is not a valid private key (openssl pkey parse failed)."
+                    echo "The APPLE_API_KEY_CONTENT secret is likely corrupted or truncated."
+                    echo "Re-download the original .p8 from App Store Connect → Users and Access → Keys"
+                    echo "(the file can only be downloaded ONCE at key creation time)."
+                    echo "If you no longer have the .p8: revoke the key, create a new one, store"
+                    echo "its base64 via:  base64 -i AuthKey_<key>.p8 | tr -d '\\n'"
+                    echo "...then update the APPLE_API_KEY, APPLE_API_KEY_CONTENT, and APPLE_API_ISSUER secrets."
+                    exit 1
+                  fi
+                  echo "✅ PEM key validated (openssl parsed it successfully)"
                   echo "API key decoded to $KEY_PATH"
 
             - name: Update version in config files
@@ -479,13 +494,20 @@ jobs:
               # Apple deprecated it ("does not sign nested code correctly"),
               # and Tauri already signed nested helpers/frameworks with
               # correct per-component entitlements during `cargo tauri build`.
+              #
+              # The requirement string is passed via env var to avoid
+              # YAML/bash quoting pitfalls: inline single-quote form
+              # (`--requirements 'designated => anchor apple generic and
+              # identifier "X"'`) is parsed by codesign as a file path when
+              # the inner double quotes are stripped at the bash layer.
               env:
                   APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+                  CODESIGN_REQUIREMENT: 'designated => anchor apple generic and identifier "net.uwuwu.origa"'
               run: |
                   codesign --force --options runtime \
                     --entitlements tauri/Entitlements.plist \
                     --sign "$APPLE_SIGNING_IDENTITY" \
-                    --requirements 'designated => anchor apple generic and identifier "net.uwuwu.origa"' \
+                    --requirements "$CODESIGN_REQUIREMENT" \
                     "$APP_PATH"
                   codesign --verify --verbose=4 "$APP_PATH"
 


### PR DESCRIPTION
🐛 fix(apple): codesign requirements quoting + openssl PEM validation

Fifth Apple CI run (workflow_dispatch 30421175450) — major progress:
macOS build SUCCEEDED (`.app` created, signed, Universal Binary
verified). But re-codesign step failed on `--requirements` quoting.
iOS still rejected PEM despite smart decode.

## macOS: codesign `--requirements` quoting

The inline form `--requirements 'designated => anchor apple generic
and identifier "X"'` failed with:

  designated => anchor apple generic and identifier "net.uwuwu.origa":
    No such file or directory
  invalid requirement specification

Bash/YAML layer stripped the inner double quotes, so codesign parsed
the unquoted blob as a file path. Fix: pass the requirement via env
var (`CODESIGN_REQUIREMENT`), then reference with double quotes:

```bash
codesign ... --requirements "$CODESIGN_REQUIREMENT" "$APP_PATH"
```

## iOS: openssl PEM validation (fail-fast)

The smart decode now produces a structurally-valid PEM (header + 255
bytes + footer), but xcodebuild still rejects with
`CryptoKitASN1Error.invalidPEMDocument`. This means the ASN.1 body
INSIDE the PEM envelope is corrupt — almost certainly because the
`APPLE_API_KEY_CONTENT` GitHub secret was truncated or damaged when
pasted via the web UI.

Add `openssl pkey -in KEY_PATH -noout` validation right after decode.
If it fails (returns nonzero), emit a clear actionable error:

```
::error::Decoded .p8 is not a valid private key (openssl pkey parse failed).
The APPLE_API_KEY_CONTENT secret is likely corrupted or truncated.
Re-download the original .p8 from App Store Connect → Users and Access → Keys
(the file can only be downloaded ONCE at key creation time).
If you no longer have the .p8: revoke the key, create a new one, store
its base64 via:  base64 -i AuthKey_<key>.p8 | tr -d '\n'
...then update the APPLE_API_KEY, APPLE_API_KEY_CONTENT, and APPLE_API_ISSUER secrets.
```

This makes the failure point clear (~30 seconds after decode, not
~10 minutes later inside `xcodebuild`).

## Verification

- YAML validated via `yaml.safe_load`
- No Rust changes

## Test plan

After merge:
- macOS pipeline should pass re-codesign + productbuild + altool upload.
- iOS pipeline will fail-fast at the decode step IF the secret is
  corrupt — clear actionable message, no need to wait 10 minutes for
  xcodebuild.
- IF the secret is actually valid (just whitespace pollution), the
  existing smart-decode logic will produce a working .p8 and xcodebuild
  will succeed.

The user needs to verify the `APPLE_API_KEY_CONTENT` secret on their
side (re-paste from the original .p8 if openssl validation fails).
