### PR TITLE
fix(ui): unify CJK on Noto Sans JP, remove Noto Serif JP

### DIFF
--- a/.github/actions/download-cdn/action.yml
+++ b/.github/actions/download-cdn/action.yml
@@ -169,8 +169,8 @@ runs:
         # fallback glyphs (woff2 404). Hashed names are globbed, so a missing
         # deploy or a stale cdn-data cache is caught here.
         FONT_COUNT=$(find cdn/fonts -name '*.woff2' 2>/dev/null | wc -l)
-        if [ "$FONT_COUNT" -lt 8 ]; then
-          echo "ERROR: expected >=8 woff2 in cdn/fonts/, found $FONT_COUNT"
+        if [ "$FONT_COUNT" -lt 7 ]; then
+          echo "ERROR: expected >=7 woff2 in cdn/fonts/, found $FONT_COUNT"
           ERRORS=$((ERRORS + 1))
         fi
         for f in cdn/fonts/noto-*-jp-400-*.woff2; do

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -244,25 +244,32 @@ Origa — минималистичный интерфейс для прилож�
 CSS-переменные задают fallback-цепочку по принципу «Latin-шрифт → CJK-шрифт»:
 
 ```css
---font-serif: "Cormorant Garamond", "Noto Serif JP", serif;
+--font-serif: "Cormorant Garamond", "Noto Sans JP", sans-serif;
 --font-mono: "IBM Plex Mono", "Noto Sans JP", monospace;
 ```
 
 Браузер выбирает шрифт посимвольно: Latin/Cyrillic рендерится
 Cormorant/IBM Plex Mono (включают Latin + Cyrillic глифы), а кандзи/кана
-«проваливаются» к Noto JP через `unicode-range` в `@font-face`. Это критично:
+«проваливается» к **Noto Sans JP** через `unicode-range` в `@font-face`. Это критично:
 Xiaomi MIUI/HyperOS и Android по умолчанию отдают **китайский** CJK-serif
 (например MiSans CJK SC) для общих хань-кандзи — формы штрихов 食/海/語/難
-визуально неправильны для японского. Noto Sans JP / Noto Serif JP дают
-корректные японские формы. Noto JP также использует `font-display: block`,
+визуально неправильны для японского. Noto Sans JP даёт корректные японские
+формы. Noto Sans JP также использует `font-display: block`,
 чтобы до загрузки шрифта браузер не «мигал» китайским системным CJK.
+
+> **Unified CJK (Gothic):** оба стека (`--font-serif` и `--font-mono`)
+> используют единую CJK-семью — **Noto Sans JP**. Ранее `--font-serif`
+> падал на Noto Serif JP (Mincho), а `--font-mono` — на Noto Sans JP (Gothic);
+> это порождало смешение Mincho-кандзи и Gothic-кана в одном слове
+> (display/heading serif + body mono сходились на карточках), что особенно
+> ломало верстку на Xiaomi. Latin-сплит сохранён: Cormorant для serif-элементов,
+> IBM Plex Mono для mono-элементов. Supersedes ADR-028 §font-set.
 
 | Семейство | Назначение | Вара | Покрытие |
 | --------- | ---------- | ---- | -------- |
 | Cormorant Garamond | Display/Heading | 300–700 (variable) + italic | Latin, Latin-Extended, **Cyrillic**, пунктуация |
 | IBM Plex Mono | Body/Label/Mono | 300, 400, 500 + italic 400 | Latin, Latin-Extended (Vietnamese), **Cyrillic**, пунктуация |
-| Noto Serif JP | CJK-fallback для `--font-serif` | 400 (Regular) | кандзи + кана + пунктуация (subset по корпусу приложения) |
-| Noto Sans JP | CJK-fallback для `--font-mono` | 400 (Regular) | кандзи + кана + пунктуация (subset по корпусу приложения) |
+| Noto Sans JP | CJK-fallback для обоих стеков (`--font-serif`, `--font-mono`) | 400 (Regular) | кандзи + кана + пунктуация (subset по корпусу приложения) |
 
 > **Cyrillic support** (ADR-030): Cormorant Garamond и IBM Plex Mono
 > теперь subsetted с Cyrillic диапазоном. Ранее Cyrillic UI-текст рендерился
