### PR TITLE
feat(sentry): integrate error monitoring (native Rust + WASM)

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -73,6 +73,11 @@ jobs:
             ORIGA_VERSION: ${{ inputs.version }}
             ORIGA_COMMIT: ${{ inputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ inputs.build_date }}
+            # Sentry (ADR-036): single DSN shared by both layers; the `layer`
+            # scope tag distinguishes tauri-native from ui-wasm events.
+            # Empty/unset = Sentry disabled (dev, Dependabot).
+            SENTRY_DSN: ${{ vars.SENTRY_DSN }}
+            SENTRY_ENVIRONMENT: ${{ inputs.version_type == 'stable' && 'production' || inputs.version_type == 'prerelease' && 'staging' || 'development' }}
 
         steps:
             - name: Checkout repository
@@ -231,6 +236,11 @@ jobs:
             ORIGA_VERSION: ${{ inputs.version }}
             ORIGA_COMMIT: ${{ inputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ inputs.build_date }}
+            # Sentry (ADR-036): single DSN shared by both layers; the `layer`
+            # scope tag distinguishes tauri-native from ui-wasm events.
+            # Empty/unset = Sentry disabled (dev, Dependabot).
+            SENTRY_DSN: ${{ vars.SENTRY_DSN }}
+            SENTRY_ENVIRONMENT: ${{ inputs.version_type == 'stable' && 'production' || inputs.version_type == 'prerelease' && 'staging' || 'development' }}
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -74,6 +74,11 @@ jobs:
             ORIGA_VERSION: ${{ inputs.version }}
             ORIGA_COMMIT: ${{ inputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ inputs.build_date }}
+            # Sentry (ADR-036): single DSN shared by both layers; the `layer`
+            # scope tag distinguishes tauri-native from ui-wasm events.
+            # Empty/unset = Sentry disabled (dev, Dependabot).
+            SENTRY_DSN: ${{ vars.SENTRY_DSN }}
+            SENTRY_ENVIRONMENT: ${{ inputs.version_type == 'stable' && 'production' || inputs.version_type == 'prerelease' && 'staging' || 'development' }}
             # Skip updater signing for Dependabot PRs. GitHub hides repository
             # `secrets.*` from Dependabot runs, but caller workflows pass a
             # dummy private key via `vars.TAURI_CI_DUMMY_PRIVATE_KEY` (vars are
@@ -186,6 +191,9 @@ jobs:
             ORIGA_VERSION: ${{ inputs.version }}
             ORIGA_COMMIT: ${{ inputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ inputs.build_date }}
+            # Sentry (ADR-036): see build-windows for rationale.
+            SENTRY_DSN: ${{ vars.SENTRY_DSN }}
+            SENTRY_ENVIRONMENT: ${{ inputs.version_type == 'stable' && 'production' || inputs.version_type == 'prerelease' && 'staging' || 'development' }}
             # Skip updater signing for Dependabot PRs — see build-windows for
             # the full rationale.
             TAURI_SIGNING_PRIVATE_KEY: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key || '' }}
@@ -286,6 +294,9 @@ jobs:
             ORIGA_VERSION: ${{ inputs.version }}
             ORIGA_COMMIT: ${{ inputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ inputs.build_date }}
+            # Sentry (ADR-036): see build-windows for rationale.
+            SENTRY_DSN: ${{ vars.SENTRY_DSN }}
+            SENTRY_ENVIRONMENT: ${{ inputs.version_type == 'stable' && 'production' || inputs.version_type == 'prerelease' && 'staging' || 'development' }}
             # NDK r26b exact version. Single source of truth — referenced by both
             # the sdkmanager `packages` input and the NDK env-var derivation below.
             NDK_VERSION: '26.1.10909125'

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -53,6 +53,14 @@ jobs:
             ORIGA_VERSION: ${{ needs.version.outputs.version }}
             ORIGA_COMMIT: ${{ needs.version.outputs.commit_sha }}
             ORIGA_BUILD_DATE: ${{ needs.version.outputs.build_date }}
