### PR TITLE
fix(ui): align kanji hover chars to baseline for mixed kana/kanji text

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1803,7 +1803,7 @@ rt {
     cursor: pointer;
     display: inline-block;
     position: relative;
-    vertical-align: middle;
+    vertical-align: baseline;
     line-height: 1;
 }
 


### PR DESCRIPTION
## Root cause

`.kanji-char-hover` had `vertical-align: middle` which shifted kanji characters up relative to surrounding hiragana/katakana (which stay on the text baseline). In mixed words like 引き出す, kanji 引・出 sat higher than kana き・す.

## Fix

```diff
- vertical-align: middle;
+ vertical-align: baseline;
```

`display: inline-block` is retained (needed for `position: relative` hover popup), but baseline alignment restores proper vertical position.

## Screenshots

**Before:** kanji characters displaced vertically upward vs hiragana in the same word
**After:** all characters on the same baseline