### PR TITLE
chore(lesson): only repeat high-difficulty cards, drop new/in-progress multi-show

### DIFF
--- a/docs/decisions/ADR-019-lesson-multishow-and-pos-cache.md
+++ b/docs/decisions/ADR-019-lesson-multishow-and-pos-cache.md
@@ -41,14 +41,14 @@ Backward-compat: кастомный `Deserialize` для `LessonData` через
 
 Функция `target_showings`:
 
-- `is_high_difficulty` || `is_new` || `is_in_progress` → 2;
-- иначе (known) → 1.
+- `is_high_difficulty` → 2;
+- иначе (new/in-progress/known) → 1.
 
 Применяется к Vocabulary/Kanji/Grammar; Phrase не умножается (`candidate_views_for_repeat` для Phrase возвращает пустой вектор). «Разные вью» = строго разные дискриминанты `LessonCardView` (дедуп через `std::mem::discriminant` в `build_distinct_views`). `compute_expansion_views` обрезает кандидатов до цели и возвращает пустой вектор, если доступных различных вью меньше 2 (в этом случае показ остаётся единичным). Если доступных различных типов (с учётом guards) меньше цели → clamp к числу доступных (НЕ fallback к 1). Каждый показ рейтится отдельно по `card_id` → N оценок FSRS.
 
-Матрица фактически достигаемых показов: Vocabulary hard/in-progress/new → 2, Kanji hard/in-progress/new → 2, Grammar hard → 2, Grammar new → 1 (только `Normal`).
+Матрица фактически достигаемых показов: Vocabulary hard → 2, Kanji hard → 2, Grammar hard → 2; Vocabulary/Kanji/Grammar new/in-progress/known → 1 (Grammar new также 1 — только `Normal`).
 
-> **Изм. от 2026-08-04:** ранее high-difficulty имел target=3 (Kanji hard достигал 3 показов); снижено до 2 — уроки получались слишком длинными.
+> **Изм. от 2026-08-04:** ранее high-difficulty имел target=3 (Kanji hard достигал 3 показов); снижено до 2 — уроки получались слишком длинными. В той же правке new/in-progress временно остались на target=2; позже снижены до 1 — повторный показ нужен только трудным картам, новые и в стадии закрепления достаточно одного показа за урок.
 
 ### 4. POS кэш + миграция
 

--- a/docs/decisions/ADR-019-lesson-multishow-and-pos-cache.md
+++ b/docs/decisions/ADR-019-lesson-multishow-and-pos-cache.md
@@ -41,13 +41,14 @@ Backward-compat: кастомный `Deserialize` для `LessonData` через
 
 Функция `target_showings`:
 
-- `is_high_difficulty` → 3;
-- `is_new` || `is_in_progress` → 2;
+- `is_high_difficulty` || `is_new` || `is_in_progress` → 2;
 - иначе (known) → 1.
 
 Применяется к Vocabulary/Kanji/Grammar; Phrase не умножается (`candidate_views_for_repeat` для Phrase возвращает пустой вектор). «Разные вью» = строго разные дискриминанты `LessonCardView` (дедуп через `std::mem::discriminant` в `build_distinct_views`). `compute_expansion_views` обрезает кандидатов до цели и возвращает пустой вектор, если доступных различных вью меньше 2 (в этом случае показ остаётся единичным). Если доступных различных типов (с учётом guards) меньше цели → clamp к числу доступных (НЕ fallback к 1). Каждый показ рейтится отдельно по `card_id` → N оценок FSRS.
 
-Матрица фактически достигаемых показов: Vocabulary hard → 2 (clamp, YesNo недоступен при high_difficulty), Vocabulary in_progress/new → 2, Kanji hard → 3, Grammar hard → 2, Grammar new → 1 (только `Normal`).
+Матрица фактически достигаемых показов: Vocabulary hard/in-progress/new → 2, Kanji hard/in-progress/new → 2, Grammar hard → 2, Grammar new → 1 (только `Normal`).
+
+> **Изм. от 2026-08-04:** ранее high-difficulty имел target=3 (Kanji hard достигал 3 показов); снижено до 2 — уроки получались слишком длинными.
 
 ### 4. POS кэш + миграция
 