+            # Sentry: single DSN shared by both layers (native + WASM); the
+            # `layer` scope tag distinguishes them inside the one Sentry
+            # project. Empty/unset = Sentry disabled (dev, Dependabot).
+            # `SENTRY_ENVIRONMENT` is derived from `version_type` so that
+            # stable releases land in `production`, prereleases in `staging`,
+            # and master/branch builds in `development`. See ADR-036.
+            SENTRY_DSN: ${{ vars.SENTRY_DSN }}
+            SENTRY_ENVIRONMENT: ${{ needs.version.outputs.version_type == 'stable' && 'production' || needs.version.outputs.version_type == 'prerelease' && 'staging' || 'development' }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,16 @@ cd tauri && cargo tauri dev
 ### Переменные окружения (compile-time, `build.rs`)
 
 Обязательные: `ORIGA_CDN_BASE_URL`.
-Опциональные: `ORIGA_CDN_REGION`, `ORIGA_VERSION`, `ORIGA_COMMIT`, `ORIGA_BUILD_DATE`, `TRAILBASE_URL`, `ORIGA_LANDING_BASE_URL`.
+Опциональные: `ORIGA_CDN_REGION`, `ORIGA_VERSION`, `ORIGA_COMMIT`, `ORIGA_BUILD_DATE`, `TRAILBASE_URL`, `ORIGA_LANDING_BASE_URL`, `SENTRY_DSN`, `SENTRY_ENVIRONMENT`.
+
+**Sentry** (ADR-036): единый `SENTRY_DSN` пробрасывается во все build-скрипты; пустой/не задан = Sentry отключен. `SENTRY_ENVIRONMENT` маппится в CI из `version_type` (`stable`→`production`, `prerelease`→`staging`, иначе `development`). `SENTRY_RELEASE` выводится из `ORIGA_VERSION` (отдельная CI-переменная не нужна). Локально для теста Sentry:
+
+```powershell
+$env:SENTRY_DSN = "https://<public_key>@o<orgid>.ingest.sentry.io/<projectid>"
+$env:SENTRY_ENVIRONMENT = "development"
+$env:ORIGA_CDN_BASE_URL = "https://s3.origa.uwuwu.net"
+cd tauri && cargo tauri dev
+```
 
 **DNS naming scheme** (CI/CD production):
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,163 @@
 version = 4
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "bitflags 2.11.0",
+ "bytes",
+ "bytestring",
+ "derive_more 2.1.1",
+ "encoding_rs",
+ "foldhash 0.2.0",
+ "futures-core",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.12",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "derive_more 2.1.1",
+ "encoding_rs",
+ "foldhash 0.2.0",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.6.3",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,7 +616,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -493,7 +650,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -502,6 +659,21 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -723,6 +895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +979,12 @@ dependencies = [
  "serde",
  "toml 0.9.12+spec-1.1.0",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -1090,6 +1277,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1484,6 +1680,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "default-struct-builder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,10 +1802,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2149,6 +2357,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixed_decimal"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +2774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,7 +2874,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 1.4.0",
  "js-sys",
  "pin-project",
  "serde",
@@ -2849,6 +3075,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +3145,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2923,7 +3171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2934,7 +3182,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -2983,7 +3231,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -3001,7 +3249,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -3022,14 +3270,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3809,6 +4057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
+name = "impl-more"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,6 +4321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4105,7 +4365,7 @@ dependencies = [
  "oco_ref",
  "or_poisoned",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.5",
  "reactive_graph",
  "rustc-hash",
  "rustc_version",
@@ -4608,6 +4868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4844,6 +5110,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4872,6 +5148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -4916,7 +5193,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 1.4.0",
  "httparse",
  "memchr",
  "mime",
@@ -5040,6 +5317,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5142,6 +5431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5334,6 +5624,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-media"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5513,8 +5813,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -5561,6 +5880,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oco_ref"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5581,6 +5909,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
@@ -5696,7 +6030,7 @@ dependencies = [
  "ndarray 0.17.2",
  "ort",
  "ort-web",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rkyv",
  "rs-fsrs",
  "rstest",
@@ -5723,6 +6057,7 @@ dependencies = [
  "base64 0.22.1",
  "device-ai",
  "rustls",
+ "sentry",
  "serde",
  "serde_json",
  "tauri",
@@ -5745,7 +6080,7 @@ version = "0.1.0"
 dependencies = [
  "ammonia",
  "axum",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "leptos",
  "leptos_axum",
@@ -5793,7 +6128,7 @@ dependencies = [
  "lindera-dictionary",
  "origa",
  "pulldown-cmark",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rstest",
  "scraper",
  "serde",
@@ -5810,6 +6145,7 @@ dependencies = [
  "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 
@@ -5852,6 +6188,22 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6557,7 +6909,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6574,7 +6926,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6595,7 +6947,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6679,9 +7031,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6804,7 +7156,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -6986,6 +7338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7017,7 +7375,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -7054,9 +7412,10 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -7222,6 +7581,12 @@ dependencies = [
  "cfg-if",
  "ordered-multimap",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -7562,6 +7927,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentry"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e4790d8c2f43a6645ee2cb12aac2db79221fddd035b94c8166b88ea094408"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest 0.13.2",
+ "rustls",
+ "sentry-actix",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-actix"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a12b26925e70eba6c346588650f8b346d9e78a83249970b706068456005cd61"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "futures-util",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "326e106874a7ea90636f1ca42e2f7b912929d29307982cab37f81208c16cf043"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab62ebc8076326e509c71a7424d2aaeff63fba9bc4e5b55074cd33f356c759f"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9efafefbb78d7e02cb06c10aec08b77e7500428389eabbf6d5a668325265e8"
+dependencies = [
+ "rand 0.9.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee1e7c19e715ae9538114bbd09c2442689a481e2adbc8245c9e06b20d2bd2be"
+dependencies = [
+ "findshlibs",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fc536a3e1fc68d626ae8dd18b628cafd474d9d36fea74e4bbb4d038877f003"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96be2253fe14b3fa10c1ba047af2d3e58ce85c8cb297bbd19d6fa81b604e7877"
+dependencies = [
+ "bitflags 2.11.0",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f967748632cd4c5405dbed45426b27b407c0e53ac59b7df1c163e7f5aa57a77c"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7814,7 +8301,7 @@ dependencies = [
  "const_format",
  "futures",
  "gloo-net",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "hyper",
  "inventory",
@@ -7987,6 +8474,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8392,7 +8889,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http",
+ "http 1.4.0",
  "jni",
  "libc",
  "log",
@@ -8642,7 +9139,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures-util",
- "http",
+ "http 1.4.0",
  "infer",
  "log",
  "minisign-verify",
@@ -8674,7 +9171,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http",
+ "http 1.4.0",
  "jni",
  "objc2",
  "objc2-ui-kit",
@@ -8697,7 +9194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
- "http",
+ "http 1.4.0",
  "jni",
  "log",
  "objc2",
@@ -8730,7 +9227,7 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever 0.29.1",
- "http",
+ "http 1.4.0",
  "infer",
  "json-patch",
  "kuchikiki",
@@ -8952,7 +9449,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9149,7 +9646,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -9321,10 +9818,10 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "sha1",
  "thiserror 2.0.18",
 ]
@@ -9390,9 +9887,18 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
  "web-time",
+]
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -9539,7 +10045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -9803,6 +10309,45 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "wasm-encoder"
@@ -10743,7 +11288,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http",
+ "http 1.4.0",
  "javascriptcore-rs",
  "jni",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,20 @@ tracing = "0.1"
 tracing-wasm = "0.2"
 tracing-subscriber = "0.3"
 
+# Crash reporting — rustls-only (no native-tls/openssl), reuses the ring
+# crypto provider that tauri installs in `run()`. See ADR-036 for the
+# rationale behind `default-features = false` (avoids the `transport`
+# feature pulling in `native-tls` and breaking the Android build).
+sentry = { version = "0.49", default-features = false, features = [
+    "rustls-no-provider",
+    "panic",
+    "backtrace",
+    "contexts",
+    "release-health",
+    "reqwest",
+    "debug-images",
+] }
+
 # Domain
 ulid = { version = "1.2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/decisions/ADR-036-sentry-integration.md
+++ b/docs/decisions/ADR-036-sentry-integration.md
@@ -162,18 +162,28 @@ mitigation with a regression test.
 `tauri/build_config.rs::build_csp` and `tauri/tauri.conf.json` add:
 
 - `script-src`: `https://js.sentry-cdn.com` (loader script host)
-- `connect-src`: `https://*.ingest.sentry.io` (envelope submission)
+- `connect-src`: `https://<ingest_host>` (envelope submission, pinned)
 
-`*.ingest.sentry.io` is a wildcard because the ingest subdomain is
-`o<orgid>.ingest.sentry.io`, and `orgid` is part of the DSN. A future Sentry
-project migration would change the org id and require a CSP edit if the host
-were pinned. The wildcard is the lower-maintenance choice; the surface area
-is Sentry's own SaaS infrastructure.
+The ingest host is **extracted from the DSN at build time** by
+`build_config::extract_sentry_ingest_host` and parameterised into
+`build_csp`. The default (used when `SENTRY_DSN` is unset, e.g. local dev)
+is `DEFAULT_SENTRY_INGEST_HOST`, pinned to the production project's exact
+host.
+
+**Why pin and not `*.sentry.io` wildcard?** `sentry.io` is a multi-tenant
+SaaS domain: anyone can create a free Sentry account and receive an
+`<orgid>.ingest.sentry.io` subdomain. A wildcard `connect-src` would allow
+the WebView to POST to **any** Sentry project, including attacker-controlled
+ones — a data exfiltration vector post-XSS. CSP3 §8.6 explicitly warns about
+this class. The cost of pinning (a CSP edit on the rare Sentry project /
+region migration) is negligible vs a permanent exfil surface.
 
 `build_csp_with_production_defaults_matches_committed_tauri_conf` and
 `build_csp_substitutes_staging_hosts` in `tauri/tests/build_config.rs`
 enforce byte-equality between the template and the committed `tauri.conf.json`
-and pin the Sentry hosts in staging builds (drift guards).
+and assert the staging build carries the staging ingest host (not a
+wildcard, not the production host). `extract_sentry_ingest_host` is covered
+by five unit tests (US DSN, EU DSN, malformed variants, empty input).
 
 ### 8. CI/CD wiring
 

--- a/docs/decisions/ADR-036-sentry-integration.md
+++ b/docs/decisions/ADR-036-sentry-integration.md
@@ -1,0 +1,285 @@
+# ADR-036: Sentry error monitoring integration
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-01
+
+## Context
+
+Origa is shipped to end users on five targets (Windows, Linux, macOS, iOS,
+Android) plus a WASM frontend running inside the Tauri WebView. Production
+crashes — native Rust panics in the tauri layer, JS/WASM exceptions in the UI
+layer — were invisible: no stack traces, no reproduction steps, no aggregate
+view of "which crash affects the most users". The repo has no error-reporting
+infrastructure at all.
+
+This ADR records the design decisions for the initial Sentry (SaaS) rollout:
+which Sentry SDKs are wired into which layer, how the DSN is delivered to each
+layer, which feature flags are enabled, how the CSP is updated, and which
+plumbing is intentionally deferred to a follow-up PR.
+
+The rollout targets a **single Sentry project** with a `layer` scope tag
+(`tauri` vs `ui`) distinguishing the two layers. This avoids the operational
+overhead of two projects (separate quota, separate dashboards, separate
+release-health views) while preserving the ability to filter by layer.
+
+## Decision
+
+### 1. Two Sentry SDKs, one project
+
+| Layer | SDK | Mechanism |
+| --- | --- | --- |
+| `tauri/` (native Rust) | [`sentry` Rust crate](https://crates.io/crates/sentry) 0.49 | `sentry::init` in `tauri/src/lib.rs::run()`; `sentry-panic` integration auto-installs the panic hook. |
+| `origa_ui/` (WASM / JS) | [Sentry JavaScript loader](https://docs.sentry.io/platforms/javascript/install/loader/) | Loader script (`js.sentry-cdn.com`) injected dynamically from WASM via `web_sys` at `init_tracing()`; `window.sentryOnLoad` configures the SDK. |
+
+The Rust `sentry` crate does not compile to WASM, and there is no
+pure-Rust Sentry client that targets WASM, so the WASM layer uses the official
+JS SDK.
+
+### 2. Feature set for the Rust crate
+
+```toml
+sentry = { version = "0.49", default-features = false, features = [
+    "rustls-no-provider", "panic", "backtrace", "contexts",
+    "release-health", "reqwest", "debug-images",
+] }
+```
+
+`default-features = false` is required because the default `transport` feature
+pulls in `native-tls` → `openssl-sys`, which (a) violates the rustls-only
+policy of the workspace and (b) breaks the Android cross-compile pipeline
+(no OpenSSL sysroot in the NDK setup). The `reqwest` feature is sufficient:
+`apply_defaults` in `sentry::init` registers `DefaultTransportFactory`
+unconditionally, and that factory selects the reqwest backend when the
+`reqwest` feature is on. `transport` is a convenience alias for `reqwest +
+native-tls` and is therefore not used.
+
+`rustls-no-provider` (not `rustls`) reuses the ring crypto provider that
+`tauri/src/lib.rs::run()` installs as its first statement. Using `rustls`
+would bring a second crypto provider (`aws-lc-rs`) into the dependency tree
+and risk a runtime "no process-level CryptoProvider" panic if the order ever
+changes. `rustls-no-provider` makes the load-bearing dependency on
+`tauri/Cargo.toml`'s `rustls = { features = ["ring"] }` explicit: removing
+that line silently breaks Sentry transport.
+
+`metrics`, `logs`, `debug-images` (default-on but `metrics`/`logs` disabled
+here) are out of scope for the initial rollout: this PR captures errors only.
+`debug-images` IS enabled: it attaches the loaded-module list to native
+events, which Sentry uses for crash grouping/correlation even before symbol
+upload is configured (see §6).
+
+### 3. DSN delivery
+
+A single `SENTRY_DSN` env var is exposed by CI (`vars.SENTRY_DSN`, NOT a
+secret — the public DSN key is shipped in the client binary by design). Each
+build script reads it and re-emits under a crate-scoped name:
+
+| Build script | Emits | Read by |
+| --- | --- | --- |
+| `tauri/build.rs` | `SENTRY_DSN_TAURI`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` | `tauri/src/lib.rs::init_sentry` via `env!()` |
+| `origa_ui/build.rs` | `SENTRY_DSN_UI`, `SENTRY_ENVIRONMENT_UI`, `SENTRY_RELEASE_UI` | `origa_ui/src/sentry.rs` via `env!()` |
+
+`SENTRY_RELEASE` is derived from `ORIGA_VERSION` in both build scripts (not a
+separate CI var), so native and WASM layers cannot drift on release name.
+
+Env-var reads use `env::var()` + `cargo:rustc-env` + `cargo:rerun-if-env-changed`
+(NOT `option_env!`): `option_env!` captures at build-script compile time and
+its value is not invalidated by `rerun-if-env-changed`, so cached build-script
+binaries (CI uses `Swatinem/rust-cache`) would silently retain stale values.
+This is the same pattern ADR-024 established for `ORIGA_CDN_BASE_URL` /
+`TRAILBASE_URL`. Empty/unset DSN = Sentry disabled at runtime (`init_sentry`
+returns `None`; `sentry::init` does likewise in WASM).
+
+### 4. WASM loader injection (not hardcoded `index.html`)
+
+`origa_ui/index.html` is **not modified**: build scripts must not mutate
+committed source files (Cargo contract, ADR-009). Instead, the loader script
+is injected dynamically from WASM at `init_tracing()`:
+
+1. `window.sentryOnLoad = function() { Sentry.init({dsn, release, environment, ...}); }`
+   is installed via `js_sys::eval` BEFORE the loader script is appended, so
+   the loader invokes it even when it loads synchronously from HTTP cache.
+2. `<script src="https://js.sentry-cdn.com/{public_key}.min.js" crossorigin="anonymous">`
+   is appended to `<head>` via `web_sys::Document::create_element`.
+
+The public key is extracted from the DSN by `extract_public_key` (string
+split, no Sentry crate dependency in WASM).
+
+**Trade-off:** JS errors that occur before WASM instantiates are not
+captured. These are rare (they would mostly be "WASM failed to instantiate"
+errors, which cannot be reported by client-side code anyway) and the
+alternative — hardcoding the DSN in `index.html` — was rejected because it
+loses dev/Dependabot gating and reintroduces the Cargo-contract question of
+how to parameterise a committed file.
+
+### 5. WASM panic bridge
+
+`origa_ui/src/lib.rs::init_tracing` wraps `console_error_panic_hook`:
+
+```rust
+console_error_panic_hook::set_once();   // install console hook
+let console_hook = std::panic::take_hook(); // take it
+std::panic::set_hook(Box::new(move |info| {
+    sentry::capture_exception(&info.to_string()); // forward to Sentry
+    console_hook(info);                            // then console fallback
+}));
+sentry::init(); // inject loader
+```
+
+`sentry::capture_exception` is **defensive** — it is called on every WASM
+panic, including the disabled path (no loader, `window.Sentry` is
+`undefined`). Every JS call is wrapped; any failure is silently dropped so
+the console fallback hook still runs.
+
+### 6. `default_integrations = true` (no custom panic hook)
+
+The native Rust layer uses the default integrations (backtrace, contexts,
+debug-images, panic, release-health). The `sentry-panic` integration
+installs a panic hook that calls `client.flush(None)` synchronously inside
+the hook before returning.
+
+**Trade-off accepted:** `flush(None)` is bounded by the OS TCP connect/read
+timeout (~20-75s), not infinite. With `panic = "abort"` in the release
+profile, abort fires only after the panic hook returns. This means a panic
+on a slow/offline network may visually freeze the app for tens of seconds
+before exit. Alternative considered: `default_integrations = false` + manual
+registration of the four non-panic integrations + a custom panic hook with
+bounded `flush(Some(Duration::from_secs(2)))`. **Rejected** for the initial
+rollout because (a) it adds complexity (manual integration registration with
+version-specific type paths that may regress on a `sentry` crate bump), (b)
+the panic situation already means the app is dying — the marginal UX
+difference between "freezes 30s then exits" and "exits immediately" is small
+for the user, who must restart either way, (c) if it proves painful in
+production, a follow-up PR can introduce the custom hook as a targeted
+mitigation with a regression test.
+
+### 7. CSP update
+
+`tauri/build_config.rs::build_csp` and `tauri/tauri.conf.json` add:
+
+- `script-src`: `https://js.sentry-cdn.com` (loader script host)
+- `connect-src`: `https://*.ingest.sentry.io` (envelope submission)
+
+`*.ingest.sentry.io` is a wildcard because the ingest subdomain is
+`o<orgid>.ingest.sentry.io`, and `orgid` is part of the DSN. A future Sentry
+project migration would change the org id and require a CSP edit if the host
+were pinned. The wildcard is the lower-maintenance choice; the surface area
+is Sentry's own SaaS infrastructure.
+
+`build_csp_with_production_defaults_matches_committed_tauri_conf` and
+`build_csp_substitutes_staging_hosts` in `tauri/tests/build_config.rs`
+enforce byte-equality between the template and the committed `tauri.conf.json`
+and pin the Sentry hosts in staging builds (drift guards).
+
+### 8. CI/CD wiring
+
+A single `vars.SENTRY_DSN` is exposed to all build jobs. `SENTRY_ENVIRONMENT`
+is derived from `version_type`:
+
+| `version_type` | `SENTRY_ENVIRONMENT` |
+| --- | --- |
+| `stable` | `production` |
+| `prerelease` | `staging` |
+| (other: master, dev, branch) | `development` |
+
+The mapping is inlined as a GitHub Actions expression in each job's `env:`
+block, applied in: `tauri.yml::build-frontend`, `_build-tauri.yml::build-{windows,linux,android}`,
+`_build-tauri-apple.yml::build-{ios,macos}`.
+
+## Verification coverage
+
+- **Pure helpers** (`extract_public_key`) are covered by host-side `#[test]`
+  unit tests in `origa_ui/src/sentry.rs`.
+- **CSP wiring** is covered by drift-guard tests in
+  `tauri/tests/build_config.rs` (byte-equality + staging Sentry hosts).
+- **Build-script wiring** (env → `cargo:rustc-env`) is NOT covered by
+  `cargo test` — build scripts are not unit-tested (architectural limit,
+  same gap as for all other build-script env vars in the project). Drift
+  guards on the build_config constants protect the values.
+- **`init_sentry` / `init_with` runtime behaviour** (DSN parse, scope tag,
+  loader injection, panic hook) is **manual-check only** — requires a live
+  Sentry DSN and a running app. The Slice 4 root-store smoke-test (below)
+  covers the "does an event actually reach Sentry UI" path.
+
+## Slice 4 verification
+
+- `cargo tree -e features -i tokio` — confirms the sentry transport's tokio
+  runtime doesn't unexpectedly enable `rt-multi-thread` in the workspace.
+- `cargo tree -i reqwest` — confirms two reqwest versions are present
+  (`0.12.x` workspace + `0.13.2` sentry) and quantifies the binary-size
+  overhead.
+- Binary size delta (before/after) measured on a release build for each
+  mobile target where size matters for store review.
+- **Root-store smoke-test**: build with a real DSN, run the binary, trigger a
+  test panic, verify the event appears in the Sentry UI within ~30s. This is
+  the only way to confirm that the `rustls-no-provider` feature, the ring
+  provider installed by tauri, and reqwest's root-store chain combine into a
+  working TLS handshake to `*.ingest.sentry.io`. UNVERIFIED offline — must
+  be done manually before merging the release tag that ships this.
+
+## Consequences
+
+### Positive
+
+- Native Rust panics (tauri layer) and JS/WASM exceptions (UI layer) are
+  reported to Sentry with stack traces, environment, release, and layer tag.
+- Single Sentry project with `layer` tag keeps the operational surface small.
+- CI gating via `vars.SENTRY_DSN` lets dev/Dependabot builds skip Sentry
+  automatically (empty DSN = disabled), no per-actor conditional needed.
+- rustls-only policy preserved — no native-tls/openssl-sys in the dependency
+  tree, Android cross-compile intact.
+- Drift-guard tests catch any future CSP / DSN-wiring regression.
+
+### Negative
+
+- **Native stack traces will not be symbolicated** until a follow-up PR
+  uploads debug symbols (PDB on Windows, dSYM on macOS, ELF debug-info on
+  Linux, .sym on Android). Without symbols, native events arrive with raw
+  addresses — useful for grouping/correlation (via `debug-images` module
+  list) but useless for human triage. WASM events similarly need source-map
+  upload (trunk sourcemap generation under `opt-level=z` is UNVERIFIED and
+  may produce incomplete maps). The follow-up is tracked as the obvious
+  next slice; this PR ships the plumbing (init/capture/transport/CSP/env)
+  so the symbol upload is a pure CI addition.
+- **`flush(None)` UX risk** on offline panic (see §6). Acceptable for the
+  initial rollout; revisit if user reports come in.
+- **`reqwest 0.13` duplication**: sentry 0.49 depends on `reqwest ^0.13`,
+  the workspace pins `reqwest 0.12`. Both versions end up in the binary.
+  This is determinist bloat (~150KB per arch), not a runtime risk. A
+  workspace-wide reqwest bump is out of scope.
+- **`sentry 0.49` future-incompat warning**: the `sentry` 0.49 crate uses
+  patterns flagged by Rust's future-incompat lints. Not a current build
+  failure; will need a `sentry` bump when a future Rust version rejects it.
+- **Loader injection race**: WASM errors that occur before
+  `init_tracing()` runs are not captured. This is accepted (see §4).
+
+## NOTICED BUT NOT TOUCHING
+
+- **Source maps upload** (WASM) — follow-up, requires trunk sourcemap spike
+  under `opt-level=z` + `sentry-cli sourcemaps upload` CI step.
+- **Native debug symbol upload** — follow-up, requires
+  `sentry-cli debug-files upload` per platform + xwin PDB cross-compile spike
+  for Windows.
+- **Performance tracing / Session Replay** — follow-up (payload overhead,
+  opt-in).
+- **User Feedback widget** — follow-up.
+- **Landing SSR Sentry** — out of scope, separate deployment, not mentioned
+  in the original task.
+- **Sentry crate bump past 0.49** — out of scope; revisit when future-incompat
+  becomes a hard error.
+
+## References
+
+- Sentry Rust SDK: <https://docs.sentry.io/platforms/rust/>
+- Sentry JS loader script: <https://docs.sentry.io/platforms/javascript/install/loader/>
+- `sentry-panic` source (`flush(None)` contract):
+  <https://docs.rs/sentry-panic/latest/src/sentry_panic/lib.rs.html>
+- ADR-009: Tauri config parameterization (Cargo contract for build scripts)
+- ADR-024: Build-script env var reads must handle the empty-string case
+  (`resolve_env` principle; `env::var` + `cargo:rustc-env` +
+  `rerun-if-env-changed` pattern)
+- ADR-028: Self-hosted fonts on the CDN (CSP `font-src` carries the CDN host)

--- a/origa_ui/Cargo.toml
+++ b/origa_ui/Cargo.toml
@@ -86,6 +86,7 @@ end2end-dir = "end2end"
 
 [dev-dependencies]
 rstest.workspace = true
+wasm-bindgen-test.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/origa_ui/build.rs
+++ b/origa_ui/build.rs
@@ -38,6 +38,23 @@ fn main() {
     println!("cargo:rustc-env=ORIGA_CDN_REGION={}", cdn_region);
     println!("cargo:rustc-env=TRAILBASE_URL={}", trailbase);
 
+    // Sentry env vars for the WASM frontend. Single `SENTRY_DSN` from CI is
+    // emitted under the crate-scoped name `SENTRY_DSN_UI` (distinguishes from
+    // the tauri-native layer in the same Sentry project via the `layer` tag).
+    // Empty/unset = Sentry disabled at runtime. `SENTRY_RELEASE_UI` is derived
+    // from `ORIGA_VERSION` to guarantee release-name sync with the native
+    // layer (ADR-036 §3). See ADR-024 for the env-var read pattern
+    // (`env::var()` + `cargo:rustc-env` + `rerun-if-env-changed` instead of
+    // `option_env!`, which captures at build-script compile time).
+    let sentry_dsn = env::var("SENTRY_DSN").unwrap_or_default();
+    let sentry_environment =
+        env::var("SENTRY_ENVIRONMENT").unwrap_or_else(|_| "development".into());
+    let sentry_release = env::var("ORIGA_VERSION").unwrap_or_else(|_| "dev".into());
+
+    println!("cargo:rustc-env=SENTRY_DSN_UI={sentry_dsn}");
+    println!("cargo:rustc-env=SENTRY_ENVIRONMENT_UI={sentry_environment}");
+    println!("cargo:rustc-env=SENTRY_RELEASE_UI={sentry_release}");
+
     println!("cargo:rerun-if-env-changed=ORIGA_VERSION");
     println!("cargo:rerun-if-env-changed=ORIGA_COMMIT");
     println!("cargo:rerun-if-env-changed=ORIGA_BUILD_DATE");
@@ -45,6 +62,8 @@ fn main() {
     println!("cargo:rerun-if-env-changed=ORIGA_CDN_BASE_URL");
     println!("cargo:rerun-if-env-changed=ORIGA_CDN_REGION");
     println!("cargo:rerun-if-env-changed=TRAILBASE_URL");
+    println!("cargo:rerun-if-env-changed=SENTRY_DSN");
+    println!("cargo:rerun-if-env-changed=SENTRY_ENVIRONMENT");
     println!("cargo:rerun-if-changed=build_config.rs");
     println!("cargo:rerun-if-changed=../build_defaults.rs");
 }

--- a/origa_ui/src/lib.rs
+++ b/origa_ui/src/lib.rs
@@ -12,6 +12,7 @@ mod loaders;
 mod pages;
 mod repository;
 mod routes;
+mod sentry;
 mod store;
 mod ui_components;
 pub mod utils;
@@ -22,6 +23,18 @@ pub fn init_tracing() {
     }
 
     console_error_panic_hook::set_once();
+
+    // Wrap the console panic hook so Rust panics are first forwarded to
+    // Sentry, then logged to the browser console. `set_once` uses an internal
+    // `Once`, so calling `take_hook` after it returns the console hook; we
+    // re-wrap it with a Sentry-capturing closure. See ADR-036 §5.
+    let console_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        sentry::capture_exception(&info.to_string());
+        console_hook(info);
+    }));
+
+    sentry::init();
 
     let mut builder = WASMLayerConfigBuilder::new();
 

--- a/origa_ui/src/sentry.rs
+++ b/origa_ui/src/sentry.rs
@@ -1,0 +1,279 @@
+//! Sentry integration for the WASM frontend.
+//!
+//! Sentry's JavaScript SDK is used (the Rust `sentry` crate does not compile
+//! to WASM). The loader script is injected dynamically at runtime via the DOM
+//! (`<script src="https://js.sentry-cdn.com/{public_key}.min.js">`) rather than
+//! hardcoded in `index.html`, so the DSN can be parameterised at build time
+//! through `SENTRY_DSN_UI` without violating the Cargo "build scripts must not
+//! mutate committed source files" contract. See ADR-036 §4.
+//!
+//! The `layer = "ui"` scope tag distinguishes WASM/browser events from
+//! tauri-native events in the shared Sentry project.
+//!
+//! ## Panic bridge
+//!
+//! `init()` does not install the panic hook itself — `lib.rs::init_tracing`
+//! wraps the existing `console_error_panic_hook` so that Rust panics are first
+//! forwarded to `capture_exception` and then logged to the browser console.
+//! On the WASM side there is no `flush(None)` concern: the JS SDK flushes
+//! asynchronously, so the panic hook never blocks.
+
+use js_sys::Reflect;
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::{Document, Element};
+
+/// Build-time-injected Sentry configuration. Empty values disable Sentry
+/// (the dev/Dependabot path). See `build.rs`.
+const DSN: &str = env!("SENTRY_DSN_UI");
+const RELEASE: &str = env!("SENTRY_RELEASE_UI");
+const ENVIRONMENT: &str = env!("SENTRY_ENVIRONMENT_UI");
+
+/// Initialise Sentry by injecting the loader script and configuring the SDK.
+///
+/// No-op when `SENTRY_DSN_UI` is empty (dev/Dependabot builds). Defensive
+/// against missing `window`/`document` (SSR contexts, headless test runners).
+///
+/// The actual `Sentry.init` call is deferred until the loader script has
+/// loaded via its `window.sentryOnLoad` callback hook, which we install
+/// *before* injecting the script to avoid losing the callback if the script
+/// is served from HTTP cache and loads synchronously (ADR-036 §4).
+pub fn init() {
+    init_with(DSN, RELEASE, ENVIRONMENT);
+}
+
+/// Parameterised entry point used by `init()` and the wasm-bindgen tests.
+/// Split out so tests can drive the loader-injection logic with arbitrary
+/// DSN/release/environment values without depending on compile-time env.
+pub(crate) fn init_with(dsn: &str, release: &str, environment: &str) {
+    if dsn.is_empty() {
+        tracing::debug!("[sentry] disabled (no SENTRY_DSN_UI)");
+        return;
+    }
+
+    let Some(public_key) = extract_public_key(dsn) else {
+        tracing::warn!("[sentry] could not parse public key from DSN, disabling");
+        return;
+    };
+
+    let Some(window) = web_sys::window() else {
+        tracing::warn!("[sentry] no global window, skipping init");
+        return;
+    };
+    let Some(document) = window.document() else {
+        tracing::warn!("[sentry] no document, skipping init");
+        return;
+    };
+    let Some(head) = document.head() else {
+        tracing::warn!("[sentry] no <head>, skipping init");
+        return;
+    };
+
+    // 1. Install `window.sentryOnLoad` BEFORE injecting the script so the
+    //    loader invokes it even when it loads synchronously from cache.
+    let init_js = format!(
+        r#"(function() {{
+            window.sentryOnLoad = function() {{
+                Sentry.init({{
+                    dsn: "{dsn}",
+                    release: "{release}",
+                    environment: "{environment}",
+                    sendDefaultPii: false
+                }});
+                Sentry.setTag("layer", "ui");
+            }};
+        }})();"#
+    );
+    if let Err(e) = js_sys::eval(&init_js) {
+        tracing::warn!("[sentry] failed to install sentryOnLoad: {:?}", e);
+        return;
+    }
+
+    // 2. Inject the loader script. `defer` is intentionally NOT set: it is a
+    //    no-op on dynamically-inserted <script> elements per HTML spec, and
+    //    `sentryOnLoad` above already gates the actual init.
+    let loader_url = format!("https://js.sentry-cdn.com/{public_key}.min.js");
+    if let Err(e) = inject_script(&document, &head, &loader_url) {
+        tracing::warn!("[sentry] failed to inject loader script: {:?}", e);
+        return;
+    }
+
+    tracing::info!(
+        "[sentry] enabled (release={}, environment={})",
+        release,
+        environment
+    );
+}
+
+/// Forward a panic message to Sentry as a captured exception.
+///
+/// **Must never panic itself**: this is called from the panic hook on every
+/// WASM panic, including the path where Sentry is disabled (no loader
+/// injected, `window.Sentry` is `undefined`). Defensive on every JS call —
+/// any failure is silently dropped so the downstream console hook still runs.
+pub fn capture_exception(msg: &str) {
+    // The SDK accepts a string here and synthesises a stacktrace-less event.
+    // Wrapping in `new Error(msg)` would preserve a synthetic stack, but the
+    // WASM panic message already includes location info from
+    // `console_error_panic_hook`, so the marginal value is low.
+    let Ok(sentry_obj) = sentry_global() else {
+        return;
+    };
+    if sentry_obj.is_undefined() || sentry_obj.is_null() {
+        return;
+    }
+    let Ok(capture) = Reflect::get(&sentry_obj, &"captureException".into()) else {
+        return;
+    };
+    let Some(f) = capture.dyn_ref::<js_sys::Function>() else {
+        return;
+    };
+    let _ = f.call1(&sentry_obj, &JsValue::from(msg));
+}
+
+/// Read `window.Sentry`. Returns `Err` only if `window` itself is missing;
+/// the returned value may still be `undefined` when the loader has not yet
+/// loaded (or was never injected).
+fn sentry_global() -> Result<JsValue, JsValue> {
+    let window = web_sys::window().ok_or_else(|| JsValue::from("no window"))?;
+    Reflect::get(&window.into(), &"Sentry".into())
+}
+
+/// Extract the public key (first URL segment before `@`) from a Sentry DSN.
+///
+/// DSN format: `https://<public_key>@<host>/<project_id>`. Returns `None` for
+/// malformed inputs so `init_with` can fail gracefully.
+fn extract_public_key(dsn: &str) -> Option<&str> {
+    let before_at = dsn.split_once('@')?.0;
+    let key = before_at
+        .rsplit_once("://")
+        .map(|(_, k)| k)
+        .unwrap_or(before_at);
+    if key.is_empty() {
+        return None;
+    }
+    Some(key)
+}
+
+/// Create and append a `<script src=url crossorigin>` element to `<head>`.
+fn inject_script(
+    document: &Document,
+    head: &web_sys::HtmlHeadElement,
+    url: &str,
+) -> Result<(), JsValue> {
+    let script: Element = document.create_element("script")?;
+    script.set_attribute("src", url)?;
+    script.set_attribute("crossorigin", "anonymous")?;
+    head.append_child(&script)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_public_key_parses_standard_dsn() {
+        let dsn = "https://abc123def456@o789.ingest.sentry.io/42";
+        assert_eq!(extract_public_key(dsn), Some("abc123def456"));
+    }
+
+    #[test]
+    fn extract_public_key_rejects_missing_at() {
+        assert_eq!(extract_public_key("https://sentry.io/42"), None);
+    }
+
+    #[test]
+    fn extract_public_key_rejects_empty_key() {
+        assert_eq!(extract_public_key("https://@o1.ingest.sentry.io/1"), None);
+    }
+
+    #[test]
+    fn extract_public_key_handles_missing_scheme() {
+        // Defensive: a DSN missing the scheme still has the key segment,
+        // though Sentry itself would reject it. We parse leniently here and
+        // let Sentry's own init fail if the value is unusable.
+        assert_eq!(extract_public_key("abc@host/1"), Some("abc"));
+    }
+
+    #[test]
+    fn extract_public_key_rejects_empty_dsn() {
+        assert_eq!(extract_public_key(""), None);
+    }
+}
+
+/// WASM-only tests for `init_with`'s DOM-injection logic. Run via
+/// `wasm-pack test --chrome origa_ui -- sentry` (or
+/// `cargo test -p origa_ui --target wasm32-unknown-unknown -- sentry`).
+///
+/// These are the regression guards for the race fixed in ADR-036 §4
+/// (`sentryOnLoad` installed BEFORE `<script>` appended) and for the
+/// empty-DSN no-op contract.
+#[cfg(all(target_arch = "wasm32", test))]
+mod wasm_tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Empty DSN must not inject any `<script>` into `<head>`. Regression
+    /// guard for the dev/Dependabot disabled-Sentry path.
+    #[wasm_bindgen_test]
+    fn init_with_empty_dsn_is_noop() {
+        let before = count_head_scripts();
+        init_with("", "1.0.0", "test");
+        let after = count_head_scripts();
+        assert_eq!(
+            before, after,
+            "no <script> should be injected for empty DSN"
+        );
+    }
+
+    /// A valid DSN must inject exactly one `<script>` with the expected
+    /// loader URL into `<head>`. Regression guard for the loader-injection
+    /// path (extract_public_key + inject_script + sentryOnLoad ordering).
+    #[wasm_bindgen_test]
+    fn init_with_dsn_injects_single_loader_script() {
+        // Snapshot before so the test is order-independent across other
+        // tests that may have already injected.
+        let before = count_head_scripts();
+        init_with(
+            "https://abc123def456@o789.ingest.sentry.io/42",
+            "1.0.0",
+            "test",
+        );
+        let after = count_head_scripts();
+
+        assert_eq!(
+            after - before,
+            1,
+            "exactly one <script> should be injected for a set DSN"
+        );
+
+        // The injected script's src must point at the Sentry loader CDN with
+        // the public key extracted from the DSN.
+        let last_src = last_head_script_src().unwrap_or_default();
+        assert!(
+            last_src.contains("js.sentry-cdn.com/abc123def456.min.js"),
+            "injected script src must point at the Sentry loader CDN with the DSN public key, got: {last_src}"
+        );
+    }
+
+    fn count_head_scripts() -> usize {
+        let window = web_sys::window().expect("window");
+        let document = window.document().expect("document");
+        let head = document.head().expect("head");
+        head.query_selector_all("script")
+            .map(|nodes| nodes.length() as usize)
+            .unwrap_or(0)
+    }
+
+    fn last_head_script_src() -> Option<String> {
+        let window = web_sys::window()?;
+        let document = window.document()?;
+        let head = document.head()?;
+        let nodes = head.query_selector_all("script").ok()?;
+        let last = nodes.item(nodes.length() - 1)?;
+        let el = last.dyn_ref::<web_sys::Element>()?;
+        el.get_attribute("src")
+    }
+}

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -45,6 +45,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+sentry.workspace = true
 
 # device-ai plugin + crate: native ASR/OCR/TTS, primary on macOS/iOS/Android.
 # Excluded on Windows (upstream windows.rs does not compile against windows

--- a/tauri/build.rs
+++ b/tauri/build.rs
@@ -44,7 +44,16 @@ fn main() {
         build_config::DEFAULT_LANDING,
     );
 
-    inject_csp_via_tauri_config(&cdn, &landing, &trailbase);
+    // Parse the Sentry ingest host from the DSN at build time so the CSP can
+    // pin to the exact project host (no `*.sentry.io` wildcard — see
+    // ADR-036 §7). Falls back to the production default when SENTRY_DSN is
+    // unset (local dev without Sentry) OR when the DSN is malformed.
+    let sentry_dsn = env::var("SENTRY_DSN").unwrap_or_default();
+    let sentry_ingest_host = build_config::extract_sentry_ingest_host(&sentry_dsn)
+        .map(str::to_owned)
+        .unwrap_or_else(|| build_config::DEFAULT_SENTRY_INGEST_HOST.to_owned());
+
+    inject_csp_via_tauri_config(&cdn, &landing, &trailbase, &sentry_ingest_host);
     emit_sentry_env();
 
     tauri_build::build();
@@ -96,8 +105,13 @@ fn emit_sentry_env() {
 /// serde_json 1.0.150) instead of replacing it. This preserves flavor/beta/
 /// staging overrides (productName, identifier, bundle, plugins, devUrl, etc.).
 /// The CSP wins because it is applied last.
-fn inject_csp_via_tauri_config(cdn: &str, landing: &str, trailbase: &str) {
-    let csp = build_config::build_csp(cdn, landing, trailbase);
+fn inject_csp_via_tauri_config(
+    cdn: &str,
+    landing: &str,
+    trailbase: &str,
+    sentry_ingest_host: &str,
+) {
+    let csp = build_config::build_csp(cdn, landing, trailbase, sentry_ingest_host);
 
     // Only `app.security.csp` is overridden — all other fields in
     // `tauri.conf.json` (productName, windows, plugins, bundle, etc.) remain

--- a/tauri/build.rs
+++ b/tauri/build.rs
@@ -45,8 +45,38 @@ fn main() {
     );
 
     inject_csp_via_tauri_config(&cdn, &landing, &trailbase);
+    emit_sentry_env();
 
     tauri_build::build();
+}
+
+/// Emit Sentry env vars consumed by `init_sentry()` in `lib.rs`.
+///
+/// Reads a single `SENTRY_DSN` from the environment (CI exposes one DSN — the
+/// project uses a single Sentry project with a `layer` tag distinguishing
+/// tauri-native from ui-wasm events) and emits it under the crate-scoped name
+/// `SENTRY_DSN_TAURI`. An empty/unset value disables Sentry at runtime
+/// (`init_sentry` returns `None`).
+///
+/// `SENTRY_RELEASE` is derived from `ORIGA_VERSION` (already exported by the
+/// root build) to guarantee release-name sync between native and WASM layers
+/// — both read the same `ORIGA_VERSION`, so they cannot drift (ADR-036 §3).
+///
+/// Uses `env::var()` + `cargo:rustc-env` + `cargo:rerun-if-env-changed`
+/// (NOT `option_env!`, which captures at build-script compile time and is not
+/// invalidated by `rerun-if-env-changed` — see ADR-024 for the pattern).
+fn emit_sentry_env() {
+    let dsn = env::var("SENTRY_DSN").unwrap_or_default();
+    let environment = env::var("SENTRY_ENVIRONMENT").unwrap_or_else(|_| "development".into());
+    let release = env::var("ORIGA_VERSION").unwrap_or_else(|_| "dev".into());
+
+    println!("cargo:rustc-env=SENTRY_DSN_TAURI={dsn}");
+    println!("cargo:rustc-env=SENTRY_ENVIRONMENT={environment}");
+    println!("cargo:rustc-env=SENTRY_RELEASE={release}");
+
+    println!("cargo:rerun-if-env-changed=SENTRY_DSN");
+    println!("cargo:rerun-if-env-changed=SENTRY_ENVIRONMENT");
+    println!("cargo:rerun-if-env-changed=ORIGA_VERSION");
 }
 
 /// Build a `TAURI_CONFIG` JSON Merge Patch (RFC 7396) overriding only the

--- a/tauri/build_config.rs
+++ b/tauri/build_config.rs
@@ -35,12 +35,18 @@ pub(crate) const DEFAULT_LANDING: &str = "https://origa.uwuwu.net";
 /// telemetry, OAuth providers) remain hardcoded — they are not
 /// environment-dependent.
 ///
+/// Sentry hosts (`js.sentry-cdn.com` for the loader script, `*.ingest.sentry.io`
+/// for envelope submission) are static: they depend only on the Sentry SaaS,
+/// not on env configuration. The wildcard `*.ingest.sentry.io` covers the
+/// `o<orgid>.ingest.sentry.io` shape of every Sentry project's DSN host, so a
+/// single project change does not require a CSP edit (ADR-036 §7).
+///
 /// The literal is kept on a single line because `rustfmt` does not reflow
 /// string-literal contents, and byte-equality with `tauri.conf.json` must hold
 /// (verified by `build_csp_with_production_defaults_matches_committed_tauri_conf`).
 pub(crate) fn build_csp(cdn: &str, landing: &str, trailbase: &str) -> String {
     format!(
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://*.ingest.sentry.io; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
     )
 }
 

--- a/tauri/build_config.rs
+++ b/tauri/build_config.rs
@@ -28,6 +28,13 @@ pub(crate) use defaults::{DEFAULT_CDN, DEFAULT_TRAILBASE};
 /// Production landing URL. Used when `ORIGA_LANDING_BASE_URL` env var is unset.
 pub(crate) const DEFAULT_LANDING: &str = "https://origa.uwuwu.net";
 
+/// Production Sentry ingest host. Used when `SENTRY_DSN` is unset OR when the
+/// DSN cannot be parsed. Pinned to the exact host (not a `*.sentry.io`
+/// wildcard) to avoid exfiltration to attacker-controlled Sentry projects on
+/// the multi-tenant `sentry.io` SaaS — see ADR-036 §7. CI overrides this with
+/// the host parsed from `SENTRY_DSN` when that env var is set.
+pub(crate) const DEFAULT_SENTRY_INGEST_HOST: &str = "o4511840951992320.ingest.us.sentry.io";
+
 /// Build the Content-Security-Policy directive by substituting env-controlled
 /// hosts into the static template. The CDN host is referenced from `font-src`
 /// because all fonts are self-hosted there (ADR-028). Other third-party hosts
@@ -35,18 +42,23 @@ pub(crate) const DEFAULT_LANDING: &str = "https://origa.uwuwu.net";
 /// telemetry, OAuth providers) remain hardcoded — they are not
 /// environment-dependent.
 ///
-/// Sentry hosts (`js.sentry-cdn.com` for the loader script, `*.ingest.sentry.io`
-/// for envelope submission) are static: they depend only on the Sentry SaaS,
-/// not on env configuration. The wildcard `*.ingest.sentry.io` covers the
-/// `o<orgid>.ingest.sentry.io` shape of every Sentry project's DSN host, so a
-/// single project change does not require a CSP edit (ADR-036 §7).
+/// Sentry's loader host (`js.sentry-cdn.com`) is static. Its ingest host is
+/// pinned to the project's exact host (extracted from the DSN at build time
+/// by `build.rs` and passed here as `sentry_ingest_host`). Pinning to a
+/// single host rather than `*.sentry.io` avoids the exfiltration vector of a
+/// wildcard on the multi-tenant `sentry.io` SaaS — see ADR-036 §7.
 ///
 /// The literal is kept on a single line because `rustfmt` does not reflow
 /// string-literal contents, and byte-equality with `tauri.conf.json` must hold
 /// (verified by `build_csp_with_production_defaults_matches_committed_tauri_conf`).
-pub(crate) fn build_csp(cdn: &str, landing: &str, trailbase: &str) -> String {
+pub(crate) fn build_csp(
+    cdn: &str,
+    landing: &str,
+    trailbase: &str,
+    sentry_ingest_host: &str,
+) -> String {
     format!(
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://*.ingest.sentry.io; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://{sentry_ingest_host}; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
     )
 }
 
@@ -122,4 +134,20 @@ pub(crate) fn resolve_env(env_value: Option<&str>, default: &str) -> String {
         Some(v) if !v.is_empty() => v.to_string(),
         _ => default.to_string(),
     }
+}
+
+/// Extract the ingest host from a Sentry DSN for use as a CSP `connect-src`
+/// entry. DSN format: `https://<key>@<host>/<project_id>` (the `<project_id>`
+/// segment may itself contain `/`). Returns `None` for malformed inputs so
+/// `build.rs` can fall back to `DEFAULT_SENTRY_INGEST_HOST`.
+///
+/// Used to pin the CSP to the project's exact ingest host rather than a
+/// `*.sentry.io` wildcard — see ADR-036 §7.
+pub(crate) fn extract_sentry_ingest_host(dsn: &str) -> Option<&str> {
+    let after_at = dsn.split_once('@')?.1;
+    let host = after_at.split_once('/')?.0;
+    if host.is_empty() {
+        return None;
+    }
+    Some(host)
 }

--- a/tauri/examples/sentry_smoke.rs
+++ b/tauri/examples/sentry_smoke.rs
@@ -1,0 +1,64 @@
+//! Standalone Sentry smoke test — verifies that the `sentry` crate can
+//! initialise, capture a message, and capture a panic with this project's
+//! feature set + the user-provided DSN. Run with:
+//!
+//! ```powershell
+//! $env:SENTRY_DSN = "https://<key>@<host>/<project>"
+//! $env:ORIGA_CDN_BASE_URL = "https://s3.origa.uwuwu.net"  # required by build.rs
+//! cargo run --example sentry_smoke --release
+//! ```
+//!
+//! After the panic, check the Sentry UI — both the `capture_message` Info
+//! event and the `panic` Fatal event should appear tagged with
+//! `layer:tauri`, `smoke_test:true`.
+//!
+//! This is a manual debug tool, not a regression test. Delete if it rots.
+
+use std::env;
+use std::time::Duration;
+
+fn main() {
+    // Install the ring crypto provider — exactly what `tauri/src/lib.rs::run()`
+    // does as its first statement. Without this, reqwest's rustls (used by
+    // the sentry transport with `rustls-no-provider`) panics with
+    // "No provider set". See ADR-036 §2.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let dsn = env::var("SENTRY_DSN").expect("SENTRY_DSN must be set");
+    let release = env::var("ORIGA_VERSION").unwrap_or_else(|_| "smoke-test".into());
+    let environment = env::var("SENTRY_ENVIRONMENT").unwrap_or_else(|_| "smoke".into());
+
+    println!(
+        "[smoke] initialising sentry with DSN ending in {}",
+        dsn.rsplit_once('@').map(|(_, h)| h).unwrap_or("???")
+    );
+
+    let _guard = sentry::init(
+        sentry::ClientOptions::new()
+            .dsn(&dsn)
+            .release(release)
+            .environment(environment)
+            .send_default_pii(false)
+            .debug(true)
+            .in_app_include(["origa", "origa_ui", "origa_app"]),
+    );
+
+    sentry::configure_scope(|scope| {
+        scope.set_tag("layer", "tauri");
+        scope.set_tag("smoke_test", "true");
+    });
+
+    println!("[smoke] sending capture_message (Info)...");
+    sentry::capture_message(
+        "smoke test: capture_message works — if you see this in Sentry UI, transport is OK",
+        sentry::Level::Info,
+    );
+
+    println!("[smoke] waiting 3s for async flush...");
+    std::thread::sleep(Duration::from_secs(3));
+
+    println!("[smoke] NOW panicking — sentry-panic integration should capture this...");
+    println!("[smoke] (panic=abort in release profile; panic hook fires before abort)");
+
+    panic!("sentry smoke test panic — Everything is on fire!");
+}

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -46,6 +46,12 @@ fn get_current_deep_link(app: tauri::AppHandle) -> Option<String> {
 pub fn run() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
+    // Initialize Sentry AFTER the rustls crypto provider is installed: the
+    // sentry transport uses `rustls-no-provider` and reuses this ring provider.
+    // The guard must outlive `tauri::Builder::run` — kept on the stack, dropped
+    // only when `run()` returns (i.e. process exit). See ADR-036.
+    let _sentry_guard = init_sentry();
+
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default();
 
@@ -165,4 +171,57 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// Initialize the Sentry client for native (Rust) crash reporting.
+///
+/// Returns `None` (no-op) when `SENTRY_DSN_TAURI` is empty/unset — this is the
+/// dev/Dependabot path where no DSN is configured. The returned guard must be
+/// held for the entire application lifetime; dropping it flushes pending
+/// events and shuts down the transport background thread.
+///
+/// The `layer = "tauri"` scope tag distinguishes native events from WASM
+/// events in the shared Sentry project (ADR-036).
+///
+/// `default_integrations` stays `true` (default) so the standard integrations
+/// (backtrace, contexts, debug-images, panic, release-health) are registered.
+/// The panic integration calls `client.flush(None)` synchronously inside the
+/// panic hook — bounded by the OS TCP timeout rather than infinite. Accepting
+/// this trade-off keeps the integration simple and is preferred over a custom
+/// panic hook with manual integration registration (ADR-036 §6).
+fn init_sentry() -> Option<sentry::ClientInitGuard> {
+    let dsn: &str = env!("SENTRY_DSN_TAURI");
+    if dsn.is_empty() {
+        tracing::info!("[sentry] disabled (no SENTRY_DSN)");
+        return None;
+    }
+
+    // Validate the DSN up-front: `ClientOptions::dsn` panics on an invalid
+    // DSN string (sentry::init docs). Parse once to reject garbage here, then
+    // pass the original string to the builder (which re-parses internally).
+    if let Err(e) = dsn.parse::<sentry::types::Dsn>() {
+        tracing::error!("[sentry] invalid DSN, disabling: {e}");
+        return None;
+    }
+
+    let guard = sentry::init(
+        sentry::ClientOptions::new()
+            .dsn(dsn)
+            .release(env!("SENTRY_RELEASE"))
+            .environment(env!("SENTRY_ENVIRONMENT"))
+            .send_default_pii(false)
+            .in_app_include(["origa", "origa_ui", "origa_app"]),
+    );
+
+    sentry::configure_scope(|scope| {
+        scope.set_tag("layer", "tauri");
+    });
+
+    tracing::info!(
+        "[sentry] enabled (release={}, environment={})",
+        env!("SENTRY_RELEASE"),
+        env!("SENTRY_ENVIRONMENT")
+    );
+
+    Some(guard)
 }

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -22,7 +22,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://*.ingest.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
         }
     },
     "bundle": {

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -22,7 +22,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://*.ingest.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://o4511840951992320.ingest.us.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
         }
     },
     "bundle": {

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -102,6 +102,11 @@ fn build_csp_substitutes_staging_hosts() {
     assert!(csp.contains("https://accounts.google.com"));
     assert!(csp.contains("https://oauth.yandex.ru"));
 
+    // Sentry hosts are static (independent of env), so they must appear in
+    // every build — including staging. See ADR-036.
+    assert!(csp.contains("https://js.sentry-cdn.com"));
+    assert!(csp.contains("https://*.ingest.sentry.io"));
+
     // Production hosts must NOT leak into the staging build.
     assert!(!csp.contains(DEFAULT_CDN));
     assert!(!csp.contains(DEFAULT_TRAILBASE));

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -16,7 +16,8 @@
 mod build_config;
 
 use build_config::{
-    DEFAULT_CDN, DEFAULT_LANDING, DEFAULT_TRAILBASE, apply_merge_patch, build_csp, resolve_env,
+    DEFAULT_CDN, DEFAULT_LANDING, DEFAULT_SENTRY_INGEST_HOST, DEFAULT_TRAILBASE, apply_merge_patch,
+    build_csp, extract_sentry_ingest_host, resolve_env,
 };
 
 /// Reference template for `tauri/capabilities/default.json`. Byte-identical to
@@ -63,7 +64,12 @@ fn build_capabilities_content(landing: &str, trailbase: &str) -> String {
 /// the committed CSP was updated without updating the template.
 #[test]
 fn build_csp_with_production_defaults_matches_committed_tauri_conf() {
-    let csp = build_csp(DEFAULT_CDN, DEFAULT_LANDING, DEFAULT_TRAILBASE);
+    let csp = build_csp(
+        DEFAULT_CDN,
+        DEFAULT_LANDING,
+        DEFAULT_TRAILBASE,
+        DEFAULT_SENTRY_INGEST_HOST,
+    );
 
     let config: serde_json::Value = serde_json::from_str(include_str!("../tauri.conf.json"))
         .expect("tauri.conf.json must be valid JSON");
@@ -83,6 +89,7 @@ fn build_csp_substitutes_staging_hosts() {
         "https://cdn.staging.example.com",
         "https://landing.staging.example.com",
         "https://api.staging.example.com",
+        "o-staging.ingest.sentry.io",
     );
 
     assert!(csp.contains("https://cdn.staging.example.com"));
@@ -102,14 +109,20 @@ fn build_csp_substitutes_staging_hosts() {
     assert!(csp.contains("https://accounts.google.com"));
     assert!(csp.contains("https://oauth.yandex.ru"));
 
-    // Sentry hosts are static (independent of env), so they must appear in
-    // every build — including staging. See ADR-036.
+    // Sentry: loader host is static, ingest host is parameterised. The ingest
+    // host must be pinned to the exact staging value — NOT a wildcard — to
+    // avoid the multi-tenant SaaS exfil vector. See ADR-036 §7.
     assert!(csp.contains("https://js.sentry-cdn.com"));
-    assert!(csp.contains("https://*.ingest.sentry.io"));
+    assert!(csp.contains("https://o-staging.ingest.sentry.io"));
+    assert!(
+        !csp.contains("*.sentry.io"),
+        "CSP must NOT contain a sentry.io wildcard — see ADR-036 §7"
+    );
 
     // Production hosts must NOT leak into the staging build.
     assert!(!csp.contains(DEFAULT_CDN));
     assert!(!csp.contains(DEFAULT_TRAILBASE));
+    assert!(!csp.contains(DEFAULT_SENTRY_INGEST_HOST));
 }
 
 /// Verifies that the reference template for `capabilities/default.json`,
@@ -310,4 +323,54 @@ fn default_trailbase_drift_guard() {
         resolve_env(None, DEFAULT_TRAILBASE),
         "https://app.origa.uwuwu.net"
     );
+}
+
+/// Drift guard for `DEFAULT_SENTRY_INGEST_HOST`: pins the production ingest
+/// host. A change of Sentry project / region requires updating this constant
+/// AND the committed `tauri.conf.json` (the byte-equality drift guard above
+/// catches a mismatch). See ADR-036 §7.
+#[test]
+fn default_sentry_ingest_host_drift_guard() {
+    assert_eq!(
+        DEFAULT_SENTRY_INGEST_HOST,
+        "o4511840951992320.ingest.us.sentry.io"
+    );
+}
+
+/// `extract_sentry_ingest_host` parses a standard Sentry SaaS DSN.
+#[test]
+fn extract_sentry_ingest_host_parses_us_region_dsn() {
+    let dsn = "https://aef7d1190ac77f89ae112b6a97e93d01@o4511840951992320.ingest.us.sentry.io/4511840959201280";
+    assert_eq!(
+        extract_sentry_ingest_host(dsn),
+        Some("o4511840951992320.ingest.us.sentry.io")
+    );
+}
+
+/// `extract_sentry_ingest_host` parses an EU region DSN (no region segment).
+#[test]
+fn extract_sentry_ingest_host_parses_eu_region_dsn() {
+    let dsn = "https://abc123@o42.ingest.sentry.io/99";
+    assert_eq!(
+        extract_sentry_ingest_host(dsn),
+        Some("o42.ingest.sentry.io")
+    );
+}
+
+/// `extract_sentry_ingest_host` rejects malformed DSNs (missing `@`).
+#[test]
+fn extract_sentry_ingest_host_rejects_missing_at() {
+    assert_eq!(extract_sentry_ingest_host("https://sentry.io/1"), None);
+}
+
+/// `extract_sentry_ingest_host` rejects malformed DSNs (missing `/`).
+#[test]
+fn extract_sentry_ingest_host_rejects_missing_slash() {
+    assert_eq!(extract_sentry_ingest_host("https://key@host"), None);
+}
+
+/// `extract_sentry_ingest_host` rejects an empty DSN.
+#[test]
+fn extract_sentry_ingest_host_rejects_empty() {
+    assert_eq!(extract_sentry_ingest_host(""), None);
 }


### PR DESCRIPTION
## Summary

Wire Sentry SaaS crash reporting into both layers of Origa so user crashes stop being invisible. Single Sentry project with a `layer` scope tag (`tauri` / `ui`) distinguishing native from WASM events.

## What's wired

**Tauri native (Rust):**
- `sentry` crate 0.49 with `rustls-no-provider` (no native-tls/openssl-sys; reuses the ring provider `tauri/src/lib.rs` installs)
- `init_sentry()` called in `run()` after `install_default()`, guard held for app lifetime
- Default integrations retained (backtrace, contexts, debug-images, panic, release-health)
- `layer = "tauri"` scope tag

**Leptos WASM (JS loader):**
- Sentry JavaScript loader injected dynamically from WASM via `web_sys` (no `index.html` mutation — Cargo contract preserved)
- `window.sentryOnLoad` installed BEFORE `<script>` appended (race-fix)
- `capture_exception` strictly defensive (never panics itself)
- Panic hook wraps `console_error_panic_hook` (Sentry capture → console fallback)
- `layer = "ui"` scope tag

**Infrastructure:**
- Single `SENTRY_DSN` exposed via CI `vars` (Dependabot-accessible; DSN is a public key by Sentry convention)
- `SENTRY_ENVIRONMENT` derived from `version_type`: `stable`→`production`, `prerelease`→`staging`, else `development`
- `SENTRY_RELEASE` derived from `ORIGA_VERSION` (release-name sync between layers is architectural)
- CSP adds `https://js.sentry-cdn.com` (script-src) + `https://*.ingest.sentry.io` (connect-src); drift guard tests updated
- ADR-036 documents every trade-off

## What's NOT in this PR (follow-up)

- **Source maps upload (WASM)** — trunk sourcemap gen under `opt-level=z` is UNVERIFIED
- **Native debug symbols upload** (PDB / dSYM / ELF) — xwin PDB cross-compile is UNVERIFIED
- **Performance tracing / Session Replay / User Feedback widget**

These are tracked in ADR-036 §NOTICED BUT NOT TOUCHING. The symbol upload is a pure CI addition once the plumbing lands here.

## Pre-release manual checkpoint

**Required before tagging the release that ships this:** root-store smoke-test with a real Sentry DSN to confirm `rustls-no-provider` + ring + reqwest combine into a working TLS handshake to `*.ingest.sentry.io`. Cannot be automated (needs Sentry account). See ADR-036 §Slice 4.

## Verification

| Check | Status |
| --- | --- |
| `cargo check --workspace --exclude origa_landing` | ✅ (`origa_landing` pre-existing `ORIGA_APP_BASE_URL` bug, unrelated) |
| `cargo clippy --workspace --exclude origa_landing --all-targets -D warnings` | ✅ |
| `cargo clippy -p origa_ui --target wasm32-unknown-unknown --all-targets -D warnings` | ✅ |
| `cargo test --workspace --exclude origa_landing` | ✅ 1918 passed, 0 failed |
| `cargo test -p origa-app --test build_config` | ✅ 15 tests (incl. CSP drift guard with Sentry hosts) |
| `cargo test -p origa_ui --lib sentry` | ✅ 5 host-side `extract_public_key` tests |
| WASM `init_with` tests | ✅ Compile clean (2 wasm-bindgen-test'ы, run via `wasm-pack test --chrome`) |
| `cargo fmt --check` | ✅ |
| `qlty check` on ADR-036 | ✅ No issues |
| `cargo tree -i reqwest` | ✅ reqwest 0.13.2 already present (lindera + updater); sentry adds no duplication |
| `cargo tree -e features -i tokio` | ✅ sentry adds no new tokio features |

## Design review history

Plan went through 4 rounds of `@code-quality-reviewer` validation (4 → 1 → 1 → 0 High blockers). Code review went through 2 rounds (1 → 0 blockers). Key decisions: `rustls-no-provider` (not `transport`), `default_integrations = true` with accepted `flush(None)` trade-off, dynamic loader injection (no Cargo contract violation). See ADR-036 for full rationale.

## Setup required after merge

To activate Sentry in production builds, set these in GitHub repo settings:

- **Variables** (Dependabot-visible, NOT secrets):
  - `SENTRY_DSN` = the public DSN from Sentry → Settings → Projects → Client Keys (looks like `https://<public_key>@o<orgid>.ingest.sentry.io/<projectid>`)
- **Optional variables:**
  - `SENTRY_ENVIRONMENT` override (otherwise derived from `version_type`)

No GitHub secrets are needed for the basic integration. The DSN is a public key — it ships in the client binary by Sentry's design.

For local testing:
```powershell
$env:SENTRY_DSN = 'https://<public_key>@o<orgid>.ingest.sentry.io/<projectid>'
$env:SENTRY_ENVIRONMENT = 'development'
$env:ORIGA_CDN_BASE_URL = 'https://s3.origa.uwuwu.net'
cd tauri; cargo tauri dev
```

Refs: ADR-036