### PR TITLE
fix: ort-web CDN fallback, Sentry v8 compat, Android TLS init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6056,7 +6056,10 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "device-ai",
+ "jni",
+ "ndk-context",
  "rustls",
+ "rustls-platform-verifier",
  "sentry",
  "serde",
  "serde_json",

--- a/origa/src/ort_init.rs
+++ b/origa/src/ort_init.rs
@@ -61,12 +61,35 @@ pub async fn ensure() -> Result<InitOutcome, OrigaError> {
     result
 }
 
+/// ort-web runtime files are served from jsDelivr's npm mirror instead of
+/// the default `cdn.pyke.io`. The pyke CDN has been intermittently unreachable
+/// (`ERR_CONNECTION_RESET`), which causes ort-web initialization to fail —
+/// Whisper and OCR silently break. jsDelivr is Cloudflare-backed, has
+/// immutable caching, and mirrors the exact same `onnxruntime-web` npm
+/// package. The version is pinned to match the ort-web crate's bundled
+/// build (0.2.1+1.24 → onnxruntime-web 1.24.3).
+const ORT_WEB_CDN: &str = "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.24.3/dist/";
+
+/// Builds a `Dist` for the CPU-only (no execution provider features) build.
+fn dist_none() -> ort_web::Dist {
+    ort_web::Dist::new(ORT_WEB_CDN)
+        .with_script_name("ort.wasm.min.js")
+        .with_binary_name("ort-wasm-simd-threaded.wasm")
+}
+
+/// Builds a `Dist` for the WebGPU-enabled (JSEP) build.
+fn dist_webgpu() -> ort_web::Dist {
+    ort_web::Dist::new(ORT_WEB_CDN)
+        .with_script_name("ort.webgpu.min.js")
+        .with_binary_name("ort-wasm-simd-threaded.jsep.wasm")
+}
+
 async fn init_inner() -> Result<InitOutcome, OrigaError> {
     let webgpu_active = webgpu_adapter_available().await;
 
     if webgpu_active {
         tracing::info!("WebGPU adapter detected, initializing ort-web with FEATURE_WEBGPU");
-        match ort_web::api(ort_web::FEATURE_WEBGPU).await {
+        match ort_web::api(dist_webgpu()).await {
             Ok(api) => {
                 ort::set_api(api);
                 tracing::info!(webgpu_active = true, "ort-web initialized");
@@ -87,7 +110,7 @@ async fn init_inner() -> Result<InitOutcome, OrigaError> {
         );
     }
 
-    let api = ort_web::api(ort_web::FEATURE_NONE)
+    let api = ort_web::api(dist_none())
         .await
         .map_err(|e| OrigaError::OcrError {
             reason: format!("ort_web::api(FEATURE_NONE) failed: {e:?}"),

--- a/origa_ui/src/sentry.rs
+++ b/origa_ui/src/sentry.rs
@@ -70,23 +70,32 @@ pub(crate) fn init_with(dsn: &str, release: &str, environment: &str) {
 
     // 1. Install `window.sentryOnLoad` BEFORE injecting the script so the
     //    loader invokes it even when it loads synchronously from cache.
+    //
+    //    Sentry v8 removed the `Integrations.XXX` class hash — integrations
+    //    are now functions (e.g. `Sentry.captureConsoleIntegration()`).
+    //    Accessing `Sentry.Integrations.CaptureConsole` throws
+    //    `TypeError: Cannot read properties of undefined (reading
+    //    'CaptureConsole')`, which prevents `Sentry.init` from running at
+    //    all. The loader script serves the latest SDK, so we must use the
+    //    v8 functional API. See Sentry v7-to-v8 migration guide.
     let init_js = format!(
         r#"(function() {{
             window.sentryOnLoad = function() {{
+                // captureConsoleIntegration routes tracing-wasm's console.error
+                // output (which is where all WASM tracing::error! calls land via
+                // the WASMLayer) into Sentry as error events. console.warn/info
+                // become breadcrumbs via the default Breadcrumbs integration.
+                var integrations = [];
+                if (typeof Sentry.captureConsoleIntegration === 'function') {{
+                    integrations.push(Sentry.captureConsoleIntegration({{ levels: ['error'] }}));
+                }}
                 Sentry.init({{
                     dsn: "{dsn}",
                     release: "{release}",
                     environment: "{environment}",
                     sendDefaultPii: false,
                     tracesSampleRate: 1.0,
-                    integrations: [
-                        // CaptureConsole routes tracing-wasm's console.error
-                        // output (which is where all WASM tracing::error! calls
-                        // land via the WASMLayer) into Sentry as error events.
-                        // console.warn/info become breadcrumbs via the default
-                        // Breadcrumbs integration (not CaptureConsole).
-                        new Sentry.Integrations.CaptureConsole({{ levels: ['error'] }})
-                    ]
+                    integrations: integrations
                 }});
                 Sentry.setTag("layer", "ui");
             }};

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -66,3 +66,14 @@ base64.workspace = true
 # in the public API). Target-scoping keeps the desktop binary clean.
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 tauri-plugin-haptics.workspace = true
+
+# Android-only: rustls-platform-verifier JNI initialization.
+# reqwest (Sentry transport, lindera build) pulls in rustls-platform-verifier
+# on non-WASM targets. On Android it must be initialized with a JNI context
+# before any TLS handshake, or the process aborts. jni crate is needed to
+# obtain JNIEnv from the JavaVM. ndk-context provides the JavaVM/Activity
+# pointers (initialized by tao before main()).
+[target.'cfg(target_os = "android")'.dependencies]
+jni = "0.21"
+rustls-platform-verifier = "0.6"
+ndk-context = "0.1"

--- a/tauri/build_config.rs
+++ b/tauri/build_config.rs
@@ -68,7 +68,7 @@ pub(crate) fn build_csp(
     sentry_ingest_host: &str,
 ) -> String {
     format!(
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://browser.sentry-cdn.com https://{sentry_ingest_host}; img-src 'self' data: blob: {cdn}; media-src 'self' blob: data: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: {cdn} {landing} {trailbase} https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://cdn.jsdelivr.net https://browser.sentry-cdn.com https://{sentry_ingest_host}; img-src 'self' data: blob: {cdn}; media-src 'self' blob: data: {cdn}; style-src 'self' 'unsafe-inline'; font-src 'self' {cdn}; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:"
     )
 }
 

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -46,6 +46,18 @@ fn get_current_deep_link(app: tauri::AppHandle) -> Option<String> {
 pub fn run() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
+    // On Android, rustls-platform-verifier (pulled in via reqwest → sentry
+    // transport) must be initialized with a JNI context before any TLS
+    // handshake. Without this, the first HTTPS request panics with
+    // "Expect rustls-platform-verifier to be initialized" and aborts the
+    // process. We dispatch to the Android event loop to obtain the JNI
+    // env + Activity context, blocking until init completes.
+    //
+    // This must happen BEFORE `init_sentry()`, because the Sentry transport
+    // creates a reqwest client that performs the first TLS handshake.
+    #[cfg(target_os = "android")]
+    init_platform_verifier_android();
+
     // Initialize Sentry AFTER the rustls crypto provider is installed: the
     // sentry transport uses `rustls-no-provider` and reuses this ring provider.
     // The guard must outlive `tauri::Builder::run` — kept on the stack, dropped
@@ -262,4 +274,57 @@ fn init_sentry() -> Option<sentry::ClientInitGuard> {
     );
 
     Some(guard)
+}
+
+/// Initialize `rustls-platform-verifier` with the Android JVM/Activity context.
+///
+/// On Android, reqwest (used by the Sentry transport) uses
+/// `rustls-platform-verifier` for TLS certificate validation. The verifier
+/// panics ("Expect rustls-platform-verifier to be initialized") unless
+/// `init_with_env` has been called with a JNI `JNIEnv` and Activity context.
+///
+/// We obtain the JavaVM and Activity context via `ndk_context`, which tao
+/// initializes before `main()` is called (see tao's `ndk_glue::create`).
+/// This avoids the deadlock risk of `wry::dispatch` (which posts to the
+/// event loop on the same thread that `run()` blocks).
+///
+/// This must happen BEFORE `init_sentry()`, because the Sentry transport
+/// creates a reqwest client that performs the first TLS handshake.
+#[cfg(target_os = "android")]
+fn init_platform_verifier_android() {
+    use jni::JNIEnv;
+    use jni::objects::JObject;
+
+    let ctx = ndk_context::android_context();
+
+    // Safety: ndk_context stores a valid JavaVM pointer initialized by tao.
+    let vm = match unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) } {
+        Ok(vm) => vm,
+        Err(e) => {
+            tracing::error!("[rustls] failed to get JavaVM: {e:?}");
+            return;
+        },
+    };
+
+    // Attach the current thread to the JVM. The returned guard detaches
+    // automatically when dropped, but we only need the env for the init call.
+    let mut env = match vm.attach_current_thread() {
+        Ok(env) => env,
+        Err(e) => {
+            tracing::error!("[rustls] failed to attach thread to JVM: {e:?}");
+            return;
+        },
+    };
+
+    // Safety: ndk_context stores a valid Android Context (Activity) jobject.
+    let context = unsafe { JObject::from_raw(ctx.context() as jni::sys::jobject) };
+
+    match rustls_platform_verifier::android::init_with_env(&mut env, context) {
+        Ok(()) => {
+            tracing::info!("[rustls] platform-verifier initialized for Android");
+        },
+        Err(e) => {
+            tracing::error!("[rustls] platform-verifier init failed: {e:?}");
+        },
+    }
 }

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -22,7 +22,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://browser.sentry-cdn.com https://o4511840951992320.ingest.us.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: data: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:",
+            "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://cdn.pyke.io https://js.sentry-cdn.com https://browser.sentry-cdn.com; connect-src 'self' ipc: http://ipc.localhost data: https://s3.origa.uwuwu.net https://origa.uwuwu.net https://app.origa.uwuwu.net https://huggingface.co https://signal.pyke.io https://cdn.pyke.io https://cdn.jsdelivr.net https://browser.sentry-cdn.com https://o4511840951992320.ingest.us.sentry.io; img-src 'self' data: blob: https://s3.origa.uwuwu.net; media-src 'self' blob: data: https://s3.origa.uwuwu.net; style-src 'self' 'unsafe-inline'; font-src 'self' https://s3.origa.uwuwu.net; form-action 'self' https://accounts.google.com https://oauth.yandex.ru; frame-ancestors 'none'; worker-src 'self' blob:; child-src 'self' blob:",
             "dangerousDisableAssetCspModification": true
         }
     },

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -105,6 +105,7 @@ fn build_csp_substitutes_staging_hosts() {
     // Other third-party hosts must survive any host substitution.
     assert!(csp.contains("https://huggingface.co"));
     assert!(csp.contains("https://cdn.pyke.io"));
+    assert!(csp.contains("https://cdn.jsdelivr.net"));
     assert!(csp.contains("https://signal.pyke.io"));
     assert!(csp.contains("https://accounts.google.com"));
     assert!(csp.contains("https://oauth.yandex.ru"));


### PR DESCRIPTION
## Summary

Three independent runtime bugs — all fixed in this PR.

### 1. ort-web CDN unavailable → Whisper and OCR break
`cdn.pyke.io` (ort-web's default CDN) intermittently returns `ERR_CONNECTION_RESET`, causing ort-web initialization to fail silently. Whisper and OCR models cannot load.

**Fix:** Switched to jsDelivr's npm mirror (`onnxruntime-web@1.24.3`) via `ort_web::Dist`. All 6 runtime files verified available with CORS `*` and immutable cache.

### 2. Sentry v8 CaptureConsole → SDK fails to init
Sentry v8 removed the `Integrations.XXX` class hash. Accessing `Sentry.Integrations.CaptureConsole` throws `TypeError`, preventing `Sentry.init` from running at all — no WASM errors reach Sentry.

**Fix:** Replaced with v8 functional API `Sentry.captureConsoleIntegration()` with `typeof` guard.

### 3. Android crash: rustls-platform-verifier not initialized
`rustls-platform-verifier` (pulled in via reqwest → Sentry transport) panics on Android: `"Expect rustls-platform-verifier to be initialized"`. The process aborts on the first HTTPS request.

**Fix:** Added `init_platform_verifier_android()` using `ndk_context` (initialized by tao before `main()`) to obtain JavaVM + Activity context. Avoids the deadlock risk of `wry::dispatch` (same-thread event loop).

## Files changed
- `origa/src/ort_init.rs` — `Dist` with jsDelivr CDN
- `origa_ui/src/sentry.rs` — v8 captureConsoleIntegration API
- `tauri/src/lib.rs` — Android rustls-platform-verifier init
- `tauri/Cargo.toml` — Android-only deps (jni, rustls-platform-verifier, ndk-context)
- `tauri/tauri.conf.json` + `tauri/build_config.rs` — CSP: added cdn.jsdelivr.net
- `tauri/tests/build_config.rs` — CSP assertion for cdn.jsdelivr.net

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p origa -p origa_ui --lib -- -D warnings` — clean
- [x] `cargo test -p origa -p origa_ui --lib` — 314 passed
- [x] `cargo test -p origa-app --test build_config` — 22 passed
- [ ] Manual: Whisper + OCR work on Windows (ort-web loads from jsDelivr)
- [ ] Manual: Sentry receives WASM events (captureConsoleIntegration works)
- [ ] Manual: Android app doesn't crash on Sentry transport HTTPS request