### PR TITLE
fix(apple): address all code review findings (6 Common + 4 Low)

### DIFF
--- a/.github/actions/decode-apple-key/action.yml
+++ b/.github/actions/decode-apple-key/action.yml
@@ -1,0 +1,76 @@
+name: "Decode Apple API Key"
+description: "Decode APPLE_API_KEY_CONTENT (base64 or raw PEM) into ./private_keys/ with validation"
+
+inputs:
+    apple-api-key-content:
+        description: "Base64-encoded .p8 contents OR raw PEM (from GitHub secret)"
+        required: true
+    apple-api-key:
+        description: "Apple API Key ID (10-char, used in filename)"
+        required: true
+
+outputs:
+    key-path:
+        description: "Absolute path to the decoded .p8 file"
+        value: ${{ steps.decode.outputs.key-path }}
+
+runs:
+    using: "composite"
+    steps:
+        - name: Decode and validate Apple API Key
+          id: decode
+          shell: bash
+          env:
+              APPLE_API_KEY_CONTENT: ${{ inputs.apple-api-key-content }}
+              APPLE_API_KEY: ${{ inputs.apple-api-key }}
+          run: |
+              # Write .p8 to ./private_keys/ (search path for xcrun altool)
+              # and set APPLE_API_KEY_PATH for cargo-mobile2 (iOS auto-provisioning).
+              #
+              # The APPLE_API_KEY_CONTENT secret may hold either:
+              # (a) base64-encoded .p8 contents
+              # (b) raw PEM pasted directly into the secret field
+              # Detect by checking whether the value starts with PEM header.
+              # Both paths strip ALL whitespace to avoid xcodebuild
+              # CryptoKitASN1Error.invalidPEMDocument from CRLF pollution.
+              KEY_PATH="private_keys/AuthKey_${APPLE_API_KEY}.p8"
+              mkdir -p private_keys
+
+              NORMALIZED=$(printf '%s' "$APPLE_API_KEY_CONTENT" | tr -d '[:space:]')
+
+              if [[ "$NORMALIZED" == -----BEGINPRIVATEKEY* ]]; then
+                  INNER=$(printf '%s' "$NORMALIZED" \
+                          | sed 's/^-----BEGINPRIVATEKEY-----//' \
+                          | sed 's/-----ENDPRIVATEKEY-----$//')
+                  {
+                      echo "-----BEGIN PRIVATE KEY-----"
+                      printf '%s' "$INNER" | fold -w 64
+                      echo ""
+                      echo "-----END PRIVATE KEY-----"
+                  } > "$KEY_PATH"
+              else
+                  printf '%s' "$NORMALIZED" | base64 --decode > "$KEY_PATH"
+              fi
+
+              ABS_KEY_PATH="$(pwd)/$KEY_PATH"
+              echo "key-path=$ABS_KEY_PATH" >> "$GITHUB_OUTPUT"
+
+              if [ ! -s "$KEY_PATH" ]; then
+                echo "::error::Decoded .p8 is empty — secret malformed"
+                exit 1
+              fi
+              file_size=$(wc -c < "$KEY_PATH")
+              echo "Decoded .p8 size: $file_size bytes"
+              if [ "$file_size" -lt 200 ]; then
+                echo "::error::Decoded .p8 is suspiciously small ($file_size bytes) — secret may be truncated"
+                exit 1
+              fi
+              echo "PEM header: $(head -1 "$KEY_PATH")"
+
+              if ! openssl pkey -in "$KEY_PATH" -noout 2>/dev/null; then
+                echo "::error::Decoded .p8 is not a valid private key (openssl pkey parse failed)."
+                echo "The APPLE_API_KEY_CONTENT secret is likely corrupted or truncated."
+                echo "Re-download the .p8 from App Store Connect → Users and Access → Keys"
+                exit 1
+              fi
+              echo "PEM key validated (openssl parsed successfully)"

--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -8,15 +8,14 @@ on:
                 required: true
             # version_base and version_type are retained for caller
             # compatibility (ci.yml and tauri.yml pass them) but are not
-            # consumed inside this workflow. Kept as required to avoid a
-            # contract-breaking change to the workflow_call signature,
-            # mirroring the same pattern in _build-tauri.yml.
+            # consumed inside this workflow. Kept as required: false to
+            # avoid implying they affect behavior.
             version_base:
                 type: string
-                required: true
+                required: false
             version_type:
                 type: string
-                required: true
+                required: false
             commit_sha:
                 type: string
                 required: true
@@ -48,9 +47,6 @@ on:
             ios-upload-status:
                 description: "iOS App Store Connect upload result: success|failure|skipped"
                 value: ${{ jobs.build-ios.outputs.upload-status }}
