### PR TITLE
fix(auth): route account deletion through repository with correct table name

### DIFF
--- a/origa_ui/src/repository/hybrid_repository.rs
+++ b/origa_ui/src/repository/hybrid_repository.rs
@@ -60,6 +60,23 @@ impl HybridUserRepository {
         self.remote.save(&updated_user).await?;
         Ok(())
     }
+
+    /// Delete the remote user record only. Unlike `delete`, this does NOT
+    /// swallow remote errors — account deletion must surface failures so the
+    /// caller (AuthStore) can abort the flow instead of leaving the user in a
+    /// half-deleted state. Local data cleanup is the caller's responsibility.
+    ///
+    /// `user_id` is accepted as `Option<Ulid>` — when `None`, the caller has no
+    /// loaded domain `User`, which means the account is in an anomalous state
+    /// (authenticated session but no User object). This is surfaced as an error
+    /// rather than silently passing a nil ULID.
+    pub async fn delete_remote(&self, user_id: Option<Ulid>) -> Result<(), OrigaError> {
+        tracing::info!("delete_remote: Deleting remote user {:?}", user_id);
+        let id = user_id.ok_or_else(|| OrigaError::RepositoryError {
+            reason: "Cannot delete account: no user is currently loaded".to_string(),
+        })?;
+        self.remote.delete(id).await
+    }
 }
 
 impl UserRepository for HybridUserRepository {

--- a/origa_ui/src/repository/trailbase_session.rs
+++ b/origa_ui/src/repository/trailbase_session.rs
@@ -231,33 +231,6 @@ impl TrailBaseClient {
         Ok(())
     }
 
-    pub async fn delete_account(&self) -> Result<(), String> {
-        let session = get_session().ok_or("Not authenticated")?;
-
-        let api = self.records("user");
-
-        if let Some(record_id) = session.record_id {
-            api.delete(&record_id.to_string())
-                .await
-                .map_err(|e| e.to_string())?;
-        } else {
-            let records: Vec<serde_json::Value> = api
-                .list_filtered("email", &session.email)
-                .await
-                .map_err(|e| e.to_string())?;
-
-            if let Some(record) = records.first()
-                && let Some(id) = record.get("id").and_then(|v| v.as_i64())
-            {
-                api.delete(&id.to_string())
-                    .await
-                    .map_err(|e| e.to_string())?;
-            }
-        }
-
-        self.logout().await
-    }
-
     pub async fn change_password(
         &self,
         old_password: &str,

--- a/origa_ui/src/store/auth_store.rs
+++ b/origa_ui/src/store/auth_store.rs
@@ -389,7 +389,13 @@ impl AuthStore {
 
         self.is_deleting_account.set(true);
 
-        if let Err(e) = self.client.delete_account().await {
+        // Capture user id before clearing auth state — we need it for the
+        // local data cleanup after the remote record is gone. If there is no
+        // loaded user, the account is in an anomalous state (authenticated
+        // session but no domain User) — abort before touching the server.
+        let user_id = self.user.with(|u| u.clone().map(|user| user.id()));
+
+        if let Err(e) = self.repository.delete_remote(user_id).await {
             tracing::error!("Server account delete failed: {:?}", e);
             self.clear_auth_state().await;
             self.is_deleting_account.set(false);
@@ -398,7 +404,10 @@ impl AuthStore {
             });
         }
 
-        let user_id = self.user.with(|u| u.clone().map(|user| user.id()));
+        // Invalidate the auth session on the server side. Best-effort — the
+        // record is already deleted, so a lingering session token is harmless.
+        let _ = self.client.logout().await;
+
         self.clear_auth_state().await;
 
         if let Some(id) = user_id


### PR DESCRIPTION
## Root Cause

`TrailBaseClient::delete_account()` hardcoded table name `"user"`, but `TrailBaseUserRepository` migrated to `"domain_user"` in PR #350. The DELETE request went to `/api/records/v1/user` → 404 → account deletion silently failed (no visible request to the correct endpoint).

## Fix

1. **Removed** `TrailBaseClient::delete_account()` — it duplicated record-lookup logic already in `TrailBaseUserRepository::find_current()` and hardcoded the wrong table name.

2. **Added** `HybridUserRepository::delete_remote(Option<Ulid>)` — delegates to `TrailBaseUserRepository::delete()` (which uses the correct `domain_user` table), but unlike `UserRepository::delete()`, it **propagates** remote errors instead of swallowing them. Account deletion must fail explicitly.

3. **Updated** `AuthStore::delete_account()` — now routes through `repository.delete_remote()` instead of `client.delete_account()`. `user_id` is `Option<Ulid>` — `None` is rejected with an explicit error (no nil-ULID silently reaching the server).

## Verification

- `cargo clippy -p origa_ui --all-targets -- -D warnings` → 0 errors
- `cargo fmt --check` → clean
- `cargo test -p origa_ui --lib` → 326 passed
- BDD scenario "Удаление аккаунта" (`profile.feature:54-60`) covers the UI flow