--- a/origa/src/domain/knowledge/lesson_builder.rs
+++ b/origa/src/domain/knowledge/lesson_builder.rs
@@ -749,15 +749,11 @@ fn place_phrases_constraint_aware(
 }
 
 /// Per-card target number of showings, derived from the FSRS memory state.
-/// Hard and in-progress/new cards both get a light drill of 2 showings; known
-/// cards keep their original single showing.
+/// Only high-difficulty cards get repeated showings (2); new, in-progress, and
+/// known cards keep their original single showing.
 fn target_showings(study_card: &StudyCard) -> usize {
     let memory = study_card.memory();
-    if memory.is_high_difficulty() || memory.is_new() || memory.is_in_progress() {
-        2
-    } else {
-        1
-    }
+    if memory.is_high_difficulty() { 2 } else { 1 }
 }
 
 /// Decides whether a primary card slot should be expanded into multiple
@@ -2647,7 +2643,7 @@ mod tests {
     }
 
     #[test]
-    fn expand_in_progress_primary_vocab_yields_multiple_showings() {
+    fn expand_in_progress_primary_vocab_preserves_single_showing() {
         init_test_dict();
         let mut ks = KnowledgeSet::new();
         seed_distractor_vocab(&mut ks, &["犬", "鳥", "魚", "馬", "牛"]);
@@ -2658,10 +2654,10 @@ mod tests {
 
         let result = build_lesson_with_one_primary_vocab(&ks, card_id);
         let showings = result.find_by_card_id(card_id);
-        assert!(
-            showings.len() >= 2,
-            "in-progress primary vocab should produce at least 2 showings, got {}",
-            showings.len()
+        assert_eq!(
+            showings.len(),
+            1,
+            "in-progress primary vocab should keep a single showing (only HD repeats)"
         );
     }
 
@@ -2783,13 +2779,13 @@ mod tests {
         for word in words {
             let sc = ks.create_card(vocab_card(word)).expect("seed primary card");
             let card_id = *sc.card_id();
-            rate_into_state(&mut ks, card_id, 10.0, 4.0, 1, Rating::Good);
+            rate_into_state(&mut ks, card_id, 3.0, 8.0, 1, Rating::Hard);
             assert!(
                 ks.get_card(card_id)
                     .expect("card exists")
                     .memory()
-                    .is_in_progress(),
-                "fixture card must be expandable review vocab"
+                    .is_high_difficulty(),
+                "fixture card must be expandable HD vocab"
             );
             cards.push((
                 card_id,

--- a/origa/src/domain/knowledge/lesson_builder.rs
+++ b/origa/src/domain/knowledge/lesson_builder.rs
@@ -749,13 +749,11 @@ fn place_phrases_constraint_aware(
 }
 
 /// Per-card target number of showings, derived from the FSRS memory state.
-/// Hard cards are repeated most, in-progress/new cards get a lighter drill,
-/// known cards keep their original single showing.
+/// Hard and in-progress/new cards both get a light drill of 2 showings; known
+/// cards keep their original single showing.
 fn target_showings(study_card: &StudyCard) -> usize {
     let memory = study_card.memory();
-    if memory.is_high_difficulty() {
-        3
-    } else if memory.is_new() || memory.is_in_progress() {
+    if memory.is_high_difficulty() || memory.is_new() || memory.is_in_progress() {
         2
     } else {
         1
@@ -3007,9 +3005,9 @@ mod tests {
             .collect()
     }
 
-    /// Best-effort fallback: a single-card core whose HD target forces 3
+    /// Best-effort fallback: a single-card core whose HD target forces 2
     /// showings cannot honour MIN_REPEAT_SPACING by construction (need
-    /// 1 + 3 + 1 + 3 + 1 = 9 slots, have 3). The contract degrades
+    /// 1 + MIN_REPEAT_SPACING + 1 slots, have 1). The contract degrades
     /// gracefully: copies are still emitted so the learner drills the
     /// card, every copy follows the anchor, and the anchor keeps the
     /// first slot.


### PR DESCRIPTION
Lessons were too long. Only high-difficulty cards now get 2 showings; new, in-progress, and known cards get 1.

target_showings: is_high_difficulty -> 2, everything else -> 1.

Follow-up to #336's first commit (f36e1304) which kept new/in-progress at target=2 — user feedback: still too long, new/in-progress should be 1.

CI: clippy + fmt + cargo test -p origa (1579 passed, 0 failed).