@@ -273,7 +280,7 @@ Xiaomi MIUI/HyperOS и Android по умолчанию отдают **китай
 - **Display**: Cormorant Garamond, 300,
   clamp(1.75rem, 6vw, 3rem) — H1, hero titles
 - **Heading**: Cormorant Garamond, 400-500,
-  1.25–1.5rem — H2–H6, Japanese text display
+  1.25–1.5rem — H2–H6 (Japanese glyphs → Noto Sans JP, Gothic)
 - **Body**: IBM Plex Mono, 400, 14px —
    Основной текст, описания
 - **Label**: IBM Plex Mono, 400, 11–13px —
@@ -281,9 +288,11 @@ Xiaomi MIUI/HyperOS и Android по умолчанию отдают **китай
 - **Mono**: IBM Plex Mono, 400-500, 13px —
    Код, технические данные
 
-> Noto JP грузится только Regular (400). Если визуальный smoke выявит
-> слишком светлые CJK-заголовки рядом с Cormorant-500, добавляется
-> Medium (500) — задокументировано как follow-up в ADR-028.
+> Noto Sans JP грузится только Regular (400). С унификацией CJK на Gothic
+> (ранее Mincho для serif-стека) риск слишком светлых CJK-глифов рядом с
+> Cormorant-500 ВЫШЕ — Gothic 400 оптически легче Mincho 400. Если визуальный
+> smoke выявит слишком светлые CJK-заголовки, добавляется Medium (500) —
+> задокументировано как follow-up в ADR-028 (теперь приоритетнее).
 
 ### Правила типографики
 
@@ -576,20 +585,27 @@ Badge — это "штамп на полях". Без рамки, приглуш
 
 ```css
 .furigana-ruby {
-  font-family: "Cormorant Garamond", serif;
+  /* font-family inherits the container (serif or mono stack) */
   ruby-align: center;
 }
 
 .furigana-rt {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.5em;
+  /* font-family inherits the container */
+  font-size: 0.6em;
   color: var(--fg-muted);
+}
+
+.furigana-plain {
+  display: inline;
 }
 ```
 
-Основной японский текст — Cormorant Garamond
-(serif создаёт классический вид иероглифов).
-Furigana (ромуадзи/кана) — IBM Plex Mono в 50% размера.
+Фуригана наследует font-family контейнера: в markdown-теле (`--font-mono`)
+кандзи/кана/аннотация — все Noto Sans JP; в заголовках (`--font-serif`) — тоже
+единая семья. Per-glyph резолв через `unicode-range` сохранён. Ранее
+`.furigana-ruby` жёстко задавал serif, а `.furigana-rt` — mono, что порождало
+смешение Mincho-кандзи и Gothic-кана/аннотации в одном слове. Furigana (кана) —
+0.6em от размера базового текста.
 
 ## Animation System
 

--- a/docs/decisions/ADR-028-self-hosted-typography-cjk-fallback.md
+++ b/docs/decisions/ADR-028-self-hosted-typography-cjk-fallback.md
@@ -29,6 +29,14 @@ Accepted
 > justified by correct CJK on the very first launch and offline operation. Web
 > builds are unchanged.
 
+> **Updated (2026-07-31): CJK unified on Noto Sans JP; Noto Serif JP removed.**
+> Both `--font-serif` and `--font-mono` now fall through to a single CJK family
+> — Noto Sans JP (Gothic) — so kanji and kana never mix Mincho/Gothic within a
+> word (the split previously broke Japanese typography on Xiaomi). Noto Serif JP
+> is dropped from `font_face.rs`, `subset_fonts.py`, and `end2end/cdn-manifest.txt`.
+> The Noto Serif JP rows in the font-set table below are historical — see
+> DESIGN.md §Система шрифтов for the current font set.
+
 ## Date
 
 2026-07-03

--- a/docs/decisions/ADR-030-cyrillic-typography-cormorant-subset-ibm-plex-mono.md
+++ b/docs/decisions/ADR-030-cyrillic-typography-cormorant-subset-ibm-plex-mono.md
@@ -4,6 +4,11 @@
 
 Accepted
 
