### PR TITLE
fix(csp): allow browser.sentry-cdn.com in connect-src + TrailBase backup

### DIFF
--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -119,17 +119,27 @@ ARG ORIGA_CDN_BASE_URL
 ENV ORIGA_CDN_BASE_URL=${ORIGA_CDN_BASE_URL}
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl sqlite aws-cli
 
 COPY --from=builder /app/origa_ui/dist /app/public
+
+# Backup machinery: GFS-rotation script, custom entrypoint (crond + trail), crontab
+COPY backup.sh     /app/backup.sh
+COPY entrypoint.sh /app/entrypoint.sh
+COPY crontab       /app/crontab
+RUN chmod +x /app/backup.sh /app/entrypoint.sh \
+ && chmod 600 /app/crontab
 
 RUN chown -R trailbase:trailbase /app
 
 USER trailbase
+
+ENV BACKUP_BUCKET_PATH=trailbase
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD ["curl", "--fail", "http://localhost:8080/api/healthcheck"]
 
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["/app/trail", "run", "--address", "0.0.0.0:8080", "--public-dir", "/app/public", "--spa"]

--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -124,9 +124,9 @@ RUN apk add --no-cache curl sqlite aws-cli
 COPY --from=builder /app/origa_ui/dist /app/public
 
 # Backup machinery: GFS-rotation script, custom entrypoint (crond + trail), crontab
-COPY backup.sh     /app/backup.sh
-COPY entrypoint.sh /app/entrypoint.sh
-COPY crontab       /app/crontab
+COPY origa_ui/backup.sh     /app/backup.sh
+COPY origa_ui/entrypoint.sh /app/entrypoint.sh
+COPY origa_ui/crontab       /app/crontab
 RUN chmod +x /app/backup.sh /app/entrypoint.sh \
  && chmod 600 /app/crontab
 

--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -141,5 +141,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD ["curl", "--fail", "http://localhost:8080/api/healthcheck"]
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "/app/entrypoint.sh"]
 CMD ["/app/trail", "run", "--address", "0.0.0.0:8080", "--public-dir", "/app/public", "--spa"]

