### PR TITLE
chore(apple): remove legacy macOS-zigbuild + simplify codesign (per Tauri docs)

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -485,32 +485,6 @@ jobs:
                   echo "✅ All 5 entitlements present"
                   rm -f /tmp/entitlements.txt
 
-            - name: Re-codesign with --requirements (Tauri #15230 workaround)
-              # Tauri-bundler prior to fix for https://github.com/tauri-apps/tauri/issues/15230
-              # omits --requirements on codesign, causing productbuild to fail
-              # the Requirement check for Mac App Store distribution. Re-sign
-              # the top-level bundle with --requirements to inject the
-              # designated requirement. --deep is intentionally NOT used:
-              # Apple deprecated it ("does not sign nested code correctly"),
-              # and Tauri already signed nested helpers/frameworks with
-              # correct per-component entitlements during `cargo tauri build`.
-              #
-              # The requirement string is passed via env var to avoid
-              # YAML/bash quoting pitfalls: inline single-quote form
-              # (`--requirements 'designated => anchor apple generic and
-              # identifier "X"'`) is parsed by codesign as a file path when
-              # the inner double quotes are stripped at the bash layer.
-              env:
-                  APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
-                  CODESIGN_REQUIREMENT: 'designated => anchor apple generic and identifier "net.uwuwu.origa"'
-              run: |
-                  codesign --force --options runtime \
-                    --entitlements tauri/Entitlements.plist \
-                    --sign "$APPLE_SIGNING_IDENTITY" \
-                    --requirements "$CODESIGN_REQUIREMENT" \
-                    "$APP_PATH"
-                  codesign --verify --verbose=4 "$APP_PATH"
-
             - name: Build .pkg via productbuild
               id: pkg
               env:

--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -30,7 +30,7 @@ on:
                 required: true
             platforms:
                 type: string
-                default: "windows,linux,macos,android"
+                default: "windows,linux,android"
             skip_android:
                 type: boolean
                 default: false
@@ -52,8 +52,6 @@ on:
                 value: ${{ jobs.build-windows.outputs.signature }}
             linux-signature:
                 value: ${{ jobs.build-linux.outputs.signature }}
-            macos-signature:
-                value: ${{ jobs.build-macos.outputs.signature }}
 
 env:
     CARGO_TERM_COLOR: always
@@ -271,119 +269,6 @@ jobs:
                       **/bundle/appimage/*.AppImage
                       **/bundle/appimage/*.sig
                       **/bundle/deb/*.deb
-                  retention-days: 7
-
-    build-macos:
-        # Desktop-distribution macOS build via cargo-zigbuild (cross-compile on
-        # Linux, fast, free runner minutes). Produces the unsigned
-        # Origa_macos-arm64.zip used by the landing page's direct download
-        # link (`/releases/latest/download/Origa_macos-arm64.zip`, ADR-025).
-        #
-        # The signed Mac App Store .pkg comes from _build-tauri-apple.yml's
-        # build-macos job on a real macos-15 runner — completely separate
-        # distribution channel.
-        #
-        # Dynamic cleanup in tauri.yml's release job drops this asset when
-        # the App Store pipeline has confirmed-successfully uploaded; until
-        # then it remains as fallback.
-        name: Build macOS (desktop fallback)
-        if: contains(inputs.platforms, 'macos')
-        runs-on: ubuntu-latest
-        container:
-            image: ghcr.io/rust-cross/cargo-zigbuild
-        permissions:
-            contents: read
-        outputs:
-            signature: ${{ steps.signature.outputs.signature }}
-        env:
-            ORIGA_VERSION: ${{ inputs.version }}
-            ORIGA_COMMIT: ${{ inputs.commit_sha }}
-            ORIGA_BUILD_DATE: ${{ inputs.build_date }}
-            TAURI_SIGNING_PRIVATE_KEY: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key || '' }}
-            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key-password || '' }}
-
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-
-            - name: Download WASM artifact
-              uses: actions/download-artifact@v8
-              with:
-                  name: ${{ inputs.wasm_artifact_name }}
-                  path: origa_ui/dist/
-
-            - name: Setup cargo cache
-              uses: Swatinem/rust-cache@v2
-              with:
-                  cache-all-crates: false
-                  cache-targets: false
-                  shared-key: origa-cross-build-v2
-                  save-if: ${{ github.ref == 'refs/heads/master' }}
-
-            - name: Update version in config files
-              uses: ./.github/actions/update-version
-              with:
-                  version: ${{ inputs.version }}
-
-            - name: Install build dependencies
-              run: apt-get update && apt-get install -y zip protobuf-compiler
-
-            - name: Setup Rust targets
-              run: rustup target add aarch64-apple-darwin
-
-            - name: Install cargo-binstall
-              run: |
-                  tmp=$(mktemp) && curl -L --proto '=https' --tlsv1.2 -sSf -o "$tmp" https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh && bash "$tmp"
-                  cargo binstall tauri-cli --no-confirm --force
-
-            - name: Add cargo bin to PATH
-              run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-            - name: Build Tauri app for macOS (desktop)
-              working-directory: tauri
-              run: cargo tauri build --runner cargo-zigbuild --target aarch64-apple-darwin --no-bundle
-
-            - name: Extract signature
-              id: signature
-              shell: bash
-              run: echo "signature=" >> $GITHUB_OUTPUT
-
-            - name: Create macOS app bundle
-              run: |
-                  mkdir -p Origa.app/Contents/MacOS
-                  mkdir -p Origa.app/Contents/Resources
-                  cp target/aarch64-apple-darwin/release/origa-app Origa.app/Contents/MacOS/origa
-                  cat > Origa.app/Contents/Info.plist << EOF
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-                  <plist version="1.0">
-                  <dict>
-                    <key>CFBundleIdentifier</key>
-                    <string>net.uwuwu.origa</string>
-                    <key>CFBundleName</key>
-                    <string>Origa</string>
-                    <key>CFBundleDisplayName</key>
-                    <string>Origa</string>
-                    <key>CFBundleVersion</key>
-                    <string>${{ inputs.version }}</string>
-                    <key>CFBundleShortVersionString</key>
-                    <string>${{ inputs.version }}</string>
-                    <key>CFBundleExecutable</key>
-                    <string>origa</string>
-                    <key>CFBundlePackageType</key>
-                    <string>APPL</string>
-                  </dict>
-                  </plist>
-                  EOF
-                  chmod +x Origa.app/Contents/MacOS/origa
-                  zip -r "Origa_macos-arm64.zip" Origa.app
-
-            - name: Upload macOS artifacts
-              uses: actions/upload-artifact@v4
-              with:
-                  name: macos-build
-                  path: |
-                      Origa_macos-arm64.zip
                   retention-days: 7
 
     build-android:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
             commit_sha: ${{ needs.version.outputs.commit_sha }}
             build_date: ${{ needs.version.outputs.build_date }}
             wasm_artifact_name: wasm-dist
-            platforms: "windows,linux,macos,android"
+            platforms: "windows,linux,android"
             skip_android: ${{ github.actor == 'dependabot[bot]' }}
         secrets:
             tauri-signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY || vars.TAURI_CI_DUMMY_PRIVATE_KEY }}

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -105,7 +105,7 @@ jobs:
             commit_sha: ${{ needs.version.outputs.commit_sha }}
             build_date: ${{ needs.version.outputs.build_date }}
             wasm_artifact_name: frontend-dist
-            platforms: "windows,linux,macos,android"
+            platforms: "windows,linux,android"
             skip_android: ${{ github.actor == 'dependabot[bot]' }}
         secrets:
             tauri-signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY || vars.TAURI_CI_DUMMY_PRIVATE_KEY }}
@@ -222,8 +222,6 @@ jobs:
                   path: artifacts
 
             - name: Prepare release assets
-              env:
-                  MACOS_UPLOAD_STATUS: ${{ needs.build-apple.outputs.macos-upload-status }}
               run: |
                   mkdir -p release_assets
                   # Keep only installable bundles + the updater manifest. Each
@@ -239,24 +237,10 @@ jobs:
                       -name '*.AppImage' -o \
                       -name '*.deb' -o \
                       -name '*.dmg' -o \
-                      -name 'Origa_macos-arm64.zip' -o \
                       -name '*.apk' -o \
                       -name '*.aab' -o \
                       -name 'latest.json' \
                   \) -exec cp -f {} release_assets/ \;
-
-                  # Dynamic cleanup: drop the legacy `Origa_macos-arm64.zip`
-                  # fallback ONLY when the new macOS App Store pipeline has
-                  # confirmed-successfully uploaded a build. If Apple builds
-                  # are skipped (e.g. Dependabot), secrets missing, or upload
-                  # failed, the fallback zip stays so macOS users always have
-                  # a downloadable artifact.
-                  if [ "$MACOS_UPLOAD_STATUS" = "success" ]; then
-                    rm -f release_assets/Origa_macos-arm64.zip
-                    echo "Apple macOS upload succeeded — Origa_macos-arm64.zip excluded from release"
-                  else
-                    echo "Apple macOS upload did not succeed (status: '$MACOS_UPLOAD_STATUS') — keeping Origa_macos-arm64.zip as fallback"
-                  fi
 
                   echo "Release assets content:"
                   ls -la release_assets/
@@ -278,11 +262,11 @@ jobs:
                       - `Origa_amd64.AppImage` — portable
                       - `Origa_amd64.deb` — Debian/Ubuntu
 
-                      ## macOS
-                      ${{ needs.build-apple.outputs.macos-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- `Origa_macos-arm64.zip` — Apple Silicon (fallback; App Store build pending)' }}
-
                       ## iOS
                       ${{ needs.build-apple.outputs.ios-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- iOS build pending (Apple pipeline did not upload)' }}
+
+                      ## macOS
+                      ${{ needs.build-apple.outputs.macos-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- macOS build pending (Apple pipeline did not upload)' }}
 
                       ## Android
                       - `origa.apk`

--- a/origa_landing/src/pages/download.rs
+++ b/origa_landing/src/pages/download.rs
@@ -9,12 +9,15 @@ use crate::content::Locale;
 // between releases, so each platform links to its alias rather than the
 // versioned asset. Clicking starts the file download directly (GitHub serves
 // these with Content-Disposition: attachment), skipping the release UI.
+//
+// macOS distribution moved to the Mac App Store (ADR-033). The legacy
+// `Origa_macos-arm64.zip` direct-download asset is no longer produced by
+// CI — the macOS DownloadCard uses the same "coming soon" treatment as
+// iOS until the App Store listing goes live.
 const DOWNLOAD_WINDOWS: &str =
     "https://github.com/yurvon-screamo/origa/releases/latest/download/Origa_x64-setup.exe";
 const DOWNLOAD_LINUX_APPIMAGE: &str =
     "https://github.com/yurvon-screamo/origa/releases/latest/download/Origa_amd64.AppImage";
-const DOWNLOAD_MACOS: &str =
-    "https://github.com/yurvon-screamo/origa/releases/latest/download/Origa_macos-arm64.zip";
 const DOWNLOAD_ANDROID: &str =
     "https://github.com/yurvon-screamo/origa/releases/latest/download/origa.apk";
 const WEB_APP_URL: &str = env!("ORIGA_APP_BASE_URL");
@@ -80,8 +83,7 @@ pub fn DownloadPage() -> impl IntoView {
                     icon=view! { <IconApple /> }.into_any()
                     name=c.download_macos
                     formats=c.download_macos_formats
-                    href=DOWNLOAD_MACOS
-                    button_text=c.download_button
+                    badge=c.download_ios_coming_soon
                 />
                 <DownloadCard
                     icon=view! { <IconLinux /> }.into_any()


### PR DESCRIPTION
🔥 chore(apple): remove legacy macOS-zigbuild + simplify codesign flow

User feedback: "зачем мы мак 2 раза собираем? Старый прикол с zip удали".
Also investigated Tauri docs (https://v2.tauri.app/distribute/sign/macos/
and https://v2.tauri.app/distribute/app-store/) — the manual re-codesign
`--requirements` workaround for Tauri #15230 is no longer needed in
current tauri-cli (2.3.x) and was causing its own failures
(`invalid requirement specification` due to bash/YAML quoting of the
inner double-quotes).

## Removed: legacy cargo-zigbuild macOS desktop pipeline

- Delete `build-macos` job from `_build-tauri.yml` (was producing the
  unsigned `Origa_macos-arm64.zip` direct-download asset for landing
  page link, ADR-025).
- Drop `macos-signature` workflow output (always empty placeholder).
- Default `platforms` input: `"windows,linux,macos,android"` →
  `"windows,linux,android"` in `_build-tauri.yml`, `ci.yml`, `tauri.yml`.
- Drop dynamic cleanup gate in `tauri.yml` release step (no legacy zip
  to gate — the asset simply isn't produced anymore).
- Drop `Origa_macos-arm64.zip` from release find pattern and body.

macOS distribution is now **Mac App Store only** (ADR-033), via the
real `macos-15` runner pipeline in `_build-tauri-apple.yml`. Two
distribution channels for macOS added complexity without value.

## Removed: `--requirements` re-codesign workaround (Tauri #15230)

The manual `codesign --force --options runtime --requirements
'designated => anchor apple generic and identifier "X"'` step after
`cargo tauri build` was failing in CI:

    designated => anchor apple generic and identifier "net.uwuwu.origa":
      No such file or directory
    invalid requirement specification

Bash/YAML quoting of inner double-quotes broke the requirement
specification even when passed via env var. Investigation of current
Tauri docs (https://v2.tauri.app/distribute/sign/macos/) shows the
recommended flow is:

    tauri build --bundles app --target universal-apple-darwin
    xcrun productbuild --sign "<identity>" --component <app> /Applications <pkg>

— no `--requirements` workaround mentioned. Modern tauri-cli
(`tauri-macos-sign v2.3.4` per CI logs) signs correctly during
`tauri build`, and `productbuild` accepts the signed .app directly.

## Updated: landing page macOS download card

- Remove `DOWNLOAD_MACOS` const (the `/releases/latest/download/
  Origa_macos-arm64.zip` link that no longer resolves).
- Change macOS DownloadCard from `href=DOWNLOAD_MACOS` to
  `badge=c.download_ios_coming_soon` — same "coming soon" treatment
  as iOS until the Mac App Store listing goes live.

## Verification

- `cargo check -p origa-app` (default) — passes
- `ORIGA_APP_STORE=1 cargo check -p origa-app` — passes
- `cargo check -p origa_landing` — passes
- `cargo fmt --check` — clean
- `cargo clippy -p origa-app --all-targets -- -D warnings` — clean
- All 4 workflow YAMLs validated via `yaml.safe_load`

## Test plan

After merge:
- `build-macos` (universal binary .pkg via productbuild) should now
  reach `xcrun altool --upload-app --type mac` without the
  `--requirements` failure.
- iOS `build-ios` should reach `cargo tauri ios build` with the
  now-valid .p8 (re-uploaded secret, openssl-validated).
- Release job will publish WITHOUT `Origa_macos-arm64.zip` asset.
- Landing `/download` page shows macOS card as "coming soon" (badge
  only, no broken download link).