+> **Updated (2026-07-31): CJK regression-guard moved to Noto Sans JP.**
+> `subset_fonts.py::verify_glyph_coverage` now runs the CJK `MUST_HAVE` check
+> against `noto-sans-jp-400-*` (was `noto-serif-jp-400-*`), because Noto Serif JP
+> was removed when CJK was unified on Noto Sans JP — see ADR-028 §Status (2026-07-31).
+
 ## Date
 
 2026-07-07

--- a/end2end/cdn-manifest.txt
+++ b/end2end/cdn-manifest.txt
@@ -963,5 +963,4 @@ fonts/ibm-plex-mono-400-81ddc57a.woff2
 fonts/ibm-plex-mono-400-italic-517950ef.woff2
 fonts/ibm-plex-mono-500-da5700a8.woff2
 fonts/noto-sans-jp-400-a1fd00ef.woff2
-fonts/noto-serif-jp-400-6c031ceb.woff2
 # FONTS-END

--- a/origa_ui/index.html
+++ b/origa_ui/index.html
@@ -15,7 +15,6 @@
         <title>オリガ</title>
 
         <link rel="preload" href="https://s3.origa.uwuwu.net/fonts/noto-sans-jp-400-a1fd00ef.woff2" as="font" type="font/woff2" crossorigin />
-        <link rel="preload" href="https://s3.origa.uwuwu.net/fonts/noto-serif-jp-400-6c031ceb.woff2" as="font" type="font/woff2" crossorigin />
 
         <style>
             /* Boot splash: static HTML visible before WASM instantiates, so the

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -67,7 +67,7 @@
     --space-xxl: 48px;
     --space-xxxl: 64px;
 
-    --font-serif: "Cormorant Garamond", "Noto Serif JP", serif;
+    --font-serif: "Cormorant Garamond", "Noto Sans JP", sans-serif;
     --font-mono: "IBM Plex Mono", "Noto Sans JP", monospace;
 
     /* Rounded */
@@ -1698,12 +1698,10 @@ input[type="submit"],
 }
 
 .furigana-ruby {
-    font-family: var(--font-serif);
     ruby-align: center;
 }
 
 .furigana-rt {
-    font-family: var(--font-mono);
     font-size: 0.6em;
     color: var(--fg-muted);
 }
@@ -1716,7 +1714,7 @@ rt {
 }
 
 .furigana-plain {
-    font-family: var(--font-serif);
+    display: inline;
 }
 
 .furigana-hidden .furigana-rt {

--- a/origa_ui/src/ui_components/font_face.rs
+++ b/origa_ui/src/ui_components/font_face.rs
@@ -111,14 +111,6 @@ const FACES: &[FaceSpec] = &[
         display: "block",
         unicode_range: CJK_RANGE,
     },
-    FaceSpec {
-        logical: "noto-serif-jp-400",
-        family: "Noto Serif JP",
-        weight: "400",
-        style: "normal",
-        display: "block",
-        unicode_range: CJK_RANGE,
-    },
 ];
 
 /// Inject the `@font-face` stylesheet into `document.head`.

