### PR TITLE
fix(csp): unblock Sentry SDK, Replay worker, and data: audio

### DIFF
--- a/origa/src/domain/user.rs
+++ b/origa/src/domain/user.rs
@@ -680,6 +680,47 @@ mod tests {
         assert_eq!(user1.imported_sets().len(), 3);
     }
 
+    /// Regression guard for the cross-device onboarding-repeat bug: a user
+    /// who completed/skipped onboarding on device 1 has the sentinel inside
+    /// `imported_sets`. When device 2 merges the remote record into its
+    /// (empty) local record, the sentinel MUST survive so
+    /// `is_onboarding_completed()` stays true — otherwise onboarding is
+    /// shown again on the new device.
+    #[test]
+    fn user_merge_preserves_onboarding_completed_sentinel() {
+        // Device 1 — finished onboarding (skip path writes SKIPPED, finish
+        // path writes COMPLETED; both must survive merge).
+        let mut device1 = User::new("d1@example.com".to_string(), NativeLanguage::Russian, None);
+        device1.mark_set_as_imported("jlpt_n5".to_string());
+        device1.mark_set_as_imported(ONBOARDING_SKIPPED_KEY.to_string());
+
+        // Device 2 — fresh local user (no imported sets yet).
+        let mut device2 = User::new("d1@example.com".to_string(), NativeLanguage::Russian, None);
+
+        // merge_current_user flow: local.merge(&remote).
+        device2.merge(&device1);
+
+        assert!(
+            device2.is_onboarding_completed(),
+            "after merging a remote user with ONBOARDING_SKIPPED_KEY, \
+             is_onboarding_completed() must be true — a false here is the \
+             cross-device onboarding-repeat regression"
+        );
+        assert!(device2.is_set_imported(ONBOARDING_SKIPPED_KEY));
+        assert!(device2.is_set_imported("jlpt_n5"));
+
+        // Also cover the COMPLETED sentinel (finish path).
+        let mut device1b = User::new("d1b@example.com".to_string(), NativeLanguage::Russian, None);
+        device1b.mark_onboarding_completed();
+        let mut device2b = User::new("d1b@example.com".to_string(), NativeLanguage::Russian, None);
+        device2b.merge(&device1b);
+        assert!(
+            device2b.is_onboarding_completed(),
+            "after merging a remote user with ONBOARDING_COMPLETED_KEY, \
+             is_onboarding_completed() must be true"
+        );
+    }
+
     #[test]
     fn user_merge_takes_identity_from_remote() {
         // Remote is the source of truth for identity. A local user created with

--- a/origa_ui/src/repository/trailbase_repository_tests.rs
+++ b/origa_ui/src/repository/trailbase_repository_tests.rs
@@ -68,3 +68,62 @@ fn userrow_to_user_self_heals_on_corrupt_knowledge_set() {
         "corrupt knowledge_set must self-heal to empty, never panic"
     );
 }
