### PR TITLE
feat(sentry): wire tracing → Sentry events, breadcrumbs, structured logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6072,6 +6072,7 @@ dependencies = [
  "tauri-plugin-tts",
  "tauri-plugin-updater",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7941,6 +7942,7 @@ dependencies = [
  "sentry-contexts",
  "sentry-core",
  "sentry-debug-images",
+ "sentry-log",
  "sentry-panic",
  "sentry-tracing",
  "tokio",
@@ -8005,6 +8007,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee1e7c19e715ae9538114bbd09c2442689a481e2adbc8245c9e06b20d2bd2be"
 dependencies = [
  "findshlibs",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-log"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba08897af468a109afafba1f00c25d40070ef76309759833cccb83151a5be73d"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
  "sentry-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ sentry = { version = "0.49", default-features = false, features = [
     "release-health",
     "reqwest",
     "debug-images",
+    "tracing",
+    "logs",
 ] }
 
 # Domain

--- a/origa_ui/src/sentry.rs
+++ b/origa_ui/src/sentry.rs
@@ -77,7 +77,16 @@ pub(crate) fn init_with(dsn: &str, release: &str, environment: &str) {
                     dsn: "{dsn}",
                     release: "{release}",
                     environment: "{environment}",
-                    sendDefaultPii: false
+                    sendDefaultPii: false,
+                    tracesSampleRate: 1.0,
+                    integrations: [
+                        // CaptureConsole routes tracing-wasm's console.error
+                        // output (which is where all WASM tracing::error! calls
+                        // land via the WASMLayer) into Sentry as error events.
+                        // console.warn/info become breadcrumbs via the default
+                        // Breadcrumbs integration (not CaptureConsole).
+                        new Sentry.Integrations.CaptureConsole({{ levels: ['error'] }})
+                    ]
                 }});
                 Sentry.setTag("layer", "ui");
             }};

--- a/origa_ui/src/sentry.rs
+++ b/origa_ui/src/sentry.rs
@@ -163,7 +163,15 @@ fn extract_public_key(dsn: &str) -> Option<&str> {
     Some(key)
 }
 
