### PR TITLE
fix(ci): macOS App Store upload fails on prerelease versions (-19239)

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -203,15 +203,14 @@ jobs:
 
             - name: Upload to App Store Connect
               id: upload
-              continue-on-error: true
               env:
                   APPLE_API_ISSUER: ${{ secrets.apple-api-issuer }}
                   APPLE_API_KEY: ${{ secrets.apple-api-key }}
               run: |
                   # xcrun altool handles App Store Connect upload using the same
-                  # API key as signing. continue-on-error: true so a failed
-                  # upload does not block the workflow — the .ipa is preserved
-                  # as artifact for manual upload via Transporter.app.
+                  # API key as signing. A failed upload fails the job so the
+                  # problem is visible immediately — the .ipa is preserved as
+                  # artifact for manual upload via Transporter.app.
                   xcrun altool --upload-app --type ios \
                     --file "${{ steps.ipa.outputs.path }}" \
                     --apiKey "$APPLE_API_KEY" \
@@ -339,9 +338,15 @@ jobs:
               run: echo "APPLE_API_KEY_PATH=${{ steps.decode-key.outputs.key-path }}" >> "$GITHUB_ENV"
 
             - name: Update version in config files
+              # macOS CFBundleShortVersionString must be one to three
+              # period-separated integers (Apple validation -19239 rejects
+              # SemVer pre-release suffixes like "-rc5"). version_base strips
+              # the suffix ("0.4.10-rc5" → "0.4.10"), which is what Apple
+              # accepts. ORIGA_VERSION (env var, for Sentry) keeps the full
+              # version including the pre-release tag.
               uses: ./.github/actions/update-version
               with:
-                  version: ${{ inputs.version }}
+                  version: ${{ inputs.version_base }}
 
             - name: Setup Rust with caching
               uses: ./.github/actions/setup-rust
@@ -494,7 +499,6 @@ jobs:
 
             - name: Upload to App Store Connect
               id: upload
-              continue-on-error: true
               timeout-minutes: 15
               env:
                   APPLE_API_ISSUER: ${{ secrets.apple-api-issuer }}

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -288,10 +288,10 @@ jobs:
                       - `Origa_amd64.deb` — Debian/Ubuntu
 
                       ## iOS
-                      ${{ needs.build-apple.outputs.ios-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- iOS build pending (Apple pipeline did not upload)' }}
+                      ${{ needs.build-apple.outputs.ios-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- ⚠️ iOS upload FAILED — check CI logs. Download ios-build artifact and upload via Transporter.app' }}
 
                       ## macOS
-                      ${{ needs.build-apple.outputs.macos-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- macOS build pending (Apple pipeline did not upload)' }}
+                      ${{ needs.build-apple.outputs.macos-upload-status == 'success' && '- App Store: install via TestFlight (see App Store Connect)' || '- ⚠️ macOS upload FAILED — check CI logs. Download macos-pkg-build artifact and upload via Transporter.app' }}
 
                       ## Android
                       - `origa.apk`


### PR DESCRIPTION
## Problem

macOS `.pkg` uploads to App Store Connect were silently failing on every prerelease tag (`v0.4.10-rc1` through `rc5`) with:

```
ERROR: CFBundleShortVersionString, "0.4.10-rc5", must be composed of one to three period-separated integers. (-19239)
```

Apple rejects SemVer pre-release suffixes for `CFBundleShortVersionString`. The job stayed **green** because the upload step had `continue-on-error: true`, and release notes misleadingly showed `macOS build pending`.

## Root Cause

`update-version` action wrote the full SemVer version (`0.4.10-rc5`) from `inputs.version` into `tauri.conf.json`, which Tauri propagated as `CFBundleShortVersionString` in the macOS `.app` → `.pkg`.

iOS uploads succeeded because `xcrun altool --type ios` is less strict than `--type mac`, but this is a latent risk for iOS submission review too.

## Fix

1. **`_build-tauri-apple.yml` (build-macos)**: use `inputs.version_base` (`0.4.10`) instead of `inputs.version` (`0.4.10-rc5`) for the `update-version` step. `ORIGA_VERSION` env var (for Sentry) keeps the full version — only the Apple-facing string is stripped.

2. **Remove `continue-on-error: true`** from both iOS and macOS `altool` upload steps so failures are immediately visible as red jobs.

3. **Release notes**: changed fallback text from misleading `pending` to `⚠️ FAILED` with actionable instructions (Transporter.app manual upload).

## Behavior after fix

- Apple upload failure → **red job** (visible immediately)
- GitHub Release still publishes (Windows/Linux/Android) since `release` job gates on `build-tauri`, not `build-apple`
- Release notes honestly report the failure state