### PR TITLE
fix(login): show spinner on email/password submit + add header divider

### DIFF
--- a/end2end/pages/login.page.ts
+++ b/end2end/pages/login.page.ts
@@ -15,6 +15,12 @@ export class LoginPage extends BasePage {
     readonly submitButton: Locator;
     readonly errorAlert: Locator;
 
+    // Layout
+    readonly headerDivider: Locator;
+
+    // Submit-state internals
+    readonly spinner: Locator;
+
     // OAuth
     readonly googleButton: Locator;
     readonly yandexButton: Locator;
@@ -34,6 +40,14 @@ export class LoginPage extends BasePage {
         this.passwordFormToggle = page.getByTestId("login-password-toggle");
         this.submitButton = page.getByTestId("login-submit");
         this.errorAlert = page.getByTestId("login-form-error");
+
+        // Layout
+        this.headerDivider = page.getByTestId("login-header-divider");
+
+        // The submit button renders an inline spinner (data-testid="btn-spinner"
+        // in ui_components/button.rs) while a request is in flight. Scoped to
+        // the submit button so it can't match a spinner on another control.
+        this.spinner = this.submitButton.getByTestId("btn-spinner");
 
         // OAuth
         this.googleButton = page.getByTestId("oauth-google");
@@ -92,6 +106,17 @@ export class LoginPage extends BasePage {
     async submit(): Promise<void> {
         await this.submitButton.waitFor({ state: "visible", timeout: 5000 });
         await this.submitButton.click({ force: true });
+    }
+
+    /**
+     * Asserts the in-flight submit state: the submit button is disabled and a
+     * spinner is rendered. Regression guard for the loader (it disappeared in
+     * the collapsible-login refactor when the loading signal stopped being
+     * threaded down to the form).
+     */
+    async expectSubmittingState(): Promise<void> {
+        await expect(this.submitButton).toBeDisabled({ timeout: 5_000 });
+        await expect(this.spinner).toBeVisible({ timeout: 5_000 });
     }
 
     async login(

--- a/end2end/tests/login_ui.spec.ts
+++ b/end2end/tests/login_ui.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import { LoginPage } from "../pages";
+import { setupTestUser } from "../helpers/auth";
+
+test.describe("Login UI", () => {
+	test("shows spinner and disables submit while logging in @smoke", async ({
+		page,
+	}) => {
+		const user = await setupTestUser();
+		try {
+			// Hold the login request until the in-flight state has been
+			// observed. Manual gate beats a fixed setTimeout: the test
+			// controls exactly when the request is released, so the spinner
+			// assertion cannot flake on timing.
+			let releaseRequest: () => void = () => {};
+			const gate = new Promise<void>((resolve) => {
+				releaseRequest = resolve;
+			});
+			await page.route("**/api/auth/v1/login", async (route) => {
+				await gate;
+				await route.continue();
+			});
+
+			const loginPage = new LoginPage(page);
+			await loginPage.goto();
+			await loginPage.expandPasswordForm();
+			await loginPage.fillEmail(user.email);
+			await loginPage.fillPassword(user.password);
+
+			await loginPage.submit();
+			await loginPage.expectSubmittingState();
+
+			// Release the held request and confirm the full cycle completes.
+			releaseRequest();
+			await loginPage.expectLoginSuccess(["/home", "/onboarding"], 30_000);
+		} finally {
+			await user.cleanup();
+		}
+	});
+
+	test("shows a divider between the header and the password section", async ({
+		page,
+	}) => {
+		const loginPage = new LoginPage(page);
+		await loginPage.goto();
+		await loginPage.expectLoginFormVisible();
+
+		// The divider sits between "Изучайте японский язык" (header) and the
+		// "Войти с помощью пароля" toggle, mirroring the legal-links divider
+		// at the bottom of the card.
+		await expect(loginPage.headerDivider).toBeVisible();
+	});
+});

--- a/origa_ui/src/pages/login/email_password_form.rs
+++ b/origa_ui/src/pages/login/email_password_form.rs
@@ -10,13 +10,13 @@ use super::validation;
 #[component]
 pub fn EmailPasswordForm(
     #[prop(optional, into)] test_id: Signal<String>,
+    #[prop(optional, into)] loading: Signal<bool>,
     #[prop(optional)] server_error: Option<RwSignal<Option<String>>>,
     on_submit: Callback<(String, String)>,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let email = RwSignal::new(String::new());
     let password = RwSignal::new(String::new());
-    let loading = RwSignal::new(false);
     let validation_error = RwSignal::new(None::<String>);
 
     let display_error = move || {
@@ -46,6 +46,13 @@ pub fn EmailPasswordForm(
 
     let on_submit_form = move |ev: leptos::ev::SubmitEvent| {
         ev.prevent_default();
+        // Guards against double-submit: the submit button is disabled while
+        // loading, but browsers still fire a form submit on Enter even when
+        // the submit button is disabled. The signal is idempotent, so this
+        // early-return is belt-and-suspenders, not data-safety.
+        if loading.get() {
+            return;
+        }
         handle_submit();
     };
 

--- a/origa_ui/src/pages/login/header.rs
+++ b/origa_ui/src/pages/login/header.rs
@@ -20,7 +20,7 @@ pub fn LoginHeader(#[prop(optional, into)] test_id: Signal<String>) -> impl Into
     });
 
     view! {
-        <div class="text-center mb-10" data-testid=test_id_val>
+        <div class="text-center" data-testid=test_id_val>
             <Logo size=LogoSize::Lg class=Signal::derive(|| "mx-auto mb-6".to_string()) />
             <Text size=TextSize::Small variant=TypographyVariant::Muted uppercase=true tracking_widest=true test_id=subtitle_test_id>
                 {t!(i18n, login.subtitle)}

--- a/origa_ui/src/pages/login/mod.rs
+++ b/origa_ui/src/pages/login/mod.rs
@@ -76,38 +76,54 @@ pub fn Login() -> impl IntoView {
         }
     });
 
+    // Wraps the login body (divider + form/oauth stack) in a single AnyView so
+    // the CardLayout children tuple (and therefore the bin crate's
+    // monomorphised type-depth) does not grow — see ADR-027 for the
+    // recursion_limit rationale. Mirrors `login_footer` below.
+    let login_body = move || {
+        view! {
+            <Divider
+                variant=Signal::derive(|| DividerVariant::Single)
+                class=Signal::derive(|| "my-6".to_string())
+                test_id=Signal::derive(|| "login-header-divider".to_string())
+            />
+            <div class="space-y-6">
+                <PasswordSection
+                    loading=loading
+                    expanded=password_expanded
+                    on_submit=on_email_submit
+                    server_error=server_error
+                    test_id=Signal::derive(|| "login-form".to_string())
+                />
+
+                <Show when=move || auth_store_for_view.oauth_error.get().is_some()>
+                    <Alert
+                        test_id=Signal::derive(|| "oauth-error".to_string())
+                        alert_type=Signal::derive(|| AlertType::Error)
+                        message=Signal::derive(move || auth_store_for_view.oauth_error.get().unwrap_or_default())
+                    />
+                </Show>
+
+                <div class="flex items-center gap-4">
+                    <Divider variant=Signal::derive(|| DividerVariant::Single) class=Signal::derive(|| "flex-1".to_string()) test_id=Signal::derive(|| "login-divider-left".to_string()) />
+                    <Text size=TextSize::Small variant=TypographyVariant::Muted class="whitespace-nowrap" test_id=Signal::derive(|| "login-divider-text".to_string())>
+                        {t!(i18n, login.or_login_with)}
+                    </Text>
+                    <Divider variant=Signal::derive(|| DividerVariant::Single) class=Signal::derive(|| "flex-1".to_string()) test_id=Signal::derive(|| "login-divider-right".to_string()) />
+                </div>
+
+                <oauth_buttons::OAuthButtons debug_sink=oauth_debug />
+            </div>
+        }
+        .into_any()
+    };
+
     view! {
         <PageLayout variant=PageLayoutVariant::Full test_id=Signal::derive(|| "login-page".to_string())>
             <CardLayout size=CardLayoutSize::Small class="px-4 pt-4 pb-8" test_id=Signal::derive(|| "login-card".to_string())>
                 <LoginLanguageToggle test_id=Signal::derive(|| "login-lang-toggle".to_string()) />
                 <LoginHeader />
-                <div class="space-y-6">
-                    <PasswordSection
-                        expanded=password_expanded
-                        on_submit=on_email_submit
-                        server_error=server_error
-                        test_id=Signal::derive(|| "login-form".to_string())
-                    />
-
-                    <Show when=move || auth_store_for_view.oauth_error.get().is_some()>
-                        <Alert
-                            test_id=Signal::derive(|| "oauth-error".to_string())
-                            alert_type=Signal::derive(|| AlertType::Error)
-                            message=Signal::derive(move || auth_store_for_view.oauth_error.get().unwrap_or_default())
-                        />
-                    </Show>
-
-                    <div class="flex items-center gap-4">
-                        <Divider variant=Signal::derive(|| DividerVariant::Single) class=Signal::derive(|| "flex-1".to_string()) test_id=Signal::derive(|| "login-divider-left".to_string()) />
-                        <Text size=TextSize::Small variant=TypographyVariant::Muted class="whitespace-nowrap" test_id=Signal::derive(|| "login-divider-text".to_string())>
-                            {t!(i18n, login.or_login_with)}
-                        </Text>
-                        <Divider variant=Signal::derive(|| DividerVariant::Single) class=Signal::derive(|| "flex-1".to_string()) test_id=Signal::derive(|| "login-divider-right".to_string()) />
-                    </div>
-
-                    <oauth_buttons::OAuthButtons debug_sink=oauth_debug />
-                </div>
-
+                {login_body()}
                 {login_footer(oauth_debug)}
             </CardLayout>
         </PageLayout>

--- a/origa_ui/src/pages/login/password_section.rs
+++ b/origa_ui/src/pages/login/password_section.rs
@@ -17,6 +17,7 @@ use super::email_password_form::EmailPasswordForm;
 #[component]
 pub fn PasswordSection(
     #[prop(optional, into)] test_id: Signal<String>,
+    #[prop(optional, into)] loading: Signal<bool>,
     expanded: RwSignal<bool>,
     server_error: RwSignal<Option<String>>,
     on_submit: Callback<(String, String)>,
@@ -59,14 +60,26 @@ pub fn PasswordSection(
         >
             <div class="space-y-4">
                 <EmailPasswordForm
+                    loading=loading
                     on_submit=on_submit
                     server_error=server_error
                     test_id=form_test_id
                 />
                 <button
                     type="button"
-                    class="w-full text-center cursor-pointer"
+                    class=move || {
+                        // Mirror the cursor to the actual disabled state so the
+                        // control doesn't read "clickable" while a request is
+                        // in flight.
+                        let cursor = if loading.get() {
+                            "cursor-not-allowed"
+                        } else {
+                            "cursor-pointer"
+                        };
+                        format!("w-full text-center {}", cursor)
+                    }
                     data-testid=BACK_TEST_ID
+                    disabled=move || loading.get()
                     on:click=move |_: leptos::ev::MouseEvent| {
                         expanded.set(false);
                     }

--- a/origa_ui/src/ui_components/button.rs
+++ b/origa_ui/src/ui_components/button.rs
@@ -69,7 +69,7 @@ pub fn Button(
             }
         >
             <Show when=move || loading.get()>
-                <span class="btn-spinner"></span>
+                <span class="btn-spinner" data-testid="btn-spinner"></span>
             </Show>
             <span class=move || if loading.get() { "btn-text btn-text-hidden" } else { "btn-text" }>
                 {children()}


### PR DESCRIPTION
## Problem

1. **No loader on email/password login** — during submit the user stares at a static form. The auth request is in flight but the button gives no feedback.
2. **Missing divider** — between the header ("Изучайте японский язык") and the "Войти с помощью пароля" toggle there was no separator, unlike the one above the privacy links at the bottom of the card.

## Root cause (loader)

Regression from #289 (collapsible login). Wrapping the form in `PasswordSection` dropped the threading of the `loading` signal: `Login` creates and drives it (`mod.rs`), but it was never passed down. `EmailPasswordForm` instead created its own local `loading` that was **never set to true** — a dead signal — so `Button` (which already supports `btn-spinner` + `disabled`) always saw `false`.

## Changes

- Thread `loading` Login → PasswordSection → EmailPasswordForm (`RwSignal` → `Signal<bool>` via `#[prop(into)]`); the dead local signal is removed.
- Form-level guard against double-submit via Enter while the submit button is disabled.
- Back button is `disabled` with `cursor-not-allowed` during loading.
- Added a `Divider` between the header and the password toggle, matching the legal-links divider (`my-6`, symmetric — `mb-10` removed from `LoginHeader` to avoid margin-collapse asymmetry).
- Body wrapped in an `AnyView` helper (`login_body`) mirroring `login_footer`, per ADR-027 to keep the bin crate under the `recursion_limit` (verified: `cargo check --bin origa_ui_bin` compiles without `queries overflow`).
- Added `data-testid="btn-spinner"` to the `Button` spinner so E2E can target it scoped (not via CSS class).

## E2E

- Regression test for the in-flight state: `page.route` on `**/api/auth/v1/login` with a **manual fulfill gate** (Promise, not a fixed `setTimeout`) → after submit asserts the button is disabled and the spinner is visible, then releases the request and waits for navigation.
- Divider visibility test.

## Verification

| Check | Status |
| --- | --- |
| `cargo clippy -p origa_ui --all-targets -- -D warnings` | ✅ |
| `cargo fmt --check` | ✅ |
| `cargo check --bin origa_ui_bin` (no `queries overflow`) | ✅ |
| `cargo test -p origa_ui` (6 passed) | ✅ |
| `npm run typecheck` (end2end) | ✅ |
| ESLint (end2end) | ✅ |
| E2E `login_ui.spec.ts` (2 passed) | ✅ |
| `qlty fmt` | ✅ |
| Code review (@code-quality-reviewer) | ✅ approve