### PR TITLE
fix(ios): eliminate inner parallelism + enable WASM Sentry logs

### DIFF
--- a/origa_ui/src/loaders/data_loader.rs
+++ b/origa_ui/src/loaders/data_loader.rs
@@ -9,8 +9,6 @@ use crate::repository::cdn_provider;
 use crate::utils::{now_ms, yield_to_browser};
 
 pub async fn load_vocabulary() -> Result<(), OrigaError> {
-    use futures::future::join_all;
-
     if is_vocabulary_loaded() {
         tracing::debug!("📖 Vocabulary already loaded");
         return Ok(());
@@ -21,28 +19,40 @@ pub async fn load_vocabulary() -> Result<(), OrigaError> {
 
     let cdn = cdn_provider();
 
-    let chunk_futures: Vec<_> = (1..=11)
-        .map(|i| {
-            let path = format!("dictionary/chunk_{:02}.json", i);
-            async move { cdn.fetch_text(&path).await }
-        })
-        .collect();
+    // Batched fetch: 11 JSON chunks (~35 MB total). Fetching all 11 at once
+    // via join_all caused WASM OOM on iOS. Batches of 3 keep peak memory
+    // bounded while still parallelizing for speed (~4 rounds instead of 11
+    // sequential requests).
+    const BATCH_SIZE: usize = 3;
+    let mut all_chunks: Vec<String> = Vec::with_capacity(11);
 
-    let chunks = join_all(chunk_futures).await;
-    let chunks: Vec<String> = chunks.into_iter().collect::<Result<Vec<_>, _>>()?;
+    for batch_start in (1..=11).step_by(BATCH_SIZE) {
+        let batch_end = (batch_start + BATCH_SIZE - 1).min(11);
+        let batch_futures: Vec<_> = (batch_start..=batch_end)
+            .map(|i| {
+                let path = format!("dictionary/chunk_{:02}.json", i);
+                async move { cdn.fetch_text(&path).await }
+            })
+            .collect();
+        let batch_results = futures::future::join_all(batch_futures).await;
+        for result in batch_results {
+            all_chunks.push(result?);
+        }
+        yield_to_browser().await;
+    }
 
     let data = VocabularyChunkData {
-        chunk_01: chunks[0].clone(),
-        chunk_02: chunks[1].clone(),
-        chunk_03: chunks[2].clone(),
-        chunk_04: chunks[3].clone(),
-        chunk_05: chunks[4].clone(),
-        chunk_06: chunks[5].clone(),
-        chunk_07: chunks[6].clone(),
-        chunk_08: chunks[7].clone(),
-        chunk_09: chunks[8].clone(),
-        chunk_10: chunks[9].clone(),
-        chunk_11: chunks[10].clone(),
+        chunk_01: all_chunks[0].clone(),
+        chunk_02: all_chunks[1].clone(),
+        chunk_03: all_chunks[2].clone(),
+        chunk_04: all_chunks[3].clone(),
+        chunk_05: all_chunks[4].clone(),
+        chunk_06: all_chunks[5].clone(),
+        chunk_07: all_chunks[6].clone(),
+        chunk_08: all_chunks[7].clone(),
+        chunk_09: all_chunks[8].clone(),
+        chunk_10: all_chunks[9].clone(),
+        chunk_11: all_chunks[10].clone(),
     };
 
     yield_to_browser().await;

--- a/origa_ui/src/loaders/dictionary.rs
+++ b/origa_ui/src/loaders/dictionary.rs
@@ -79,7 +79,6 @@ async fn fetch_file(field: &str, path: &str) -> Result<(String, Vec<u8>), OrigaE
 }
 
 async fn load_dictionary_from_network() -> Result<DictionaryData, OrigaError> {
-    use futures::future::join_all;
     tracing::info!("📖 Fetching dictionary files...");
 
     let files = [
@@ -94,18 +93,22 @@ async fn load_dictionary_from_network() -> Result<DictionaryData, OrigaError> {
     ];
 
     let fetch_start = now_ms();
-    let fetch_futures: Vec<_> = files
-        .iter()
-        .map(|(field, path)| fetch_file(field, path))
-        .collect();
 
-    let results = join_all(fetch_futures).await;
+    // Sequential fetch: UniDic files are large (matrix.mtx alone is 25 MB
+    // compressed → ~100 MB decompressed). Fetching all 8 simultaneously via
+    // join_all caused WASM OOM on iOS. Sequential download keeps peak memory
+    // to one file at a time; each fetch_bytes → decompress → store cycle
+    // drops the compressed bytes before the next download starts.
+    let mut results = Vec::with_capacity(files.len());
+    for (field, path) in &files {
+        results.push(fetch_file(field, path).await?);
+    }
+
     tracing::info!(
         "📖 Dictionary files fetched ({:.2}s)",
         (now_ms() - fetch_start) / 1000.0
     );
 
-    let results: Vec<_> = results.into_iter().collect::<Result<Vec<_>, _>>()?;
     let mut data = DictionaryData {
         char_def: Vec::new(),
         matrix: Vec::new(),

--- a/origa_ui/src/sentry.rs
+++ b/origa_ui/src/sentry.rs
@@ -95,6 +95,7 @@ pub(crate) fn init_with(dsn: &str, release: &str, environment: &str) {
                     environment: "{environment}",
                     sendDefaultPii: false,
                     tracesSampleRate: 1.0,
+                    enableLogs: true,
                     integrations: integrations
                 }});
                 Sentry.setTag("layer", "ui");


### PR DESCRIPTION
## Problem

iOS still crashes at **0 of 9** after #356 (outer staging) and #357 (Sentry flush). Two root causes remain:

### 1. Inner parallelism not addressed (OOM)

`#356` fixed outer parallelism (8 loaders via `join!` → 3 stages), but **inner parallelism survived**:

| Loader | Inner parallelism | Peak memory |
|--------|-------------------|-------------|
| `load_dictionary` | `join_all` on 8 UniDic files | matrix.mtx = 25 MB → ~100 MB decompressed, all 8 simultaneously |
| `load_vocabulary` | `join_all` on 11 JSON chunks | ~35 MB of response bodies in JS heap simultaneously |

These inner `join_all` calls caused the same OOM peak that the outer staging was meant to eliminate.

### 2. No Sentry logs from iOS/Android WASM

Traces arrived from all platforms, but structured logs only from Windows. Root cause: Sentry JS SDK `init` was missing `enableLogs: true`. Native `sentry-rust` had `enable_logs(true)` but WASM JS SDK did not.

## Fix

**`dictionary.rs`** — sequential fetch (1 file at a time). Each compressed buffer is dropped before the next download starts. Peak memory: 1 file instead of 8.

**`data_loader.rs`** — batched vocabulary fetch (3 chunks at a time, 4 rounds). Peak memory: ~10 MB instead of ~35 MB.

**`sentry.rs`** — `enableLogs: true` added to `Sentry.init` so `tracing::warn!/info!` from WASM are sent as structured logs.

## Testing

- `cargo clippy -p origa_ui --all-targets -- -D warnings` ✅
- `cargo test -p origa_ui --lib` — 314 passed ✅
- `cargo fmt --check` ✅