-/// Create and append a `<script src=url crossorigin>` element to `<head>`.
+/// Create and append a `<script src=url crossorigin data-lazy=no>` element to
+/// `<head>`.
+///
+/// `data-lazy="no"` forces the loader to fetch the full SDK immediately (on the
+/// next event-loop tick) instead of waiting for the first error. This is
+/// required for performance monitoring: BrowserTracing must be active *before*
+/// the app's `fetch` calls to capture them as transactions. Without it, the
+/// loader only downloads the SDK when an error occurs — by which point the
+/// dictionary-loading `fetch` requests have already happened uninstrumented.
 fn inject_script(
     document: &Document,
     head: &web_sys::HtmlHeadElement,
@@ -172,6 +180,7 @@ fn inject_script(
     let script: Element = document.create_element("script")?;
     script.set_attribute("src", url)?;
     script.set_attribute("crossorigin", "anonymous")?;
+    script.set_attribute("data-lazy", "no")?;
     head.append_child(&script)?;
     Ok(())
 }
@@ -265,6 +274,15 @@ mod wasm_tests {
             last_src.contains("js.sentry-cdn.com/abc123def456.min.js"),
             "injected script src must point at the Sentry loader CDN with the DSN public key, got: {last_src}"
         );
+
+        // data-lazy="no" must be set so the loader fetches the full SDK
+        // immediately (required for BrowserTracing to capture fetch calls
+        // during dictionary loading).
+        let last_data_lazy = last_head_script_data_lazy().unwrap_or_default();
+        assert_eq!(
+            last_data_lazy, "no",
+            "injected script must have data-lazy=no for eager SDK loading"
+        );
     }
 
     fn count_head_scripts() -> usize {
@@ -284,5 +302,15 @@ mod wasm_tests {
         let last = nodes.item(nodes.length() - 1)?;
         let el = last.dyn_ref::<web_sys::Element>()?;
         el.get_attribute("src")
+    }
+
+    fn last_head_script_data_lazy() -> Option<String> {
+        let window = web_sys::window()?;
+        let document = window.document()?;
+        let head = document.head()?;
+        let nodes = head.query_selector_all("script").ok()?;
+        let last = nodes.item(nodes.length() - 1)?;
+        let el = last.dyn_ref::<web_sys::Element>()?;
+        el.get_attribute("data-lazy")
     }
 }

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -45,6 +45,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt"] }
 sentry.workspace = true
 
 # device-ai plugin + crate: native ASR/OCR/TTS, primary on macOS/iOS/Android.

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -50,7 +50,18 @@ pub fn run() {
     // sentry transport uses `rustls-no-provider` and reuses this ring provider.
     // The guard must outlive `tauri::Builder::run` — kept on the stack, dropped
     // only when `run()` returns (i.e. process exit). See ADR-036.
+    // 1. Initialize Sentry FIRST — it creates the global Hub that
+    //    `sentry::integrations::tracing::layer()` relies on to dispatch
+    //    events/logs/breadcrumbs. The tracing subscriber (step 2) must be
+    //    registered AFTER the Hub exists, otherwise tracing events fire
+    //    into a void.
     let _sentry_guard = init_sentry();
+
+    // 2. Register the tracing subscriber with the Sentry layer. The
+    //    sentry-tracing layer routes `tracing::error!` → Sentry events,
+    //    `tracing::warn!/info!` → breadcrumbs, and (with `enable_logs`)
+    //    structured logs — instead of silently dropping them.
+    init_tracing();
 
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default();
@@ -173,6 +184,31 @@ pub fn run() {
         .expect("error while running tauri application");
 }
 
+/// Register the tracing subscriber with a Sentry layer.
+///
+/// **Must be called AFTER `init_sentry()`** — the `sentry::integrations::tracing::layer()`
+/// dispatches events through the global Hub created by `sentry::init`. Registering
+/// the subscriber before the Hub exists causes tracing events to fire into a void.
+///
+/// The Sentry layer routes tracing events as follows (with `logs` feature):
+/// - `ERROR` → Sentry event (issue) + structured log
+/// - `WARN`/`INFO` → breadcrumb + structured log
+/// - `DEBUG`/`TRACE` → ignored
+///
+/// The `fmt` layer (stdout/stderr) is desktop-only: on iOS/Android there is no
+/// terminal, and writing to stdout/stderr may pollute the system log or be silently
+/// dropped depending on the WebView configuration.
+fn init_tracing() {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    let registry = tracing_subscriber::registry().with(sentry::integrations::tracing::layer());
+
+    #[cfg(desktop)]
+    let registry = registry.with(tracing_subscriber::fmt::layer());
+
+    registry.init();
+}
+
 /// Initialize the Sentry client for native (Rust) crash reporting.
 ///
 /// Returns `None` (no-op) when `SENTRY_DSN_TAURI` is empty/unset — this is the
@@ -210,6 +246,8 @@ fn init_sentry() -> Option<sentry::ClientInitGuard> {
             .release(env!("SENTRY_RELEASE"))
             .environment(env!("SENTRY_ENVIRONMENT"))
             .send_default_pii(false)
+            .enable_logs(true)
+            .traces_sample_rate(1.0)
             .in_app_include(["origa", "origa_ui", "origa_app"]),
     );
 


### PR DESCRIPTION
## Problem

The `sentry` crate was compiled without the `"tracing"` and `"logs"` features, so all 172 `tracing::error!/warn!` calls across the codebase were silently dropped. Sentry received only panic events and release-health sessions — zero errors, zero logs, zero breadcrumbs.

## Solution

Wire the existing `tracing` instrumentation into Sentry on both layers:

| Layer | ERROR | WARN/INFO |
|-------|-------|-----------|
| Native (tauri) | Sentry event + structured log | breadcrumb + structured log |
| WASM (origa_ui) | Sentry event (via CaptureConsole) | breadcrumb |

### Changes

- **`Cargo.toml`**: add `"tracing"` + `"logs"` features to sentry crate
- **`tauri/Cargo.toml`**: add `tracing-subscriber` with `fmt` feature
- **`tauri/src/lib.rs`**: register tracing subscriber with `sentry::integrations::tracing::layer()` after `init_sentry()` (Hub must exist first). Enable `enable_logs(true)` + `traces_sample_rate(1.0)` in ClientOptions. `fmt` layer is desktop-only (no terminal on iOS/Android).
- **`origa_ui/src/sentry.rs`**: add `tracesSampleRate: 1.0` + `CaptureConsole({ levels: ['error'] })` to JS SDK init so WASM `tracing::error!` (routed to `console.error` by tracing-wasm) becomes Sentry events.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy -p origa-app -p origa_ui --all-targets -- -D warnings` ✓ (0 errors)
- `cargo test -p origa-app --lib` ✓ (10/10)
- `cargo test -p origa --lib` ✓ (1581/1581)