+
+/// Regression guard for the cross-device onboarding-repeat bug: the
+/// `__onboarding_skipped__` / `__onboarding_completed__` sentinel keys
+/// live inside `imported_sets`, so they MUST survive the
+/// `user_to_json` → wire → `UserRow::to_user` round-trip. If they are
+/// dropped, a user who skips onboarding on device A is shown onboarding
+/// again on device B because `is_onboarding_completed()` returns false.
+#[test]
+fn user_to_json_then_userrow_roundtrip_preserves_onboarding_sentinels() {
+    use origa::domain::{ONBOARDING_COMPLETED_KEY, ONBOARDING_SKIPPED_KEY};
+
+    // Arrange — a user who skipped onboarding (skip path writes
+    // ONBOARDING_SKIPPED_KEY via mark_set_as_imported).
+    let mut user = User::new(
+        "sentinel-test@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    );
+    user.mark_set_as_imported(ONBOARDING_SKIPPED_KEY.to_string());
+    assert!(
+        user.is_onboarding_completed(),
+        "fixture precondition: user must be onboarding-completed before round-trip"
+    );
+
+    // Act — encode to the wire body, deserialize back as a UserRow, rebuild.
+    let body = user_to_json(&user, "00000000-0000-0000-0000-000000000003").expect("user_to_json");
+    let row: UserRow = serde_json::from_value(body).expect("UserRow deserialize from wire body");
+    let restored = row.to_user();
+
+    // Assert — both sentinel keys survive, and the routing guard still
+    // reports onboarding as completed after the round-trip.
+    assert!(
+        restored.is_set_imported(ONBOARDING_SKIPPED_KEY),
+        "ONBOARDING_SKIPPED_KEY must survive the wire round-trip"
+    );
+    assert!(
+        restored.is_onboarding_completed(),
+        "is_onboarding_completed() must be true after the round-trip — \
+         a false here is the cross-device onboarding-repeat regression"
+    );
+
+    // Also cover the completed-marker path (written by the finish path via
+    // mark_onboarding_completed, which inserts ONBOARDING_COMPLETED_KEY).
+    let mut finished = User::new(
+        "completed-test@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    );
+    finished.mark_onboarding_completed();
+    let body =
+        user_to_json(&finished, "00000000-0000-0000-0000-000000000004").expect("user_to_json");
+    let row: UserRow = serde_json::from_value(body).expect("UserRow deserialize from wire body");
+    let restored = row.to_user();
+    assert!(
+        restored.is_set_imported(ONBOARDING_COMPLETED_KEY),
+        "ONBOARDING_COMPLETED_KEY must survive the wire round-trip"
+    );
+    assert!(restored.is_onboarding_completed());
+}

--- a/tauri/build_config.rs
+++ b/tauri/build_config.rs
@@ -42,11 +42,21 @@ pub(crate) const DEFAULT_SENTRY_INGEST_HOST: &str = "o4511840951992320.ingest.us
 /// telemetry, OAuth providers) remain hardcoded — they are not
 /// environment-dependent.
 ///
-/// Sentry's loader host (`js.sentry-cdn.com`) is static. Its ingest host is
-/// pinned to the project's exact host (extracted from the DSN at build time
-/// by `build.rs` and passed here as `sentry_ingest_host`). Pinning to a
-/// single host rather than `*.sentry.io` avoids the exfiltration vector of a
-/// wildcard on the multi-tenant `sentry.io` SaaS — see ADR-036 §7.
+/// Sentry's loader host (`js.sentry-cdn.com`) is static, as is the SDK
+/// bundle host (`browser.sentry-cdn.com`). The ingest host is pinned to
+/// the project's exact host (extracted from the DSN at build time by
+/// `build.rs` and passed here as `sentry_ingest_host`). Pinning to a
+/// single host rather than `*.sentry.io` avoids the exfiltration vector
+/// of a wildcard on the multi-tenant `sentry.io` SaaS — see ADR-036 §7.
+///
+/// Session Replay requires three extra directives beyond the loader /
+/// bundle / ingest hosts:
+/// - `connect-src data:` — the SDK encodes compression payloads as
+///   `data:` URLs (getsentry/sentry-javascript#4468).
+/// - `worker-src 'self' blob:` — Replay runs its compression in a
+///   blob-URL Web Worker.
+/// - `child-src 'self' blob:` — fallback for browsers that do not
+///   implement `worker-src` yet.
 ///
 /// The literal is kept on a single line because `rustfmt` does not reflow
 /// string-literal contents, and byte-equality with `tauri.conf.json` must hold
@@ -58,7 +68,7 @@ pub(crate) fn build_csp(
     sentry_ingest_host: &str,
 ) -> String {
     format!(
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://{sentry_ingest_host}; img-src 'self' data: blob: {cdn}; media-src 'self' blob: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://{sentry_ingest_host}; img-src 'self' data: blob: {cdn}; media-src 'self' blob: data: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:"
     )
 }
 

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -22,7 +22,8 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://o4511840951992320.ingest.us.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'"
+            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://o4511840951992320.ingest.us.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: data: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:",
+            "dangerousDisableAssetCspModification": true
         }
     },
     "bundle": {

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -112,11 +112,32 @@ fn build_csp_substitutes_staging_hosts() {
     // Sentry: loader host is static, ingest host is parameterised. The ingest
     // host must be pinned to the exact staging value — NOT a wildcard — to
     // avoid the multi-tenant SaaS exfil vector. See ADR-036 §7.
+    //
+    // The loader (js.sentry-cdn.com) is a thin bootstrap that fetches the
+    // actual SDK bundle from browser.sentry-cdn.com, so BOTH hosts must be in
+    // script-src — listing only the loader leaves the bundle blocked by CSP.
+    //
+    // Session Replay additionally needs connect-src data: (compression
+    // payload encoding), worker-src 'self' blob: (compression Web Worker),
+    // and child-src 'self' blob: (worker-src fallback for older browsers).
     assert!(csp.contains("https://js.sentry-cdn.com"));
+    assert!(csp.contains("https://browser.sentry-cdn.com"));
     assert!(csp.contains("https://o-staging.ingest.sentry.io"));
     assert!(
         !csp.contains("*.sentry.io"),
         "CSP must NOT contain a sentry.io wildcard — see ADR-036 §7"
+    );
+    assert!(
+        csp.contains("connect-src 'self' ipc: http://ipc.localhost data:"),
+        "connect-src must allow data: for Sentry Replay compression payloads"
+    );
+    assert!(
+        csp.contains("worker-src 'self' blob:"),
+        "worker-src must allow blob: for the Sentry Replay Web Worker"
+    );
+    assert!(
+        csp.contains("child-src 'self' blob:"),
+        "child-src must allow blob: as a worker-src fallback for older browsers"
     );
 
     // Production hosts must NOT leak into the staging build.


### PR DESCRIPTION
## Problem

Three CSP directives were blocking Sentry from initialising and audio data URIs from playing:

1. **Sentry SDK bundle blocked** — `script-src` had `js.sentry-cdn.com` (the loader) but not `browser.sentry-cdn.com` (where the actual `bundle.tracing.replay.min.js` is served from). Result: zero Sentry activity despite `SENTRY_DSN` being set.

2. **Session Replay blocked** — the Replay integration needs additional directives beyond the bundle host:
   - `connect-src data:` — compression payloads encoded as `data:` URLs ([getsentry/sentry-javascript#4468](https://github.com/getsentry/sentry-javascript/issues/4468))
   - `worker-src 'self' blob:` — compression runs in a `blob:` Web Worker
   - `child-src 'self' blob:` — `worker-src` fallback for older WebView

3. **`data:audio/wav` blocked** — `media-src` was missing `data:`.

Also added `dangerousDisableAssetCspModification: true` so Tauri does not re-inject its own CSP modification on top of the hand-tuned policy.

## Changes

- `tauri/tauri.conf.json` — committed CSP updated + `dangerousDisableAssetCspModification`
- `tauri/build_config.rs` — build-time CSP template updated (byte-equality with committed CSP preserved)
- `tauri/tests/build_config.rs` — regression assertions for `browser.sentry-cdn.com`, `connect-src data:`, `worker-src`, `child-src`

## Tests

Added regression tests guarding the cross-device onboarding-repeat code path (reported separately, root cause still under investigation at runtime):
- `user_to_json_then_userrow_roundtrip_preserves_onboarding_sentinels` — TrailBase wire round-trip of `__onboarding_skipped__` / `__onboarding_completed__` sentinel keys
- `user_merge_preserves_onboarding_completed_sentinel` — `User::merge` preserving sentinels when syncing a fresh device against a remote record

Both pass against the current code, locking the contract that `is_onboarding_completed()` survives sync.

## Verification

- `cargo test --test build_config` — 22 passed (byte-equality + staging assertions)
- `cargo test -p origa --lib domain::user` — 29 passed
- `cargo test -p origa_ui --lib repository::trailbase_repository` — 3 passed
- `cargo fmt --check` — clean
- `cargo clippy -p origa -p origa_ui --all-targets -- -D warnings` — clean