### PR TITLE
fix(ci): disable updater artifacts when signing key is absent

### DIFF
--- a/tauri/build.rs
+++ b/tauri/build.rs
@@ -182,6 +182,33 @@ fn inject_csp_via_tauri_config(
             env::set_var("TAURI_CONFIG", &patched);
         }
         println!("cargo:rustc-env=TAURI_CONFIG={patched}");
+    } else if env::var("TAURI_SIGNING_PRIVATE_KEY")
+        .unwrap_or_default()
+        .is_empty()
+    {
+        // No signing key available (Dependabot PRs — GitHub hides repository
+        // secrets from bot runs; or local dev without a key). The workflow
+        // workaround in _build-tauri.yml sets TAURI_SIGNING_PRIVATE_KEY to
+        // an empty string, but tauri.conf.json has createUpdaterArtifacts:
+        // true, which makes the bundler try to sign regardless. An empty key
+        // fails with "failed to decode secret key: … Missing comment in
+        // secret key". Patching createUpdaterArtifacts: false here skips the
+        // signing step entirely, producing a compile-only build without
+        // updater signatures — the desired behaviour for verification.
+        let no_sign_patch = json!({
+            "bundle": {
+                "createUpdaterArtifacts": false
+            }
+        });
+        let mut cfg: serde_json::Value = serde_json::from_str(&final_config_str)
+            .expect("TAURI_CONFIG must be valid JSON for no-signing-key patch");
+        build_config::apply_merge_patch(&mut cfg, no_sign_patch);
+        let patched = cfg.to_string();
+        // SAFETY: same single-threaded build-script contract as above.
+        unsafe {
+            env::set_var("TAURI_CONFIG", &patched);
+        }
+        println!("cargo:rustc-env=TAURI_CONFIG={patched}");
     } else {
         // Desktop distribution path: emit final_config_str unchanged
         // (CSP-merged, createUpdaterArtifacts still true per tauri.conf.json
@@ -200,6 +227,7 @@ fn inject_csp_via_tauri_config(
     }
 
     println!("cargo:rerun-if-env-changed=ORIGA_APP_STORE");
+    println!("cargo:rerun-if-env-changed=TAURI_SIGNING_PRIVATE_KEY");
     println!("cargo:rerun-if-env-changed=ORIGA_CDN_BASE_URL");
     println!("cargo:rerun-if-env-changed=TRAILBASE_URL");
     println!("cargo:rerun-if-env-changed=ORIGA_LANDING_BASE_URL");

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -277,6 +277,49 @@ fn apply_merge_patch_csp_into_tauri_cli_config_preserves_overrides() {
     assert_eq!(target["app"]["security"]["csp"], "default-src 'self'");
 }
 
+/// Regression guard for the no-signing-key patch applied when
+/// `TAURI_SIGNING_PRIVATE_KEY` is empty (Dependabot PRs, local dev without a
+/// key). The committed `tauri.conf.json` has `createUpdaterArtifacts: true`;
+/// the build script patches it to `false` so the bundler skips signing.
+/// Without this patch, Tauri fails with "failed to decode secret key:
+/// … Missing comment in secret key" because the empty key is invalid.
+///
+/// This test simulates the exact merge: load the committed config, apply the
+/// CSP patch, then apply the no-sign patch, and assert the final result.
+#[test]
+fn apply_merge_patch_no_signing_key_disables_updater_artifacts() {
+    // Start from the committed tauri.conf.json (includes
+    // createUpdaterArtifacts: true).
+    let mut target: serde_json::Value = serde_json::from_str(include_str!("../tauri.conf.json"))
+        .expect("tauri.conf.json must be valid JSON");
+
+    // The CSP patch our build.rs applies first.
+    let csp_patch = serde_json::json!({
+        "app": { "security": { "csp": "default-src 'self'" } }
+    });
+    apply_merge_patch(&mut target, csp_patch);
+
+    // The no-signing-key patch our build.rs applies when
+    // TAURI_SIGNING_PRIVATE_KEY is empty.
+    let no_sign_patch = serde_json::json!({
+        "bundle": { "createUpdaterArtifacts": false }
+    });
+    apply_merge_patch(&mut target, no_sign_patch);
+
+    // The patch must flip createUpdaterArtifacts to false.
+    assert_eq!(
+        target["bundle"]["createUpdaterArtifacts"], false,
+        "no-signing-key patch must disable createUpdaterArtifacts"
+    );
+    // CSP must survive (applied first, not overwritten).
+    assert_eq!(target["app"]["security"]["csp"], "default-src 'self'");
+    // Other bundle keys (icon, targets) must survive the merge.
+    assert_eq!(
+        target["bundle"]["targets"], "all",
+        "bundle.targets must survive the no-signing-key patch"
+    );
+}
+
 /// `resolve_env` falls back to the default when the env var is unset (`None`).
 /// Asserting against the literal CDN host (not the `DEFAULT_CDN` constant)
 /// makes this a real drift guard: changing the constant breaks the assertion.


### PR DESCRIPTION
## Root Cause

ALL 14 dependabot PRs fail with the same error in Build Tauri / Build Linux + Build Windows:

```
Error failed to decode secret key: incorrect updater private key password: Missing comment in secret key
```

The workaround in `_build-tauri.yml` (lines 90-91, 199-200) empties `TAURI_SIGNING_PRIVATE_KEY` for dependabot runs — but `tauri.conf.json:31` has `createUpdaterArtifacts: true` (added in #257), so tauri-bundler tries to sign regardless and chokes on the empty key.

The workflow workaround (#175) predates `createUpdaterArtifacts: true` (#257) and no longer works.

## Fix

Extend `tauri/build.rs` with a third branch: when `TAURI_SIGNING_PRIVATE_KEY` is empty/unset, patch `createUpdaterArtifacts: false` via `TAURI_CONFIG` — the same RFC 7396 mechanism already used for `ORIGA_APP_STORE`. The bundler then skips signing entirely, producing a compile-only build.

## Test

New regression test `apply_merge_patch_no_signing_key_disables_updater_artifacts` simulates the full merge chain (CSP patch → no-sign patch) against the committed `tauri.conf.json`.

```
test result: ok. 22 passed; 0 failed; 0 ignored
```

## Verification

- `cargo test -p origa-app --test build_config` — 22/22 ✓
- `cargo clippy -p origa-app --all-targets -- -D warnings` — clean ✓
- `cargo fmt --check --all` — clean ✓

Once this merges, all dependabot PRs should pass Build Tauri Linux/Windows and can be triaged on their actual merits.