### PR TITLE
ci(apple): gate build-apple on tag push (like RuStore)

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -5,6 +5,11 @@ on:
         tags:
             - "v*.*.*"
     workflow_dispatch:
+        inputs:
+            force_apple:
+                description: "Force Apple builds (consumes ~30 min of macOS runner per target)"
+                type: boolean
+                default: false
 
 concurrency:
     group: tauri-${{ github.ref }}
@@ -117,6 +122,19 @@ jobs:
 
     build-apple:
         name: Build Apple (iOS + macOS)
+        # Apple builds use expensive macOS runners (~30 min/target).
+        # Gate on tag push (stable/prerelease) like upload-rustore, so
+        # workflow_dispatch runs do NOT consume macOS minutes.
+        # Set `force_apple: true` in workflow_dispatch inputs to override
+        # for manual testing / debugging.
+        if: >
+            always() &&
+            needs.build-frontend.result == 'success' &&
+            (startsWith(github.ref, 'refs/tags/v') &&
+             (needs.version.outputs.version_type == 'stable' ||
+              needs.version.outputs.version_type == 'prerelease') ||
+             inputs.force_apple == true) &&
+            github.actor != 'dependabot[bot]'
         needs: [version, build-frontend]
         uses: ./.github/workflows/_build-tauri-apple.yml
         with:
@@ -126,7 +144,6 @@ jobs:
             commit_sha: ${{ needs.version.outputs.commit_sha }}
             build_date: ${{ needs.version.outputs.build_date }}
             wasm_artifact_name: frontend-dist
-            skip_apple: ${{ github.actor == 'dependabot[bot]' }}
         secrets:
             apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
             apple-api-key: ${{ secrets.APPLE_API_KEY }}


### PR DESCRIPTION
Apple builds only on tag push + opt-in force_apple for manual testing. Saves macOS runner minutes.