-            macos-build-status:
-                description: "macOS .app build result: success|failure|skipped"
-                value: ${{ jobs.build-macos.outputs.build-status }}
             macos-upload-status:
                 description: "macOS App Store Connect upload result: success|failure|skipped"
                 value: ${{ jobs.build-macos.outputs.upload-status }}
@@ -110,89 +106,14 @@ jobs:
                   path: origa_ui/dist/
 
             - name: Decode Apple API Key
-              env:
-                  APPLE_API_KEY_CONTENT: ${{ secrets.apple-api-key-content }}
-                  APPLE_API_KEY: ${{ secrets.apple-api-key }}
-              run: |
-                  # Two consumers need the .p8 file:
-                  # 1. Tauri iOS build (cargo-mobile2 → xcodebuild auto-provisioning)
-                  #    reads it via APPLE_API_KEY_PATH env var (any path).
-                  # 2. `xcrun altool --upload-app` (App Store Connect upload)
-                  #    searches for `AuthKey_<key>.p8` ONLY in these dirs:
-                  #    ./private_keys/, ~/private_keys/, ~/.private_keys/,
-                  #    ~/.appstoreconnect/private_keys/, or $API_PRIVATE_KEYS_DIR.
-                  #    altool does NOT honor APPLE_API_KEY_PATH.
-                  # Solution: write the .p8 to ./private_keys/ so both consumers
-                  #    can find it, and set APPLE_API_KEY_PATH to the same file
-                  #    for cargo-mobile2.
-                  #
-                  # The APPLE_API_KEY_CONTENT secret may hold either:
-                  # (a) base64-encoded .p8 contents (from `base64 -i AuthKey.p8`
-                  #     or `[Convert]::ToBase64String(...)` in PowerShell)
-                  # (b) raw PEM contents pasted directly into the secret field.
-                  # Detect at runtime by checking whether the value starts with
-                  # the PEM header. Both paths strip ALL whitespace to avoid
-                  # xcodebuild `CryptoKitASN1Error.invalidPEMDocument` errors
-                  # caused by CRLF/CR/LF pollution from web UI paste.
-                  KEY_PATH="private_keys/AuthKey_${APPLE_API_KEY}.p8"
-                  mkdir -p private_keys
+              id: decode-key
+              uses: ./.github/actions/decode-apple-key
+              with:
+                  apple-api-key-content: ${{ secrets.apple-api-key-content }}
+                  apple-api-key: ${{ secrets.apple-api-key }}
 
-                  # Normalize: strip ALL whitespace; this collapses both the
-                  # base64 case (newlines folded in web UI) and the raw-PEM
-                  # case (CRLF line endings) into a single contiguous string
-                  # for the format test below.
-                  NORMALIZED=$(printf '%s' "$APPLE_API_KEY_CONTENT" | tr -d '[:space:]')
-
-                  if [[ "$NORMALIZED" == -----BEGINPRIVATEKEY* ]]; then
-                      # Raw PEM pasted directly. Re-wrap at 64 chars per line
-                      # with proper PEM headers (PKCS#8 format Apple uses).
-                      INNER=$(printf '%s' "$NORMALIZED" \
-                              | sed 's/^-----BEGINPRIVATEKEY-----//' \
-                              | sed 's/-----ENDPRIVATEKEY-----$//')
-                      {
-                          echo "-----BEGIN PRIVATE KEY-----"
-                          printf '%s' "$INNER" | fold -w 64
-                          echo ""
-                          echo "-----END PRIVATE KEY-----"
-                      } > "$KEY_PATH"
-                  else
-                      # base64-encoded .p8 file. Decode to original PEM.
-                      printf '%s' "$NORMALIZED" | base64 --decode > "$KEY_PATH"
-                  fi
-
-                  echo "APPLE_API_KEY_PATH=$(pwd)/$KEY_PATH" >> "$GITHUB_ENV"
-
-                  # Sanity check: file must contain PEM markers and be ~200-250 bytes.
-                  if [ ! -s "$KEY_PATH" ]; then
-                    echo "::error::Decoded .p8 is empty — secret malformed"
-                    exit 1
-                  fi
-                  file_size=$(wc -c < "$KEY_PATH")
-                  echo "Decoded .p8 size: $file_size bytes"
-                  if [ "$file_size" -lt 200 ]; then
-                    echo "::error::Decoded .p8 is suspiciously small ($file_size bytes) — secret may be truncated"
-                    exit 1
-                  fi
-                  # Show the PEM header line (safe — not sensitive).
-                  echo "PEM header: $(head -1 "$KEY_PATH")"
-
-                  # Validate the key parses as a real EC private key. Catches
-                  # truncation/corruption that produces a valid-looking PEM
-                  # envelope but an invalid ASN.1 key body inside. Without
-                  # this check, xcodebuild fails ~10 min later with
-                  # `CryptoKitASN1Error.invalidPEMDocument` after cargo build.
-                  if ! openssl pkey -in "$KEY_PATH" -noout 2>/dev/null; then
-                    echo "::error::Decoded .p8 is not a valid private key (openssl pkey parse failed)."
-                    echo "The APPLE_API_KEY_CONTENT secret is likely corrupted or truncated."
-                    echo "Re-download the original .p8 from App Store Connect → Users and Access → Keys"
-                    echo "(the file can only be downloaded ONCE at key creation time)."
-                    echo "If you no longer have the .p8: revoke the key, create a new one, store"
-                    echo "its base64 via:  base64 -i AuthKey_<key>.p8 | tr -d '\\n'"
-                    echo "...then update the APPLE_API_KEY, APPLE_API_KEY_CONTENT, and APPLE_API_ISSUER secrets."
-                    exit 1
-                  fi
-                  echo "✅ PEM key validated (openssl parsed it successfully)"
-                  echo "API key decoded to $KEY_PATH"
+            - name: Set API key env
+              run: echo "APPLE_API_KEY_PATH=${{ steps.decode-key.outputs.key-path }}" >> "$GITHUB_ENV"
 
             - name: Update version in config files
               uses: ./.github/actions/update-version
