### PR TITLE
fix(apple): correct macOS upload type + add timeouts

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -538,6 +538,7 @@ jobs:
             - name: Upload to App Store Connect
               id: upload
               continue-on-error: true
+              timeout-minutes: 15
               env:
                   APPLE_API_ISSUER: ${{ secrets.apple-api-issuer }}
                   APPLE_API_KEY: ${{ secrets.apple-api-key }}


### PR DESCRIPTION
PR #311 introduced accidental duplication of iOS upload step into macOS job. Fix + add timeouts to prevent altool hangs.