### PR TITLE
fix(apple): installer cert via -p basic + iOS developmentTeam via --config

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -226,8 +226,17 @@ jobs:
                   # `--no-default-features --features` to cargo.
                   ORIGA_APP_STORE: "1"
               run: |
+                  # Pass APPLE_TEAM_ID via tauri.conf.json `bundle.iOS.developmentTeam`
+                  # through the --config merge patch. Without this, xcodebuild
+                  # fails with "No Account for Team" / "No profiles for
+                  # 'net.uwuwu.origa' were found" because tauri-cli's
+                  # auto-provisioning needs to know which team owns the bundle ID.
+                  # The APPLE_TEAM_ID env var alone is NOT picked up by tauri-cli
+                  # for iOS team assignment — it must be in the config.
+                  APP_STORE_CONFIG="{\"bundle\":{\"iOS\":{\"developmentTeam\":\"$APPLE_TEAM_ID\"}}}"
                   cargo tauri ios build \
-                    --export-method app-store-connect
+                    --export-method app-store-connect \
+                    --config "$APP_STORE_CONFIG"
 
             - name: Locate .ipa
               id: ipa
@@ -493,10 +502,17 @@ jobs:
                   # productbuild signs the .pkg with Mac Installer
                   # Distribution cert (separate from Application cert).
                   # Match both old (pre-Xcode 11) and new CN naming.
-                  INSTALLER_IDENTITY=$(security find-identity -v -p codesigning | grep -E "Mac Installer Distribution|3rd Party Mac Developer Installer" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+                  #
+                  # NOTE: Installer cert lookup uses `-p basic` (not
+                  # `-p codesigning`). Mac Installer Distribution is not
+                  # classified as a "codesigning" identity by Security
+                  # framework — `find-identity -p codesigning` returns
+                  # only Application certs. `productbuild` itself accepts
+                  # any identity visible in the keychain.
+                  INSTALLER_IDENTITY=$(security find-identity -v -p basic | grep -E "Mac Installer Distribution|3rd Party Mac Developer Installer" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
                   if [ -z "$INSTALLER_IDENTITY" ]; then
                     echo "::error::Mac Installer Distribution / 3rd Party Mac Developer Installer identity not found"
-                    security find-identity -v -p codesigning
+                    security find-identity -v -p basic
                     exit 1
                   fi
                   echo "Installer identity: $INSTALLER_IDENTITY"


### PR DESCRIPTION
🐛 fix(apple): installer cert lookup via -p basic + iOS developmentTeam via --config

Sixth Apple CI run (workflow_dispatch 30427729013) — both jobs failed
again after the cleanup. Distinct root causes this time.

## iOS: "No Account for Team 'Tauri'" + "No profiles for 'net.uwuwu.origa'"

xcodebuild could not auto-provision the iOS bundle because tauri-cli
did not know which Apple Team owns `net.uwuwu.origa`. The `APPLE_TEAM_ID`
env var alone is NOT consumed by tauri-cli for iOS team assignment —
it must be in `tauri.conf.json > bundle > iOS > developmentTeam`.

Fix: pass `developmentTeam` via `--config` merge patch in the
`cargo tauri ios build` command. This is the tauri-cli native merge
mechanism, identical to how macOS updater cleanup is applied.

```bash
APP_STORE_CONFIG="{\"bundle\":{\"iOS\":{\"developmentTeam\":\"$APPLE_TEAM_ID\"}}}"
cargo tauri ios build --export-method app-store-connect --config "$APP_STORE_CONFIG"
```

Team ID never lands in source (tauri.conf.json stays clean), only in
the runtime merge patch sourced from `APPLE_TEAM_ID` secret.

## macOS: "Mac Installer Distribution / 3rd Party Mac Developer Installer identity not found"

The previous lookup used `security find-identity -v -p codesigning`.
Mac Installer Distribution is NOT classified as a "codesigning"
identity by the Security framework — that policy returns only
Application certs. Installer certs are visible via `-p basic` (any
X.509 identity).

Fix: change installer lookup from `-p codesigning` to `-p basic`.
Application cert lookup stays on `-p codesigning` (correct — those
ARE codesigning identities used by `codesign --sign`).

This is a regression introduced in PR #299 commit 131cc294 "address
code review" where I changed `-p basic` → `-p codesigning` per code
reviewer feedback without verifying that installer certs classify as
codesigning. Now corrected based on actual Apple Security framework
behavior.

## Verification

- YAML valid (yaml.safe_load)
- qlty check clean
- No Rust changes

## Test plan

After merge:
- macOS `build-macos` should reach `productbuild` and find installer
  identity.
- iOS `build-ios` should pass xcodebuild auto-provisioning (team ID
  known via --config).
