### PR TITLE
fix(ui): cancel toast/modal timers on dispose to prevent reactive panic

### DIFF
--- a/origa_ui/src/ui_components/modal.rs
+++ b/origa_ui/src/ui_components/modal.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos::task::spawn_local_scoped_with_cancellation;
 use leptos_use::use_event_listener;
 
 #[component]
@@ -12,7 +13,6 @@ pub fn Modal(
     let children = StoredValue::new(children);
     let is_closing = RwSignal::new(false);
     let on_close_clone = on_close;
-    let disposed = StoredValue::new(());
 
     let test_id_val = move || {
         let val = test_id.get();
@@ -42,11 +42,8 @@ pub fn Modal(
         let is_open_clone = is_open;
         let on_close_inner = on_close_clone;
         let ev_clone = ev.clone();
-        leptos::task::spawn_local(async move {
+        spawn_local_scoped_with_cancellation(async move {
             gloo_timers::future::TimeoutFuture::new(250).await;
-            if disposed.is_disposed() {
-                return;
-            }
             is_open_clone.set(false);
             is_closing.set(false);
             if let Some(on_close) = on_close_inner {
@@ -63,11 +60,8 @@ pub fn Modal(
                 is_closing.set(true);
                 let is_open_clone = is_open;
                 let on_close_inner = on_close_clone;
-                leptos::task::spawn_local(async move {
+                spawn_local_scoped_with_cancellation(async move {
                     gloo_timers::future::TimeoutFuture::new(250).await;
-                    if disposed.is_disposed() {
-                        return;
-                    }
                     is_open_clone.set(false);
                     is_closing.set(false);
                     if let Some(on_close) = on_close_inner {

--- a/origa_ui/src/ui_components/toast.rs
+++ b/origa_ui/src/ui_components/toast.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use leptos::task::spawn_local;
+use leptos::task::spawn_local_scoped_with_cancellation;
 use std::collections::HashMap;
 
 #[derive(Clone, Copy, PartialEq, Default, Debug)]
@@ -46,14 +46,10 @@ pub fn Toast(
     let toast_id = toast.id;
     let actual_duration = toast.duration_ms.unwrap_or(duration_ms);
     let has_duration = actual_duration > 0;
-    let disposed = StoredValue::new(());
 
     if has_duration {
-        spawn_local(async move {
+        spawn_local_scoped_with_cancellation(async move {
             gloo_timers::future::TimeoutFuture::new(actual_duration as u32).await;
-            if disposed.is_disposed() {
-                return;
-            }
             on_close.run(toast_id);
         });
     }
@@ -128,18 +124,14 @@ pub fn ToastContainer(
         if val.is_empty() { None } else { Some(val) }
     };
     let closing_toasts = RwSignal::new(HashMap::<usize, bool>::new());
-    let disposed = StoredValue::new(());
 
     let on_close = Callback::new(move |id: usize| {
         let toasts_clone = toasts;
         closing_toasts.update(|c| {
             c.insert(id, true);
         });
-        leptos::task::spawn_local(async move {
+        spawn_local_scoped_with_cancellation(async move {
             gloo_timers::future::TimeoutFuture::new(200).await;
-            if disposed.is_disposed() {
-                return;
-            }
             toasts_clone.update(|t| t.retain(|toast| toast.id != id));
             closing_toasts.update(|c| {
                 c.remove(&id);


### PR DESCRIPTION
## Context

Follow-up to PR #362 which fixed the same class of bug in `KanjiAnimation`.

Code review of #362 identified 4 sibling call sites with the identical TOCTOU-vulnerable pattern: `spawn_local` + `TimeoutFuture` + manual `disposed.is_disposed()` guard.

## Vulnerable sites fixed

| File | Component | Timer |
|------|-----------|-------|
| `toast.rs` | `Toast` | auto-dismiss after `actual_duration` |
| `toast.rs` | `ToastContainer` | 200ms exit animation before removing from list |
| `modal.rs` | `close_modal_anim` | 250ms close animation |
| `modal.rs` | Escape key handler | 250ms close animation |

## Fix

Replace `spawn_local` → `spawn_local_scoped_with_cancellation` in all 4 sites. Remove the now-redundant `StoredValue<()> disposed` sentinel from both `Toast`, `ToastContainer`, and `Modal`.

## Verification

- `cargo clippy -p origa_ui --lib -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p origa_ui --lib` — 314 passed, 0 failed