@@ -305,7 +226,6 @@ jobs:
         permissions:
             contents: read
         outputs:
-            build-status: ${{ steps.build-report.outputs.status }}
             upload-status: ${{ steps.upload-report.outputs.status }}
         env:
             ORIGA_VERSION: ${{ inputs.version }}
@@ -316,7 +236,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
 
-            - name: Select latest Xcode
+            - name: Select latest Xcode with macOS SDK
               shell: bash
               run: |
                   LATEST_XCODE=$(ls -d /Applications/Xcode*.app | sort -V | tail -1)
@@ -326,6 +246,12 @@ jobs:
                   fi
                   echo "Selected Xcode: $LATEST_XCODE"
                   sudo xcode-select -s "$LATEST_XCODE"
+                  if ! xcodebuild -showsdks | grep -q "macosx"; then
+                    echo "::error::macOS SDK not found in $LATEST_XCODE"
+                    xcodebuild -showsdks
+                    exit 1
+                  fi
+                  echo "macOS SDK verified"
 
             - name: Download WASM artifact
               uses: actions/download-artifact@v8
@@ -380,21 +306,14 @@ jobs:
                   echo "Signing identity: $APP_IDENTITY"
 
             - name: Decode Apple API Key
-              env:
-                  APPLE_API_KEY_CONTENT: ${{ secrets.apple-api-key-content }}
-                  APPLE_API_KEY: ${{ secrets.apple-api-key }}
-              run: |
-                  # Same pattern as build-ios: write to ./private_keys/ so
-                  # xcrun altool finds the key (it searches ./private_keys/,
-                  # ~/private_keys/, ~/.private_keys/, ~/.appstoreconnect/
-                  # private_keys/, or $API_PRIVATE_KEYS_DIR — NOT /tmp/).
-                  # APPLE_API_KEY_PATH is unused by macOS build (codesign uses
-                  # keychain identity, not API key), but set for consistency.
-                  KEY_PATH="private_keys/AuthKey_${APPLE_API_KEY}.p8"
-                  mkdir -p private_keys
-                  echo "$APPLE_API_KEY_CONTENT" | base64 --decode > "$KEY_PATH"
-                  echo "APPLE_API_KEY_PATH=$(pwd)/$KEY_PATH" >> "$GITHUB_ENV"
-                  echo "API key decoded to $KEY_PATH"
+              id: decode-key
+              uses: ./.github/actions/decode-apple-key
+              with:
+                  apple-api-key-content: ${{ secrets.apple-api-key-content }}
+                  apple-api-key: ${{ secrets.apple-api-key }}
+
+            - name: Set API key env
+              run: echo "APPLE_API_KEY_PATH=${{ steps.decode-key.outputs.key-path }}" >> "$GITHUB_ENV"
 
             - name: Update version in config files
               uses: ./.github/actions/update-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,14 @@ jobs:
             - name: Run clippy
               run: cargo clippy --workspace --all-targets -- -D warnings
 
+            - name: Verify App Store cfg compiles
+              # The ORIGA_APP_STORE env var triggers build.rs to emit
+              # cargo:rustc-cfg=app_store, gating out updater /
+              # single-instance / devtools. Without this check, regressions
+              # in the gated code path surface only at tag-push on
+              # macos-15 (~30 min, blocks release).
+              run: ORIGA_APP_STORE=1 cargo check -p origa-app
+
     cdn-download:
         name: Download CDN
         permissions:

--- a/docs/decisions/ADR-033-apple-platforms-mac-app-store-only-distribution.md
+++ b/docs/decisions/ADR-033-apple-platforms-mac-app-store-only-distribution.md
@@ -190,7 +190,7 @@ The correct flow per Tauri docs is:
 tauri build --bundles app --target universal-apple-darwin
 xcrun productbuild --sign "<installer identity>" \
   --component <app-path> /Applications <output.pkg>
-xcrun altool --upload-app --type macos --file <output.pkg> \
+xcrun altool --upload-app --type mac --file <output.pkg> \
   --apiKey $APPLE_API_KEY_ID --apiIssuer $APPLE_API_ISSUER
 ```
 
@@ -245,12 +245,13 @@ xcrun altool --upload-app --type macos --file <output.pkg> \
   newlines or truncation, `xcodebuild` fails ~10 min later with
   `CryptoKitASN1Error.invalidPEMDocument`. CI now fail-fasts via
   `openssl pkey -in KEY_PATH -noout` validation right after decode.
+- **`xcrun altool` deprecated** by Apple (mid-2026). Works for now, but
+  may be removed in a future Xcode version. Migration path: App Store
+  Connect API direct upload, or `Transporter` CLI. Not blocking — altool
+  expected to be supported through at least 2027.
 
 ## Out of scope for this ADR
 
-- **Frontend haptics integration**: `tauri-plugin-haptics` is registered
-  (mobile-only, target-scoped dep) but no Leptos/WASM consumer calls it
-  yet. Tracked in follow-up `mobile-haptics-ui-integration` task.
 - **`bundle.createUpdaterArtifacts: true` unconditional in
   `tauri.conf.json`**: kept for desktop distribution (Windows/Linux
   updater). App Store builds override to `false` via `--config` flag

--- a/tauri/gen/apple/project.yml
+++ b/tauri/gen/apple/project.yml
@@ -70,7 +70,7 @@ targets:
       base:
         ENABLE_BITCODE: false
         ARCHS: [arm64]
-        VALID_ARCHS: arm64 
+        VALID_ARCHS: arm64
         LIBRARY_SEARCH_PATHS[arch=x86_64]: $(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)
         LIBRARY_SEARCH_PATHS[arch=arm64]: $(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)
         ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: true


### PR DESCRIPTION
🐛 fix(apple): address all code review findings (Common #1-6 + Low #7-10)

Addresses 6 Common + 4 Low findings from the final code-quality-reviewer
pass on the Apple CI/CD pipeline.

## Common fixes

### #1+#9: Unify decode Apple API Key into composite action
Created `.github/actions/decode-apple-key/action.yml` — shared composite
action that both `build-ios` and `build-macos` jobs call. Eliminates the
DRY violation where iOS job had robust PEM-detect + whitespace-strip +
openssl validation, while macOS job had naive `echo | base64 --decode`
without any validation. Now both jobs use identical robust decode path.

### #2: ADR-033 "no frontend haptics" outdated
Removed the "Frontend haptics integration" bullet from Out of scope —
haptics consumer (`origa_ui/src/core/haptics.rs` + `on_rate.rs`) was
added in PR #299. ADR now reflects reality.

### #3: ADR-033 §7 `--type macos` → `--type mac`
Tauri docs say `--type macos`, but the actual altool flag is `--type mac`
(both work, `mac` is canonical). Updated ADR to match working code.

### #4: Remove dead `macos-build-status` output
Workflow output and job output were declared but never consumed by any
caller. Removed from both workflow outputs and `build-macos` job outputs.

### #5: CI test for `app_store` cfg-gated path
Added `ORIGA_APP_STORE=1 cargo check -p origa-app` step to `ci.yml` lint
job. Regressions in the gated code path (updater/single-instance skip)
now surface on PR, not at tag-push on macos-15.

### #6: ADR-033 altool deprecation risk
Added note to Risks section: `xcrun altool` deprecated by Apple
(mid-2026), expected to work through 2027, migration path documented.

## Low fixes

### #7: Trailing whitespace in project.yml
`VALID_ARCHS: arm64 ` → `VALID_ARCHS: arm64`

### #8: `version_base`/`version_type` → `required: false`
These inputs are not consumed inside the workflow. Changed from
`required: true` to `required: false` to avoid implying they affect
behavior.

### #10: macOS SDK validation checkpoint
macOS job now verifies `macosx` SDK presence after `xcode-select`,
matching the iOS job's `iphoneos26` checkpoint pattern. Fail-fast on
runner image issues instead of mysterious build failures later.

## Verification

- All 4 workflow YAMLs validated via `yaml.safe_load`
- `qlty check` — clean
- `ORIGA_APP_STORE=1 cargo check -p origa-app` — passes
- `cargo fmt --check` — clean