--- a/scripts/subset_fonts.py
+++ b/scripts/subset_fonts.py
@@ -82,14 +82,6 @@ SOURCES: tuple[Source, ...] = (
         extract_glob="NotoSansJP-Regular.otf",
     ),
     Source(
-        logical="noto-serif-jp-400",
-        url="https://github.com/notofonts/noto-cjk/releases/download/Serif2.003/12_NotoSerifJP.zip",
-        sha256="53bdd2a6e4eb63bf24f7890e018dddb94366e3555d0814c72b74fbb128f328f0",
-        kind="cjk",
-        archive="NotoSerifJP.zip",
-        extract_glob="**/NotoSerifJP-Regular.otf",
-    ),
-    Source(
         logical="cormorant-garamond",
         url="https://raw.githubusercontent.com/google/fonts/main/ofl/cormorantgaramond/CormorantGaramond%5Bwght%5D.ttf",
         sha256="b20b7d9626dd956b2c5e558692ad328b1f19e3275e2782db4fa07670d83f35e0",
@@ -296,7 +288,7 @@ def main() -> None:
     for src in SOURCES:
         try:
             source_path = ensure_source(src)
-        except (subprocess.CalledProcessError, OSError) as e:
+        except (subprocess.CalledProcessError, OSError):
             # Transient network failure (e.g. release-assets.githubusercontent.com
             # blocked). Preserve any existing woff2 for this logical name so the
             # CDN/font registry stays consistent; the source can be re-fetched
@@ -336,7 +328,7 @@ CYRILLIC_MUST_HAVE = "АаБбВвГгДдЕеЁёЖжЗзИиЙйКкЛлМмН
 def verify_glyph_coverage() -> None:
     from fontTools.ttLib import TTFont
 
-    noto = next(FONTS_OUT.glob("noto-serif-jp-400-*.woff2"))
+    noto = next(FONTS_OUT.glob("noto-sans-jp-400-*.woff2"))
     cmap = TTFont(noto).getBestCmap()
     missing = [c for c in MUST_HAVE if ord(c) not in cmap]
     if missing:


### PR DESCRIPTION
## Problem

Kanji and kana resolved to **different Noto JP families** (Mincho via `--font-serif`, Gothic via `--font-mono`) whenever a serif-styled element met a mono container — most visibly furigana inside markdown body:

```
存(Mincho) ずる(Gothic)   ← one word, two typefaces
```

This is broken Japanese typography (Japanese never mixes Mincho kanji with Gothic kana in a single word) and looks especially broken on Xiaomi MIUI/HyperOS.

Root cause: `font_face.rs` registered both Noto Serif JP and Noto Sans JP on the same `CJK_RANGE`, so the browser picked Mincho-vs-Gothic **solely** by the element's `font-family` (serif vs mono). The two stacks diverged, and serif/mono elements coexist on cards.

## Fix

**Unify both stacks on Noto Sans JP (Gothic):**

```css
--font-serif: "Cormorant Garamond", "Noto Sans JP", sans-serif;
--font-mono:  "IBM Plex Mono", "Noto Sans JP", monospace;
```

Every CJK glyph now resolves to one family regardless of element. The **Latin split is preserved** via `unicode-range` (Cormorant for display/headings, IBM Plex Mono for body/UI).

Plus **defense-in-depth**: furigana classes (`.furigana-ruby` / `.furigana-rt` / `.furigana-plain`) no longer hard-code a family — they inherit the container, so a future stack re-split can't silently reintroduce the mix.

**Drop Noto Serif JP entirely** (was now dead weight): `font_face.rs`, `subset_fonts.py`, `cdn-manifest.txt`, `index.html` preload, CI font-count assert. Removes ~1.9 MB of dead cold-start payload.

## Changes

| File | Change |
|---|---|
| `origa_ui/input.css` | `--font-serif` CJK fallback → Noto Sans JP; furigana classes inherit container |
| `origa_ui/index.html` | drop `noto-serif-jp` preload |
| `origa_ui/src/ui_components/font_face.rs` | drop `noto-serif-jp` FaceSpec |
| `scripts/subset_fonts.py` | drop Source; CJK coverage check → `noto-sans-jp` |
| `end2end/cdn-manifest.txt` | drop noto-serif-jp line |
| `.github/actions/download-cdn/action.yml` | font-count assert 8 → 7 |
| `DESIGN.md` | unified CJK model |
| `ADR-028`, `ADR-030` | §Status amendment notes (precedent pattern) |

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p origa --lib furigana` → 43 passed ✅
- `cargo test -p origa_ui --lib` → 292 passed ✅ (incl. `cjk_faces_block_to_avoid_wrong_glyph_flash`)
- build registers **7 fonts** (was 8) ✅
- `qlty check` → No issues ✅
- grep: 0 references to `noto-serif-jp`/`Noto Serif JP` in code/build/CI/runtime (only in immutable ADR bodies + their §Status notes)

## Notes / out of scope

- **Visual change:** display/heading kanji render in Gothic instead of Mincho. Accepted trade-off for consistency + better small-size legibility on the dense UI. If Gothic 400 looks too light next to Cormorant 500, Noto Sans JP Medium (500) is a documented follow-up (DESIGN.md note, now higher priority).
- `multi_line_chart.rs` SVG labels (`font_family="IBM Plex Mono"`, Latin-only) — out of scope; class-refactor needed for var() support.
- Boot splash `オリガ` (transient <1s pre-WASM, can't use CDN fonts at first paint) — out of scope.
- S3 orphan `noto-serif-jp` object remains (harmless, unreferenced); local `cdn/fonts/` mirror cleaned.