### PR TITLE
fix(android): Japanese OCR — use ML Kit Japanese recognizer instead of Latin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,8 @@ tauri-build = { version = "2", features = [] }
 #  - Linux: device-ai has no Linux backend (returns FeatureNotAvailable).
 # Windows + Linux keep their current stack — strictly non-regressing.
 # Future: upstream the mobile fix and switch back to hypothesi/...
-tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "e5709f64b0abdd364bac048a02d36cfc22ed8b8c" }
-device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "e5709f64b0abdd364bac048a02d36cfc22ed8b8c" }
+tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "9b21400f7a91a46d0b803aaac90bc70b5b399cd0" }
+device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "9b21400f7a91a46d0b803aaac90bc70b5b399cd0" }
 
 # Dev Dependencies
 wasm-bindgen = "0.2"


### PR DESCRIPTION
## Problem

Android OCR returned **empty results for all Japanese text**. iOS worked fine.

## Root cause

The `tauri-plugin-device-ai-apis` Android implementation used **ML Kit's Latin-only text recognizer** (`TextRecognizerOptions.DEFAULT_OPTIONS` + `text-recognition:16.0.0` dependency). The Latin model does not contain a neural model for kanji/hiragana/katakana — it silently returns empty `visionText.text`, no error.

ML Kit architecture: separate dependency + separate RecognizerOptions per script (Latin, Japanese, Chinese, Korean, Devanagari). There is no "all scripts" recognizer.

iOS Vision framework auto-detects all scripts — that's why iOS worked and Android didn't.

## Fix

Bump `tauri-plugin-device-ai-apis` fork rev → `9b21400` which switches to the Japanese script model:
- `text-recognition-japanese:16.0.1` (kanji, hiragana, katakana)
- `JapaneseTextRecognizerOptions.Builder().build()`

Plugin PR: yurvon-screamo/tauri-plugin-device-ai-apis#1 (merged)

Refs: [Google ML Kit docs](https://developers.google.com/ml-kit/vision/text-recognition/v2/android)