### PR TITLE
fix(android): add wasm-dev profile to prevent OOM on dev emulator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,20 @@ $env:ORIGA_CDN_BASE_URL = "https://s3.origa.uwuwu.net"  # ОБЯЗАТЕЛЬНО
 cd tauri && cargo tauri dev
 ```
 
+### Android dev (эмулятор)
+
+Debug WASM-бандл раздувается до ~300 МБ и крашит Android WebView кучу
+(`OutOfMemoryError` в `RustWebViewClient.shouldInterceptRequest`,
+tauri-apps/tauri#13554). Для `cargo tauri android dev` обязательно
+использовать профиль `wasm-dev` (определён в корневом `Cargo.toml`):
+стрип debug-символов + opt-level=1, компилируется быстро, WASM ~8–19 МБ.
+
+```powershell
+$env:ORIGA_CDN_BASE_URL = "https://s3.origa.uwuwu.net"
+$env:TRUNK_BUILD_CARGO_PROFILE = "wasm-dev"
+cd tauri && cargo tauri android dev
+```
+
 ### Переменные окружения (compile-time, `build.rs`)
 
 Обязательные: `ORIGA_CDN_BASE_URL`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,3 +213,16 @@ opt-level = 'z'
 lto = "fat"
 codegen-units = 1
 panic = "abort"
+
+# Android dev: debug WASM balloons to ~300 MB and crashes the WebView heap
+# (OutOfMemoryError in RustWebViewClient.shouldInterceptRequest — see
+# tauri-apps/tauri#13554). This profile strips debug symbols and applies a
+# light opt-level so the resulting .wasm fits the ~192 MB Android heap while
+# still compiling fast enough for hot reload. Use via
+# `TRUNK_BUILD_CARGO_PROFILE=wasm-dev cargo tauri android dev`.
+[profile.wasm-dev]
+inherits = "dev"
+opt-level = 1
+debug = 0
+strip = true
+codegen-units = 16


### PR DESCRIPTION
## Problem

Debug WASM bundle (`origa_ui_bin.wasm`) balloons to **~312 MB** after wasm-opt (1.3 GB before it). Android WebView cannot allocate 326 MB in the app heap (~192 MB limit) → `OutOfMemoryError` in `RustWebViewClient.shouldInterceptRequest` → crash on launch.

This is a known Tauri issue on Android: tauri-apps/tauri#13554.

## Solution

Added a `wasm-dev` cargo profile (in root `Cargo.toml`) that inherits from `dev` but:
- `strip = true` — removes debug symbols (~80% of the size)
- `debug = 0` — no debug info
- `opt-level = 1` — light optimization (fast compile, good compression)
- `codegen-units = 16` — parallel compilation

| Metric | Debug (was) | wasm-dev (now) |
|--------|------------|----------------|
| WASM size | **312 MB** | **8–19 MB** |
| Reduction | — | **~37×** |
| Android OOM | 💥 crash | ✅ fits heap |
| Compile speed | fast | acceptable (opt-level=1) |

## Usage

```bash
TRUNK_BUILD_CARGO_PROFILE=wasm-dev cargo tauri android dev
```

Desktop dev is unaffected — `cargo tauri dev` uses the default debug profile with full hot reload.

Documented in AGENTS.md.