### PR TITLE
fix(macos): Speech/Microphone usage strings + RuStore stable-only

### DIFF
--- a/.github/workflows/_upload-rustore.yml
+++ b/.github/workflows/_upload-rustore.yml
@@ -2,6 +2,9 @@ name: Upload to RuStore
 
 # Reusable workflow for uploading signed AAB to RuStore via Public API.
 # Called from tauri.yml after build-tauri succeeds on tag pushes.
+# STABLE-ONLY contract: prerelease (RC) and alpha are gated out by the caller
+# (tauri.yml upload-rustore if-clause); this workflow also self-gates on
+# inputs.version_type == 'stable'.
 #
 # Flow:
 #   1. POST /public/auth/ — exchange signed keyId+timestamp for JWE token (15 min TTL)
@@ -44,7 +47,7 @@ permissions:
 
 jobs:
     upload:
-        if: inputs.version_type == 'stable' || inputs.version_type == 'prerelease'
+        if: inputs.version_type == 'stable'
         runs-on: ubuntu-latest
         env:
             PACKAGE_NAME: net.uwuwu.origa

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -123,8 +123,8 @@ jobs:
     build-apple:
         name: Build Apple (iOS + macOS)
         # Apple builds use expensive macOS runners (~30 min/target).
-        # Gate on tag push (stable/prerelease) like upload-rustore, so
-        # workflow_dispatch runs do NOT consume macOS minutes.
+        # Gate on tag push (stable/prerelease), so workflow_dispatch runs do
+        # NOT consume macOS minutes.
         # Set `force_apple: true` in workflow_dispatch inputs to override
         # for manual testing / debugging.
         if: >
@@ -299,16 +299,20 @@ jobs:
 
     upload-rustore:
         name: Upload to RuStore
-        # Independent of release: failure does NOT block GitHub Release.
-        # Continue-on-error semantics during burn-in — RuStore API has multiple
-        # hard requirements (signing cert in Console, no stale drafts, version
-        # bump) that may not be met on first run. Soft-fail until stable.
+        # Stable-only: only v*.*.* stable tags publish to RuStore; prerelease
+        # (RC) and alpha are intentionally excluded — RC still ships to GitHub
+        # Release via the `release` job.
+        #
+        # Intentionally NOT a dependency of `release`: this job is absent from
+        # release.needs ([version, build-tauri, build-apple, generate-latest-json]).
+        # Transient RuStore failures (network, stale drafts, moderation quirks)
+        # even on a stable release MUST NOT block the GitHub Release.
+        # Do NOT add upload-rustore to release.needs — that regresses isolation.
         if: >
             always() &&
             needs.build-tauri.result == 'success' &&
             startsWith(github.ref, 'refs/tags/v') &&
-            (needs.version.outputs.version_type == 'stable' ||
-             needs.version.outputs.version_type == 'prerelease')
+            needs.version.outputs.version_type == 'stable'
         needs: [version, build-tauri]
         uses: ./.github/workflows/_upload-rustore.yml
         with:

--- a/tauri/MacOS-Info.plist
+++ b/tauri/MacOS-Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Origa recognizes Japanese speech to transcribe audio input.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Origa records audio to transcribe Japanese speech.</string>
+</dict>
+</plist>

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -45,7 +45,8 @@
         },
         "macOS": {
             "entitlements": "Entitlements.plist",
-            "minimumSystemVersion": "13.0"
+            "minimumSystemVersion": "13.0",
+            "infoPlist": "MacOS-Info.plist"
         }
     },
     "plugins": {


### PR DESCRIPTION
## Summary

Two unrelated changes that happened to be in the working tree together.

### 1. macOS Info.plist usage strings (App Store ITMS-90683)

Build 0.4.10 was rejected: the app references the Speech framework
(`SFSpeechRecognizer`) via the **device-ai plugin**, so Apple requires
`NSSpeechRecognitionUsageDescription` in `Origa.app/Contents/Info.plist` —
even though Origa itself does not call speech APIs directly (libraries that
reference them still need a purpose string).

- Add `tauri/MacOS-Info.plist` with `NSSpeechRecognitionUsageDescription`
  and `NSMicrophoneUsageDescription` (live speech input).
- Wire via `bundle.macOS.infoPlist` — Tauri v2 **merges** this with the
  generated Info.plist (not replaces — per official docs).
- iOS `project.yml` already carries both keys.

### 2. RuStore: publish only stable tags

`upload-rustore` now self-gates on `version_type == 'stable'` (RC/prerelease
excluded). RC still ships via the GitHub Release job, which is independent of
`upload-rustore` (intentionally NOT in `release.needs`).

## Verification
- `cargo check -p origa-app` — passes (tauri.conf.json valid, infoPlist path resolves).
- macOS bundle generation is a release-step (no PR CI for it); the merge semantics are confirmed by Tauri v2 docs (`infoPlist`: *Path to a Info.plist file to merge with the default Info.plist*).

🤖 Generated autonomously.