--- a/origa_ui/backup.sh
+++ b/origa_ui/backup.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# TrailBase SQLite → S3 backup with GFS (Grandfather-Father-Son) rotation.
+#
+# Retention (always exactly 6 main.db snapshots + 1 latest logs.db):
+#   snapshot-1.db.gz       — most recent  (≈12h ago)
+#   snapshot-2.db.gz       — 24h ago
+#   snapshot-3.db.gz       — 36h ago
+#   weekly-current.db.gz   — this week (Monday 03:00 UTC)
+#   weekly-previous.db.gz  — last week
+#   monthly.db.gz          — this month (1st, 03:00 UTC)
+#   logs-latest.db.gz      — latest logs.db (overwritten each run)
+set -eu
+
+# --- Configuration ---
+DATA_DIR="${TRAILBASE_DATA_DIR:-/app/traildepot/data}"
+BACKUP_BUCKET_PATH="${BACKUP_BUCKET_PATH:-trailbase}"
+S3_BASE="s3://${AWS_S3_BUCKET_NAME}/${BACKUP_BUCKET_PATH}"
+TMP_DIR="${TMPDIR:-/tmp}"
+
+export AWS_PAGER=""
+
+# --- S3 helper (always uses the configured endpoint) ---
+s3() {
+    aws s3 "$@" --endpoint-url "${AWS_ENDPOINT_URL}"
+}
+
+log() {
+    printf '[backup %s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+# --- Bail out if database doesn't exist yet ---
+if [ ! -f "${DATA_DIR}/main.db" ]; then
+    log "main.db not found — nothing to back up."
+    exit 0
+fi
+
+# --- Determine rotation scope from current date (UTC) ---
+CURRENT_HOUR=$(date -u +%H)
+CURRENT_DOW=$(date -u +%u)   # 1 = Monday
+CURRENT_DOM=$(date -u +%-d)  # day of month, no leading zero
+
+DO_WEEKLY=0
+DO_MONTHLY=0
+
+# Weekly rotation: Monday 03:00 UTC
+if [ "${CURRENT_DOW}" = "1" ] && [ "${CURRENT_HOUR}" = "03" ]; then
+    DO_WEEKLY=1
+fi
+
+# Monthly rotation: 1st of month 03:00 UTC
+if [ "${CURRENT_DOM}" = "1" ] && [ "${CURRENT_HOUR}" = "03" ]; then
+    DO_MONTHLY=1
+fi
+
+# --- Step 1: Online SQLite backup (safe while server is running) ---
+log "Backing up main.db..."
+sqlite3 "${DATA_DIR}/main.db" ".backup '${TMP_DIR}/main.db'"
+gzip -f "${TMP_DIR}/main.db"
+
+HAS_LOGS=0
+if [ -f "${DATA_DIR}/logs.db" ]; then
+    log "Backing up logs.db..."
+    sqlite3 "${DATA_DIR}/logs.db" ".backup '${TMP_DIR}/logs.db'"
+    gzip -f "${TMP_DIR}/logs.db"
+    HAS_LOGS=1
+fi
+
+# --- Step 2: Snapshot rotation (shift: 3 deleted, 2→3, 1→2, new→1) ---
+log "Rotating snapshots..."
+s3 rm "${S3_BASE}/snapshot-3.db.gz" 2>/dev/null || true
+s3 mv "${S3_BASE}/snapshot-2.db.gz" "${S3_BASE}/snapshot-3.db.gz" 2>/dev/null || true
+s3 mv "${S3_BASE}/snapshot-1.db.gz" "${S3_BASE}/snapshot-2.db.gz" 2>/dev/null || true
+s3 cp "${TMP_DIR}/main.db.gz" "${S3_BASE}/snapshot-1.db.gz"
+
+# --- Step 3: logs.db (latest only, overwrite each run) ---
+if [ "${HAS_LOGS}" = "1" ]; then
+    log "Uploading logs-latest..."
+    s3 cp "${TMP_DIR}/logs.db.gz" "${S3_BASE}/logs-latest.db.gz"
+fi
+
+# --- Step 4: Weekly rotation (Monday 03:00 UTC) ---
+if [ "${DO_WEEKLY}" = "1" ]; then
+    log "Weekly rotation..."
+    s3 mv "${S3_BASE}/weekly-current.db.gz" "${S3_BASE}/weekly-previous.db.gz" 2>/dev/null || true
+    s3 cp "${S3_BASE}/snapshot-1.db.gz" "${S3_BASE}/weekly-current.db.gz"
+fi
+
+# --- Step 5: Monthly overwrite (1st of month 03:00 UTC) ---
+if [ "${DO_MONTHLY}" = "1" ]; then
+    log "Monthly rotation..."
+    s3 cp "${S3_BASE}/snapshot-1.db.gz" "${S3_BASE}/monthly.db.gz"
+fi
+
+# --- Cleanup ---
+rm -f "${TMP_DIR}/main.db.gz" "${TMP_DIR}/logs.db.gz"
+log "Backup completed."

--- a/origa_ui/crontab
+++ b/origa_ui/crontab
@@ -1,0 +1,4 @@
+# TrailBase backup schedule (UTC)
+# Twice daily: 03:00 and 15:00
+# Weekly/monthly rotation is determined inside backup.sh by date.
+0 3,15 * * * /app/backup.sh

--- a/origa_ui/entrypoint.sh
+++ b/origa_ui/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# Custom entrypoint: start crond in background, then exec the main process.
-# busybox crond needs crontab files in a dedicated directory, one file per user.
+# Custom entrypoint: start crond in background, then exec the main process (trail).
+# tini runs as PID 1 (see Dockerfile ENTRYPOINT) and handles signal forwarding + zombie reaping.
 CROND_DIR=/tmp/crond
 mkdir -p "$CROND_DIR"
 cp /app/crontab "$CROND_DIR/root"
 crond -c "$CROND_DIR" -l 8
-exec tini -- "$@"
+exec "$@"

--- a/origa_ui/entrypoint.sh
+++ b/origa_ui/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Custom entrypoint: start crond in background, then exec the main process.
+# busybox crond needs crontab files in a dedicated directory, one file per user.
+CROND_DIR=/tmp/crond
+mkdir -p "$CROND_DIR"
+cp /app/crontab "$CROND_DIR/root"
+crond -c "$CROND_DIR" -l 8
+exec tini -- "$@"

--- a/tauri/build_config.rs
+++ b/tauri/build_config.rs
@@ -68,7 +68,7 @@ pub(crate) fn build_csp(
     sentry_ingest_host: &str,
 ) -> String {
     format!(
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://{sentry_ingest_host}; img-src 'self' data: blob: {cdn}; media-src 'self' blob: data: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://browser.sentry-cdn.com https://{sentry_ingest_host}; img-src 'self' data: blob: {cdn}; media-src 'self' blob: data: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:"
     )
 }
 

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -22,7 +22,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://o4511840951992320.ingest.us.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: data: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:",
+            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://browser.sentry-cdn.com https://o4511840951992320.ingest.us.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: data: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:",
             "dangerousDisableAssetCspModification": true
         }
     },

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -132,6 +132,10 @@ fn build_csp_substitutes_staging_hosts() {
         "connect-src must allow data: for Sentry Replay compression payloads"
     );
     assert!(
+        csp.contains("https://browser.sentry-cdn.com https://o-staging.ingest.sentry.io"),
+        "connect-src must allow browser.sentry-cdn.com for source map (.map) fetches"
+    );
+    assert!(
         csp.contains("worker-src 'self' blob:"),
         "worker-src must allow blob: for the Sentry Replay Web Worker"
     );


### PR DESCRIPTION
## CSP fix (follow-up to #345)

Sentry SDK fetches `.map` source map files from `browser.sentry-cdn.com` via `fetch()` to beautify stack traces. The host was already in `script-src` (#345) but **missing from `connect-src`**, so every source map request was blocked:

```
Connecting to 'https://browser.sentry-cdn.com/10.69.0/bundle.tracing.replay.min.js.map'
violates the following Content Security Policy directive: "connect-src ..."
```

Added `https://browser.sentry-cdn.com` to `connect-src` in all three CSP entry points.

## TrailBase backup (GFS rotation)

Adds a backup sidecar to the `origa_ui` Docker image:
- **backup.sh** — GFS-rotation SQLite backup (daily 14d, weekly 8w, monthly 6m) uploaded to S3 via `aws-cli`
- **entrypoint.sh** — starts busybox `crond` in background, then execs the main `trail` process under `tini`
- **crontab** — twice-daily schedule (03:00 + 15:00 UTC)
- **Dockerfile** — installs `sqlite` + `aws-cli`, copies backup scripts, sets `ENTRYPOINT` + `BACKUP_BUCKET_PATH` env

## Verification

- `cargo test --test build_config` — 22 passed (byte-equality + staging assertions updated)
- `cargo fmt --check` — clean