### PR TITLE
feat(scripts): sync user → domain_user for rolling deployment

### DIFF
--- a/origa_ui/src/repository/hybrid_repository.rs
+++ b/origa_ui/src/repository/hybrid_repository.rs
@@ -60,6 +60,23 @@ impl HybridUserRepository {
         self.remote.save(&updated_user).await?;
         Ok(())
     }
+
+    /// Delete the remote user record only. Unlike `delete`, this does NOT
+    /// swallow remote errors — account deletion must surface failures so the
+    /// caller (AuthStore) can abort the flow instead of leaving the user in a
+    /// half-deleted state. Local data cleanup is the caller's responsibility.
+    ///
+    /// `user_id` is accepted as `Option<Ulid>` — when `None`, the caller has no
+    /// loaded domain `User`, which means the account is in an anomalous state
+    /// (authenticated session but no User object). This is surfaced as an error
+    /// rather than silently passing a nil ULID.
+    pub async fn delete_remote(&self, user_id: Option<Ulid>) -> Result<(), OrigaError> {
+        tracing::info!("delete_remote: Deleting remote user {:?}", user_id);
+        let id = user_id.ok_or_else(|| OrigaError::RepositoryError {
+            reason: "Cannot delete account: no user is currently loaded".to_string(),
+        })?;
+        self.remote.delete(id).await
+    }
 }
 
 impl UserRepository for HybridUserRepository {

--- a/origa_ui/src/repository/trailbase_session.rs
+++ b/origa_ui/src/repository/trailbase_session.rs
@@ -231,33 +231,6 @@ impl TrailBaseClient {
         Ok(())
     }
 
-    pub async fn delete_account(&self) -> Result<(), String> {
-        let session = get_session().ok_or("Not authenticated")?;
-
-        let api = self.records("user");
-
-        if let Some(record_id) = session.record_id {
-            api.delete(&record_id.to_string())
-                .await
-                .map_err(|e| e.to_string())?;
-        } else {
-            let records: Vec<serde_json::Value> = api
-                .list_filtered("email", &session.email)
-                .await
-                .map_err(|e| e.to_string())?;
-
-            if let Some(record) = records.first()
-                && let Some(id) = record.get("id").and_then(|v| v.as_i64())
-            {
-                api.delete(&id.to_string())
-                    .await
-                    .map_err(|e| e.to_string())?;
-            }
-        }
-
-        self.logout().await
-    }
-
     pub async fn change_password(
         &self,
         old_password: &str,

--- a/origa_ui/src/store/auth_store.rs
+++ b/origa_ui/src/store/auth_store.rs
@@ -389,7 +389,13 @@ impl AuthStore {
 
         self.is_deleting_account.set(true);
 
-        if let Err(e) = self.client.delete_account().await {
+        // Capture user id before clearing auth state — we need it for the
+        // local data cleanup after the remote record is gone. If there is no
+        // loaded user, the account is in an anomalous state (authenticated
+        // session but no domain User) — abort before touching the server.
+        let user_id = self.user.with(|u| u.clone().map(|user| user.id()));
+
+        if let Err(e) = self.repository.delete_remote(user_id).await {
             tracing::error!("Server account delete failed: {:?}", e);
             self.clear_auth_state().await;
             self.is_deleting_account.set(false);
@@ -398,7 +404,10 @@ impl AuthStore {
             });
         }
 
-        let user_id = self.user.with(|u| u.clone().map(|user| user.id()));
+        // Invalidate the auth session on the server side. Best-effort — the
+        // record is already deleted, so a lingering session token is harmless.
+        let _ = self.client.logout().await;
+
         self.clear_auth_state().await;
 
         if let Some(id) = user_id

--- a/scripts/_knowledge_set_codec.py
+++ b/scripts/_knowledge_set_codec.py
@@ -159,7 +159,9 @@ def _select_later_state(
     return copy.deepcopy(left)
 
 
-def merge_memory_history(local: dict[str, Any], remote: dict[str, Any]) -> dict[str, Any]:
+def merge_memory_history(
+    local: dict[str, Any], remote: dict[str, Any]
+) -> dict[str, Any]:
     """Mirror MemoryHistory::merge — merge remote into local."""
     local_lrd = local.get("last_review_date")
     remote_lrd = remote.get("last_review_date")
@@ -305,7 +307,7 @@ def _card_content_key(card: dict[str, Any]) -> str | None:
     """
     if not isinstance(card, dict) or len(card) != 1:
         return None
-    (variant, inner), = card.items()
+    ((variant, inner),) = card.items()
     match variant:
         case "Vocabulary":
             return _nested_text(inner, "word")
@@ -343,7 +345,9 @@ def _validate_unique_card(
         return True
 
     for existing_card in study_cards.values():
-        existing = existing_card.get("card") if isinstance(existing_card, dict) else None
+        existing = (
+            existing_card.get("card") if isinstance(existing_card, dict) else None
+        )
         if existing is None:
             continue
         existing_key = _card_content_key(existing)

--- a/scripts/_knowledge_set_codec.py
+++ b/scripts/_knowledge_set_codec.py
@@ -1,0 +1,398 @@
+"""Shared codec and merge logic for Origa knowledge_set blobs (ADR-034).
+
+Used by:
+  - migrate_reviews_to_counters.py — one-time reviews→counters conversion
+  - sync_user_to_domain_user.py — rolling-deployment merge (user → domain_user)
+
+All merge functions mirror the Rust domain contracts exactly:
+  - MemoryHistory::merge     (origa/src/domain/memory/mod.rs)
+  - StudyCard::merge          (origa/src/domain/knowledge/card.rs)
+  - KnowledgeSet::merge       (origa/src/domain/knowledge/mod.rs)
+  - StatsTracker::merge       (origa/src/domain/knowledge/stats_tracker.rs)
+  - DailyHistoryItem::merge_with (origa/src/domain/knowledge/daily_history.rs)
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import zlib
+from typing import Any, cast
+
+# ─── ADR-034 codec constants ──────────────────────────────────────────
+DEFLATE_PREFIX = "DEFLATE;"
+
+# Rating enum values as serialized by serde (string variants)
+RATING_EASY = "Easy"
+RATING_GOOD = "Good"
+RATING_HARD = "Hard"
+RATING_AGAIN = "Again"
+
+# Serialized field name for favorite_easy_streak (serde rename in StudyCard)
+PERFECT_STREAK_FIELD = "perfect_streak_since_known"
+
+
+# ─── Encode / Decode ──────────────────────────────────────────────────
+
+
+def decode_knowledge_set(raw: str) -> dict[str, Any]:
+    """Decode knowledge_set wire blob to a dict.
+
+    Handles both legacy plain-JSON and DEFLATE;<base64> formats (ADR-034).
+    Recovering: corrupt input → empty KnowledgeSet.
+    """
+    if raw.startswith(DEFLATE_PREFIX):
+        b64_data = raw[len(DEFLATE_PREFIX) :]
+        try:
+            deflated = base64.b64decode(b64_data)
+            json_bytes = zlib.decompress(deflated)
+            return cast(dict[str, Any], json.loads(json_bytes))
+        except Exception:
+            return _empty_knowledge_set()
+    else:
+        # Legacy plain JSON
+        try:
+            return cast(dict[str, Any], json.loads(raw))
+        except Exception:
+            return _empty_knowledge_set()
+
+
+def encode_knowledge_set(ks: dict[str, Any]) -> str:
+    """Encode KnowledgeSet dict to DEFLATE;<base64> wire format."""
+    json_str = json.dumps(ks, separators=(",", ":"), ensure_ascii=False)
+    deflated = zlib.compress(json_str.encode("utf-8"), level=6)
+    return DEFLATE_PREFIX + base64.b64encode(deflated).decode("ascii")
+
+
+def _empty_knowledge_set() -> dict[str, Any]:
+    return {"study_cards": {}, "lesson_history": []}
+
+
+# ─── Reviews → Counters conversion ────────────────────────────────────
+
+
+def migrate_memory_history(memory: dict[str, Any]) -> dict[str, Any]:
+    """Replace reviews array with scalar counters in a single MemoryHistory.
+
+    Input shape (old):
+        {"current_state": {...} | null, "reviews": [...]}
+    Output shape (new):
+        {"current_state": {...} | null, "reps": N, "lapses": N,
+         "easy_count": N, "good_count": N,
+         "last_review_date": "..." | null, "last_rating": "..." | null}
+    """
+    reviews = memory.get("reviews", [])
+    current_state = memory.get("current_state")
+
+    reps = len(reviews)
+    lapses = sum(1 for r in reviews if r.get("rating") == RATING_AGAIN)
+    easy_count = sum(1 for r in reviews if r.get("rating") == RATING_EASY)
+    good_count = sum(1 for r in reviews if r.get("rating") == RATING_GOOD)
+
+    last_review_date = None
+    last_rating = None
+    if reviews:
+        sorted_reviews = sorted(reviews, key=lambda r: r.get("timestamp", ""))
+        last = sorted_reviews[-1]
+        last_review_date = last.get("timestamp")
+        last_rating = last.get("rating")
+
+    return {
+        "current_state": current_state,
+        "reps": reps,
+        "lapses": lapses,
+        "easy_count": easy_count,
+        "good_count": good_count,
+        "last_review_date": last_review_date,
+        "last_rating": last_rating,
+    }
+
+
+def migrate_knowledge_set(ks: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    """Migrate all StudyCards from reviews to counters.
+
+    Returns (migrated_ks, migrated_count). Idempotent: cards already in
+    counter format (no "reviews" key) are skipped.
+    """
+    study_cards = ks.get("study_cards", {})
+    migrated_count = 0
+
+    for study_card in study_cards.values():
+        memory = study_card.get("memory_history")
+        if memory is None:
+            continue
+        if "reviews" not in memory:
+            continue
+        study_card["memory_history"] = migrate_memory_history(memory)
+        migrated_count += 1
+
+    return ks, migrated_count
+
+
+# ─── Merge logic (mirrors Rust domain) ────────────────────────────────
+
+
+def _select_later_state(
+    left: dict[str, Any] | None,
+    right: dict[str, Any] | None,
+    left_last_review: str | None,
+    right_last_review: str | None,
+) -> dict[str, Any] | None:
+    """Mirror select_later_state() — LWW by last_review_date."""
+    if left is None and right is None:
+        return None
+    if left is not None and right is None:
+        return copy.deepcopy(left)
+    if left is None and right is not None:
+        return copy.deepcopy(right)
+    # Both present — compare last_review_date
+    if left_last_review is None and right_last_review is None:
+        return copy.deepcopy(right)
+    if left_last_review is not None and right_last_review is None:
+        return copy.deepcopy(left)
+    if left_last_review is None and right_last_review is not None:
+        return copy.deepcopy(right)
+    # Both have timestamps — RFC3339 UTC strings compare lexicographically
+    if right_last_review >= left_last_review:
+        return copy.deepcopy(right)
+    return copy.deepcopy(left)
+
+
+def merge_memory_history(local: dict[str, Any], remote: dict[str, Any]) -> dict[str, Any]:
+    """Mirror MemoryHistory::merge — merge remote into local."""
+    local_lrd = local.get("last_review_date")
+    remote_lrd = remote.get("last_review_date")
+
+    current_state = _select_later_state(
+        local.get("current_state"),
+        remote.get("current_state"),
+        local_lrd,
+        remote_lrd,
+    )
+
+    # Counters: max()
+    reps = max(local.get("reps", 0), remote.get("reps", 0))
+    lapses = max(local.get("lapses", 0), remote.get("lapses", 0))
+    easy_count = max(local.get("easy_count", 0), remote.get("easy_count", 0))
+    good_count = max(local.get("good_count", 0), remote.get("good_count", 0))
+
+    # last_review_date + last_rating: from whichever side is newer
+    last_review_date = local_lrd
+    last_rating = local.get("last_rating")
+    if remote_lrd:
+        if not local_lrd or remote_lrd >= local_lrd:
+            last_review_date = remote_lrd
+            last_rating = remote.get("last_rating")
+
+    return {
+        "current_state": current_state,
+        "reps": reps,
+        "lapses": lapses,
+        "easy_count": easy_count,
+        "good_count": good_count,
+        "last_review_date": last_review_date,
+        "last_rating": last_rating,
+    }
+
+
+def merge_study_card(local: dict[str, Any], remote: dict[str, Any]) -> dict[str, Any]:
+    """Mirror StudyCard::merge — merge remote into local."""
+    result = copy.deepcopy(local)
+
+    # Merge memory_history
+    result["memory_history"] = merge_memory_history(
+        local.get("memory_history", {}),
+        remote.get("memory_history", {}),
+    )
+
+    # Favorite merge — LWW by favorite_changed_at
+    local_fca = local.get("favorite_changed_at")
+    remote_fca = remote.get("favorite_changed_at")
+
+    if local_fca and remote_fca:
+        if remote_fca > local_fca:
+            result["is_favorite"] = remote.get("is_favorite", False)
+            result["favorite_changed_at"] = remote_fca
+            if not result["is_favorite"]:
+                result[PERFECT_STREAK_FIELD] = 0
+    elif not local_fca and remote_fca:
+        result["is_favorite"] = remote.get("is_favorite", False)
+        result["favorite_changed_at"] = remote_fca
+        if not result["is_favorite"]:
+            result[PERFECT_STREAK_FIELD] = 0
+    elif not local_fca and not remote_fca:
+        # Legacy: no timestamps — OR fallback
+        result["is_favorite"] = local.get("is_favorite", False) or remote.get(
+            "is_favorite", False
+        )
+    # else: local has fca, remote doesn't → keep local (already in result)
+
+    # favorite_easy_streak: max(result, remote) — result may have been reset
+    # to 0 above by an unfavorite-wins branch, mirroring Rust's
+    # self.favorite_easy_streak.max(other.favorite_easy_streak) after the
+    # favorite LWW branch already mutated self.favorite_easy_streak.
+    result[PERFECT_STREAK_FIELD] = max(
+        result.get(PERFECT_STREAK_FIELD, 0),
+        remote.get(PERFECT_STREAK_FIELD, 0),
+    )
+
+    return result
+
+
+def merge_daily_history_item(self_item: dict[str, Any], other: dict[str, Any]) -> None:
+    """Mirror DailyHistoryItem::merge_with — in-place on self_item."""
+    self_item["lessons_completed"] = max(
+        self_item.get("lessons_completed", 0), other.get("lessons_completed", 0)
+    )
+    self_item["positive_ratings"] = max(
+        self_item.get("positive_ratings", 0), other.get("positive_ratings", 0)
+    )
+    self_item["negative_ratings"] = max(
+        self_item.get("negative_ratings", 0), other.get("negative_ratings", 0)
+    )
+    self_item["total_ratings"] = max(
+        self_item.get("total_ratings", 0), other.get("total_ratings", 0)
+    )
+    self_item["new_cards_studied_today"] = max(
+        self_item.get("new_cards_studied_today", 0),
+        other.get("new_cards_studied_today", 0),
+    )
+    self_item["phrase_cards_studied_today"] = max(
+        self_item.get("phrase_cards_studied_today", 0),
+        other.get("phrase_cards_studied_today", 0),
+    )
+
+    other_ts = other.get("timestamp", "")
+    self_ts = self_item.get("timestamp", "")
+    if other_ts > self_ts:
+        self_item["timestamp"] = other_ts
+        self_item["avg_stability"] = other.get("avg_stability")
+        self_item["avg_difficulty"] = other.get("avg_difficulty")
+
+
+def _date_part(timestamp: str) -> str:
+    """Extract date (YYYY-MM-DD) from RFC3339 timestamp string."""
+    return timestamp[:10] if timestamp else ""
+
+
+def merge_lesson_history(
+    local: list[dict[str, Any]], remote: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Mirror StatsTracker::merge — merge remote lesson_history into local."""
+    result = [copy.deepcopy(item) for item in local]
+
+    for remote_item in remote:
+        remote_date = _date_part(remote_item.get("timestamp", ""))
+        found = False
+        for existing in result:
+            if _date_part(existing.get("timestamp", "")) == remote_date:
+                merge_daily_history_item(existing, remote_item)
+                found = True
+                break
+        if not found:
+            result.append(copy.deepcopy(remote_item))
+
+    result.sort(key=lambda x: x.get("timestamp", ""))
+    return result
+
+
+def _card_content_key(card: dict[str, Any]) -> str | None:
+    """Extract the content key from a serialized Card enum.
+
+    Mirrors Card::content_key() in Rust. The serialized shape is
+    {"Variant": {...}} (externally tagged serde enum).
+    """
+    if not isinstance(card, dict) or len(card) != 1:
+        return None
+    (variant, inner), = card.items()
+    match variant:
+        case "Vocabulary":
+            return _nested_text(inner, "word")
+        case "Kanji":
+            return _nested_text(inner, "kanji")
+        case "Grammar":
+            return inner.get("rule_id") if isinstance(inner, dict) else None
+        case "Phrase":
+            return inner.get("phrase_id") if isinstance(inner, dict) else None
+        case _:
+            return None
+
+
+def _nested_text(inner: Any, field: str) -> str | None:
+    """Extract inner[field]["text"] from a serialized card variant."""
+    if not isinstance(inner, dict):
+        return None
+    nested = inner.get(field)
+    if not isinstance(nested, dict):
+        return None
+    return nested.get("text")
+
+
+def _validate_unique_card(
+    study_cards: dict[str, Any], new_card: dict[str, Any]
+) -> bool:
+    """Mirror KnowledgeSet::validate_unique_card.
+
+    Returns True if the card passes (no duplicate), False otherwise.
+    Checks content_key uniqueness (word, kanji, rule_id, phrase_id).
+    """
+    new_key = _card_content_key(new_card)
+    if new_key is None:
+        # Unknown card shape — allow (can't validate)
+        return True
+
+    for existing_card in study_cards.values():
+        existing = existing_card.get("card") if isinstance(existing_card, dict) else None
+        if existing is None:
+            continue
+        existing_key = _card_content_key(existing)
+        if existing_key == new_key:
+            return False
+
+    return True
+
+
+def merge_knowledge_sets(
+    local_ks: dict[str, Any], remote_ks: dict[str, Any]
+) -> dict[str, Any]:
+    """Mirror KnowledgeSet::merge — merge remote into local.
+
+    Idempotent: LWW + max() + union semantics ensure repeated runs produce
+    the same result if inputs don't change.
+    """
+    result = copy.deepcopy(local_ks)
+
+    # Union deleted_cards (tombstones) — remove from study_cards
+    result_deleted = set(result.get("deleted_cards", []))
+    for deleted_id in remote_ks.get("deleted_cards", []):
+        result_deleted.add(deleted_id)
+        result.get("study_cards", {}).pop(deleted_id, None)
+    result["deleted_cards"] = list(result_deleted)
+
+    # Union deleted_companion_words
+    result_companion = set(result.get("deleted_companion_words", []))
+    result_companion.update(remote_ks.get("deleted_companion_words", []))
+    result["deleted_companion_words"] = list(result_companion)
+
+    # Per-card merge
+    result.setdefault("study_cards", {})
+    for card_id, remote_card in remote_ks.get("study_cards", {}).items():
+        if card_id in result_deleted:
+            continue
+        if card_id in result["study_cards"]:
+            result["study_cards"][card_id] = merge_study_card(
+                result["study_cards"][card_id], remote_card
+            )
+        elif _validate_unique_card(result["study_cards"], remote_card.get("card", {})):
+            # New card — add only if content_key is unique (mirrors Rust
+            # KnowledgeSet::merge validate_unique_card gate)
+            result["study_cards"][card_id] = copy.deepcopy(remote_card)
+
+    # Merge lesson_history (StatsTracker)
+    result["lesson_history"] = merge_lesson_history(
+        result.get("lesson_history", []),
+        remote_ks.get("lesson_history", []),
+    )
+
+    return result

--- a/scripts/migrate_reviews_to_counters.py
+++ b/scripts/migrate_reviews_to_counters.py
@@ -22,131 +22,21 @@ Prerequisites:
 from __future__ import annotations
 
 import argparse
-import base64
-import json
 import os
 import sys
-from datetime import datetime, timezone
 
 import requests
 
-# ─── ADR-034 codec constants ──────────────────────────────────────────
-DEFLATE_PREFIX = "DEFLATE;"
-
-# Rating enum values as serialized by serde (string variants)
-RATING_EASY = "Easy"
-RATING_GOOD = "Good"
-RATING_HARD = "Hard"
-RATING_AGAIN = "Again"
-
-
-def decode_knowledge_set(raw: str) -> dict:
-    """Decode knowledge_set wire blob to a dict.
-
-    Handles both legacy plain-JSON and DEFLATE;<base64> formats (ADR-034).
-    Recovering: corrupt input → empty KnowledgeSet.
-    """
-    if raw.startswith(DEFLATE_PREFIX):
-        import zlib
-
-        b64_data = raw[len(DEFLATE_PREFIX) :]
-        try:
-            deflated = base64.b64decode(b64_data)
-            json_bytes = zlib.deinflate(deflated)
-            return json.loads(json_bytes)
-        except Exception as e:
-            print(f"  WARN: decode failed ({e}), returning empty KnowledgeSet", file=sys.stderr)
-            return {"study_cards": {}, "lesson_history": []}
-    else:
-        # Legacy plain JSON
-        try:
-            return json.loads(raw)
-        except Exception as e:
-            print(f"  WARN: JSON decode failed ({e}), returning empty", file=sys.stderr)
-            return {"study_cards": {}, "lesson_history": []}
+# Import shared codec + merge logic
+sys.path.insert(0, os.path.dirname(__file__))
+from _knowledge_set_codec import (  # noqa: E402
+    decode_knowledge_set,
+    encode_knowledge_set,
+    migrate_knowledge_set,
+)
 
 
-def encode_knowledge_set(ks: dict) -> str:
-    """Encode KnowledgeSet dict to DEFLATE;<base64> wire format."""
-    import zlib
-
-    json_str = json.dumps(ks, separators=(",", ":"), ensure_ascii=False)
-    deflated = zlib.compress(json_str.encode("utf-8"), level=6)
-    return DEFLATE_PREFIX + base64.b64encode(deflated).decode("ascii")
-
-
-def migrate_memory_history(memory: dict) -> dict:
-    """Replace reviews array with scalar counters in a single MemoryHistory.
-
-    Input shape (old):
-        {
-            "current_state": {...} | null,
-            "reviews": [
-                {"id": "...", "rating": "Good", "timestamp": "...", "interval": {...}},
-                ...
-            ]
-        }
-
-    Output shape (new):
-        {
-            "current_state": {...} | null,
-            "reps": 3,
-            "lapses": 1,
-            "easy_count": 1,
-            "good_count": 1,
-            "last_review_date": "2025-01-01T12:00:00Z" | null,
-            "last_rating": "Good" | null
-        }
-    """
-    reviews = memory.get("reviews", [])
-    current_state = memory.get("current_state")
-
-    reps = len(reviews)
-    lapses = sum(1 for r in reviews if r.get("rating") == RATING_AGAIN)
-    easy_count = sum(1 for r in reviews if r.get("rating") == RATING_EASY)
-    good_count = sum(1 for r in reviews if r.get("rating") == RATING_GOOD)
-
-    # last_review_date: timestamp of the last review (chronologically)
-    last_review_date = None
-    last_rating = None
-    if reviews:
-        # Reviews are appended chronologically; last element is most recent.
-        # But sort by timestamp defensively in case of disorder.
-        sorted_reviews = sorted(reviews, key=lambda r: r.get("timestamp", ""))
-        last = sorted_reviews[-1]
-        last_review_date = last.get("timestamp")
-        last_rating = last.get("rating")
-
-    return {
-        "current_state": current_state,
-        "reps": reps,
-        "lapses": lapses,
-        "easy_count": easy_count,
-        "good_count": good_count,
-        "last_review_date": last_review_date,
-        "last_rating": last_rating,
-    }
-
-
-def migrate_knowledge_set(ks: dict) -> dict:
-    """Migrate all StudyCards in a KnowledgeSet from reviews to counters."""
-    study_cards = ks.get("study_cards", {})
-    migrated_count = 0
-
-    for card_id, study_card in study_cards.items():
-        memory = study_card.get("memory_history")
-        if memory is None:
-            continue
-        if "reviews" not in memory:
-            # Already migrated or no reviews — skip
-            continue
-        study_card["memory_history"] = migrate_memory_history(memory)
-        migrated_count += 1
-
-    return ks, migrated_count
-
-
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Migrate domain_user knowledge_set from reviews array to scalar counters"
     )
@@ -226,7 +116,7 @@ def main():
         )
 
         if args.dry_run:
-            print(f"    DRY RUN — not writing")
+            print("    DRY RUN — not writing")
             continue
 
         # Write back
@@ -234,7 +124,7 @@ def main():
         resp = session.patch(update_url, json={"knowledge_set": new_ks_raw})
         resp.raise_for_status()
         total_rows_updated += 1
-        print(f"    Written ✓")
+        print("    Written ✓")
 
     print(f"\nDone. {total_cards_migrated} cards migrated, {total_rows_updated} rows updated.")
     if args.dry_run:

--- a/scripts/migrate_reviews_to_counters.py
+++ b/scripts/migrate_reviews_to_counters.py
@@ -41,10 +41,14 @@ def main() -> None:
         description="Migrate domain_user knowledge_set from reviews array to scalar counters"
     )
     parser.add_argument(
-        "--dry-run", action="store_true", help="Decode and show what would change, but don't write"
+        "--dry-run",
+        action="store_true",
+        help="Decode and show what would change, but don't write",
     )
     parser.add_argument(
-        "--table", default="domain_user", help="TrailBase table name (default: domain_user)"
+        "--table",
+        default="domain_user",
+        help="TrailBase table name (default: domain_user)",
     )
     args = parser.parse_args()
 
@@ -52,7 +56,10 @@ def main() -> None:
     admin_token = os.environ.get("TRAILBASE_ADMIN_TOKEN")
 
     if not base_url or not admin_token:
-        print("ERROR: TRAILBASE_URL and TRAILBASE_ADMIN_TOKEN must be set", file=sys.stderr)
+        print(
+            "ERROR: TRAILBASE_URL and TRAILBASE_ADMIN_TOKEN must be set",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     session = requests.Session()
@@ -126,7 +133,9 @@ def main() -> None:
         total_rows_updated += 1
         print("    Written ✓")
 
-    print(f"\nDone. {total_cards_migrated} cards migrated, {total_rows_updated} rows updated.")
+    print(
+        f"\nDone. {total_cards_migrated} cards migrated, {total_rows_updated} rows updated."
+    )
     if args.dry_run:
         print("(dry run — no changes written)")
 

--- a/scripts/sync_user_to_domain_user.py
+++ b/scripts/sync_user_to_domain_user.py
@@ -13,6 +13,15 @@ The merge is idempotent (LWW + max() + union semantics) — it can be run
 repeatedly as the app-store rollout progresses, and the final run after
 100% rollout guarantees no data is left behind.
 
+⚠️  CONCURRENCY: This script does a read-merge-write cycle without
+    optimistic locking. If a new-client user does save_sync to
+    domain_user while this script runs, their write may be lost.
+    Mitigations:
+      - Run during low-traffic window (e.g. night)
+      - The idempotent merge means re-runs are safe — data lost to a
+        race will be recovered on the next sync run if the source data
+        still exists in `user`.
+
 Usage:
     TRAILBASE_URL=https://app.origa.uwuwu.net \\
     TRAILBASE_ADMIN_TOKEN=... \\

--- a/scripts/sync_user_to_domain_user.py
+++ b/scripts/sync_user_to_domain_user.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+Sync users from the `user` table (old client, reviews format) into the
+`domain_user` table (new client, counters format).
+
+Rolling-deployment migration (PR #350): the old client keeps writing to
+`user`, the new client writes to `domain_user`. This script merges any
+fresh data from `user` into `domain_user`, so new-client users who
+reviewed cards on an old-client device during the rollout window don't
+lose progress.
+
+The merge is idempotent (LWW + max() + union semantics) — it can be run
+repeatedly as the app-store rollout progresses, and the final run after
+100% rollout guarantees no data is left behind.
+
+Usage:
+    TRAILBASE_URL=https://app.origa.uwuwu.net \\
+    TRAILBASE_ADMIN_TOKEN=... \\
+    python scripts/sync_user_to_domain_user.py [--apply]
+
+Without --apply the script runs in dry-run mode: it shows what would
+change but writes nothing.
+
+The merge logic mirrors the Rust domain contracts exactly:
+  - MemoryHistory::merge     (LWW state + max counters)
+  - StudyCard::merge          (LWW favorites + max streak)
+  - KnowledgeSet::merge       (union tombstones + per-card merge)
+  - StatsTracker::merge       (per-date lesson history)
+
+Prerequisites:
+    pip install requests
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+from datetime import datetime
+from typing import Any
+
+import requests
+
+# Import shared codec + merge logic
+sys.path.insert(0, os.path.dirname(__file__))
+from _knowledge_set_codec import (  # noqa: E402
+    decode_knowledge_set,
+    encode_knowledge_set,
+    migrate_knowledge_set,
+    merge_knowledge_sets,
+)
+
+# ─── HTTP helpers ─────────────────────────────────────────────────────
+
+
+def fetch_all_records(session: requests.Session, base_url: str, table: str) -> list[dict]:
+    """Fetch all records from a TrailBase table with cursor pagination."""
+    records: list[dict] = []
+    cursor = None
+
+    while True:
+        params: dict[str, Any] = {"limit": 1024}
+        if cursor:
+            params["cursor"] = cursor
+
+        url = f"{base_url}/api/records/v1/{table}"
+        resp = session.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+
+        batch = data.get("records", [])
+        records.extend(batch)
+        cursor = data.get("cursor")
+
+        if not cursor:
+            break
+
+    return records
+
+
+def parse_timestamp(ts: str | None) -> datetime | None:
+    """Parse RFC3339 timestamp string to datetime (UTC)."""
+    if not ts:
+        return None
+    try:
+        # Handle both 'Z' suffix and explicit offset
+        if ts.endswith("Z"):
+            return datetime.fromisoformat(ts[:-1] + "+00:00")
+        return datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return None
+
+
+# ─── Field-level merge ────────────────────────────────────────────────
+
+
+def merge_scalar_fields(
+    user_row: dict[str, Any], domain_row: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge non-knowledge_set fields from user (remote) into domain_user.
+
+    Mirrors User::merge: scalar fields (email, username, native_language,
+    telegram_user_id, daily_load, reminders_enabled) follow LWW by updated_at.
+    imported_sets is unioned. jlpt_progress and known_vocab_hash are taken
+    from the newer row — they're recomputed client-side from knowledge_set.
+    """
+    user_updated = parse_timestamp(user_row.get("updated_at"))
+    domain_updated = parse_timestamp(domain_row.get("updated_at"))
+
+    # Default: keep domain_user values (current source of truth for new client)
+    merged = copy.deepcopy(domain_row)
+
+    # If user row is newer → take scalar fields from it
+    if user_updated and (not domain_updated or user_updated >= domain_updated):
+        for field in (
+            "username",
+            "native_language",
+            "telegram_user_id",
+            "daily_load",
+            "reminders_enabled",
+            "current_japanese_level",
+            "jlpt_progress",
+            "known_vocab_hash",
+        ):
+            if field in user_row:
+                merged[field] = user_row[field]
+
+    # imported_sets: union (stored as JSON array string)
+    merged["imported_sets"] = _union_imported_sets(
+        domain_row.get("imported_sets"), user_row.get("imported_sets")
+    )
+
+    # trailbase_id: keep domain_user's (it's the RLS identity for new client)
+    # updated_at: set to max of both
+    if user_updated and domain_updated:
+        merged["updated_at"] = max(user_updated, domain_updated).isoformat()
+    elif user_updated:
+        merged["updated_at"] = user_updated.isoformat()
+
+    return merged
+
+
+def _union_imported_sets(
+    domain_json: str | None, user_json: str | None
+) -> str:
+    """Union two imported_sets JSON arrays."""
+    domain_sets = set()
+    user_sets = set()
+
+    if domain_json:
+        try:
+            domain_sets = set(json.loads(domain_json))
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    if user_json:
+        try:
+            user_sets = set(json.loads(user_json))
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return json.dumps(sorted(domain_sets | user_sets))
+
+
+# ─── Per-user sync ────────────────────────────────────────────────────
+
+
+def sync_user_to_domain(
+    user_row: dict[str, Any],
+    domain_row: dict[str, Any] | None,
+    apply: bool,  # noqa: A002
+) -> dict[str, Any]:
+    """Sync one user record into domain_user. Returns a summary dict."""
+
+    # Case B: user only in `user` table → create in domain_user
+    if domain_row is None:
+        return _create_domain_from_user(user_row, apply)
+
+    # Case A: both exist → merge
+    return _merge_user_into_domain(user_row, domain_row, apply)
+
+
+def _create_domain_from_user(
+    user_row: dict[str, Any], apply: bool  # noqa: A002
+) -> dict[str, Any]:
+    """Create a new domain_user row from a user row (full copy + migration)."""
+    email = user_row.get("email", "?")
+
+    # Build new row — copy all fields from user
+    new_row = copy.deepcopy(user_row)
+    # Remove the DB primary key (let TrailBase auto-assign)
+    new_row.pop("id", None)
+
+    # Convert knowledge_set: reviews → counters
+    ks_raw = new_row.get("knowledge_set")
+    if ks_raw and ks_raw != '{"study_cards":{},"lesson_history":[]}':
+        ks = decode_knowledge_set(ks_raw)
+        ks, migrated = migrate_knowledge_set(ks)
+        new_ks_raw = encode_knowledge_set(ks)
+        old_size = len(ks_raw)
+        new_size = len(new_ks_raw)
+    else:
+        migrated = 0
+        old_size = len(ks_raw) if ks_raw else 0
+        new_size = old_size
+        new_ks_raw = ks_raw
+
+    new_row["knowledge_set"] = new_ks_raw
+
+    print(
+        f"  [{email}] CREATE in domain_user: "
+        f"{migrated} cards migrated, {old_size} → {new_size} bytes"
+    )
+
+    if not apply:
+        print("    DRY RUN — not writing")
+        return {"action": "create", "email": email, "migrated": migrated}
+
+    # POST create
+    create_url = f"{_BASE_URL}/api/records/v1/{_TABLE_DOMAIN}"
+    resp = _SESSION.post(create_url, json=new_row)
+    resp.raise_for_status()
+    print(f"    Created ✓ (id={resp.json().get('id', '?')})")
+    return {"action": "create", "email": email, "migrated": migrated, "id": resp.json().get("id")}
+
+
+def _merge_user_into_domain(
+    user_row: dict[str, Any],
+    domain_row: dict[str, Any],
+    apply: bool,  # noqa: A002
+) -> dict[str, Any]:
+    """Merge user data into existing domain_user row."""
+    email = user_row.get("email", "?")
+    record_id = domain_row.get("id")
+
+    # Decode both knowledge_sets
+    user_ks_raw = user_row.get("knowledge_set") or ""
+    domain_ks_raw = domain_row.get("knowledge_set") or ""
+
+    if not user_ks_raw or user_ks_raw == '{"study_cards":{},"lesson_history":[]}':
+        print(f"  [{email}] No data in user table, skipping")
+        return {"action": "skip", "email": email, "reason": "empty user ks"}
+
+    user_ks = decode_knowledge_set(user_ks_raw)
+
+    # Convert user's reviews → counters first (old format → new format)
+    user_ks, migrated = migrate_knowledge_set(user_ks)
+
+    if not domain_ks_raw or domain_ks_raw == '{"study_cards":{},"lesson_history":[]}':
+        # domain_user is empty — just take user's migrated KS
+        merged_ks = user_ks
+        user_card_count = len(user_ks.get("study_cards", {}))
+        print(f"  [{email}] domain_user empty, importing {user_card_count} cards")
+    else:
+        domain_ks = decode_knowledge_set(domain_ks_raw)
+        # Merge: domain_user is "local" (current), user is "remote" (incoming)
+        merged_ks = merge_knowledge_sets(domain_ks, user_ks)
+        domain_card_count = len(domain_ks.get("study_cards", {}))
+        user_card_count = len(user_ks.get("study_cards", {}))
+        merged_card_count = len(merged_ks.get("study_cards", {}))
+        print(
+            f"  [{email}] MERGE: domain={domain_card_count} cards, "
+            f"user={user_card_count} cards → {merged_card_count} cards"
+        )
+
+    new_ks_raw = encode_knowledge_set(merged_ks)
+
+    # Merge scalar fields
+    merged_row = merge_scalar_fields(user_row, domain_row)
+    merged_row["knowledge_set"] = new_ks_raw
+
+    if not apply:
+        print("    DRY RUN — not writing")
+        return {"action": "update", "email": email, "migrated": migrated}
+
+    # PATCH update
+    update_url = f"{_BASE_URL}/api/records/v1/{_TABLE_DOMAIN}/{record_id}"
+    resp = _SESSION.patch(update_url, json=merged_row)
+    resp.raise_for_status()
+    print("    Written ✓")
+    return {"action": "update", "email": email, "migrated": migrated}
+
+
+# ─── Main ─────────────────────────────────────────────────────────────
+
+# Module-level globals set in main() — used by helper functions above.
+_BASE_URL: str = ""
+_SESSION: requests.Session = requests.Session()  # type: ignore[assignment]
+_TABLE_DOMAIN: str = "domain_user"
+_TABLE_SOURCE: str = "user"
+
+
+def main() -> None:
+    global _BASE_URL, _SESSION, _TABLE_DOMAIN, _TABLE_SOURCE
+
+    parser = argparse.ArgumentParser(
+        description="Sync users from `user` table into `domain_user` table"
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply changes (default: dry-run, show what would change)",
+    )
+    parser.add_argument(
+        "--source-table",
+        default="user",
+        help="Source table name (default: user)",
+    )
+    parser.add_argument(
+        "--target-table",
+        default="domain_user",
+        help="Target table name (default: domain_user)",
+    )
+    args = parser.parse_args()
+
+    base_url = os.environ.get("TRAILBASE_URL")
+    admin_token = os.environ.get("TRAILBASE_ADMIN_TOKEN")
+
+    if not base_url or not admin_token:
+        print(
+            "ERROR: TRAILBASE_URL and TRAILBASE_ADMIN_TOKEN must be set",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    _BASE_URL = base_url
+    _TABLE_SOURCE = args.source_table
+    _TABLE_DOMAIN = args.target_table
+
+    _SESSION = requests.Session()
+    _SESSION.headers.update(
+        {
+            "Authorization": f"Bearer {admin_token}",
+            "Content-Type": "application/json",
+        }
+    )
+
+    print(f"Mode: {'APPLY' if args.apply else 'DRY RUN'}")
+    print(f"Source: {args.source_table} → Target: {args.target_table}")
+    print()
+
+    # Fetch all records from both tables
+    print(f"Fetching {args.source_table}...")
+    user_records = fetch_all_records(_SESSION, base_url, args.source_table)
+    print(f"  {len(user_records)} records")
+
+    print(f"Fetching {args.target_table}...")
+    domain_records = fetch_all_records(_SESSION, base_url, args.target_table)
+    print(f"  {len(domain_records)} records")
+    print()
+
+    # Index domain_user by email
+    domain_by_email: dict[str, dict[str, Any]] = {}
+    for row in domain_records:
+        email = row.get("email")
+        if email:
+            domain_by_email[email] = row
+
+    # Process each user
+    results: list[dict[str, Any]] = []
+    for user_row in user_records:
+        email = user_row.get("email", "?")
+        domain_row = domain_by_email.get(email)
+        result = sync_user_to_domain(user_row, domain_row, args.apply)
+        results.append(result)
+
+    # Summary
+    created = sum(1 for r in results if r["action"] == "create")
+    updated = sum(1 for r in results if r["action"] == "update")
+    skipped = sum(1 for r in results if r["action"] == "skip")
+
+    print()
+    print(f"Done. Created: {created}, Updated: {updated}, Skipped: {skipped}")
+    if not args.apply:
+        print("(dry run — no changes written)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_user_to_domain_user.py
+++ b/scripts/sync_user_to_domain_user.py
@@ -64,7 +64,9 @@ from _knowledge_set_codec import (  # noqa: E402
 # ─── HTTP helpers ─────────────────────────────────────────────────────
 
 
-def fetch_all_records(session: requests.Session, base_url: str, table: str) -> list[dict]:
+def fetch_all_records(
+    session: requests.Session, base_url: str, table: str
+) -> list[dict]:
     """Fetch all records from a TrailBase table with cursor pagination."""
     records: list[dict] = []
     cursor = None
@@ -110,10 +112,18 @@ def merge_scalar_fields(
 ) -> dict[str, Any]:
     """Merge non-knowledge_set fields from user (remote) into domain_user.
 
-    Mirrors User::merge: scalar fields (email, username, native_language,
-    telegram_user_id, daily_load, reminders_enabled) follow LWW by updated_at.
-    imported_sets is unioned. jlpt_progress and known_vocab_hash are taken
-    from the newer row — they're recomputed client-side from knowledge_set.
+    INTENTIONAL DIVERGENCE from Rust User::merge (user.rs:130-134): Rust
+    unconditionally takes remote values for scalar fields
+    (`self.username = another_user.username.clone()`). That works for
+    client-to-client sync where the remote is always the "latest" device
+    state. Here, we merge across TABLES, not devices — both tables have
+    independent update histories. LWW by `updated_at` is the correct
+    heuristic: the table that was written to last wins for scalar fields.
+
+    imported_sets is always unioned (matches Rust).
+
+    jlpt_progress and known_vocab_hash are taken from the newer row —
+    the new client recalculates both from knowledge_set on first sync.
     """
     user_updated = parse_timestamp(user_row.get("updated_at"))
     domain_updated = parse_timestamp(domain_row.get("updated_at"))
@@ -151,9 +161,7 @@ def merge_scalar_fields(
     return merged
 
 
-def _union_imported_sets(
-    domain_json: str | None, user_json: str | None
-) -> str:
+def _union_imported_sets(domain_json: str | None, user_json: str | None) -> str:
     """Union two imported_sets JSON arrays."""
     domain_sets = set()
     user_sets = set()
@@ -192,7 +200,8 @@ def sync_user_to_domain(
 
 
 def _create_domain_from_user(
-    user_row: dict[str, Any], apply: bool  # noqa: A002
+    user_row: dict[str, Any],
+    apply: bool,  # noqa: A002
 ) -> dict[str, Any]:
     """Create a new domain_user row from a user row (full copy + migration)."""
     email = user_row.get("email", "?")
@@ -204,16 +213,23 @@ def _create_domain_from_user(
 
     # Convert knowledge_set: reviews → counters
     ks_raw = new_row.get("knowledge_set")
-    if ks_raw and ks_raw != '{"study_cards":{},"lesson_history":[]}':
+    if ks_raw:
         ks = decode_knowledge_set(ks_raw)
-        ks, migrated = migrate_knowledge_set(ks)
-        new_ks_raw = encode_knowledge_set(ks)
-        old_size = len(ks_raw)
-        new_size = len(new_ks_raw)
+        if ks.get("study_cards"):
+            ks, migrated = migrate_knowledge_set(ks)
+            new_ks_raw = encode_knowledge_set(ks)
+            old_size = len(ks_raw)
+            new_size = len(new_ks_raw)
+        else:
+            # Empty knowledge_set — no migration needed
+            migrated = 0
+            old_size = len(ks_raw)
+            new_size = old_size
+            new_ks_raw = ks_raw
     else:
         migrated = 0
-        old_size = len(ks_raw) if ks_raw else 0
-        new_size = old_size
+        old_size = 0
+        new_size = 0
         new_ks_raw = ks_raw
 
     new_row["knowledge_set"] = new_ks_raw
@@ -232,7 +248,12 @@ def _create_domain_from_user(
     resp = _SESSION.post(create_url, json=new_row)
     resp.raise_for_status()
     print(f"    Created ✓ (id={resp.json().get('id', '?')})")
-    return {"action": "create", "email": email, "migrated": migrated, "id": resp.json().get("id")}
+    return {
+        "action": "create",
+        "email": email,
+        "migrated": migrated,
+        "id": resp.json().get("id"),
+    }
 
 
 def _merge_user_into_domain(
@@ -244,35 +265,44 @@ def _merge_user_into_domain(
     email = user_row.get("email", "?")
     record_id = domain_row.get("id")
 
-    # Decode both knowledge_sets
+    # Decode user knowledge_set
     user_ks_raw = user_row.get("knowledge_set") or ""
     domain_ks_raw = domain_row.get("knowledge_set") or ""
 
-    if not user_ks_raw or user_ks_raw == '{"study_cards":{},"lesson_history":[]}':
+    if not user_ks_raw:
         print(f"  [{email}] No data in user table, skipping")
         return {"action": "skip", "email": email, "reason": "empty user ks"}
 
     user_ks = decode_knowledge_set(user_ks_raw)
+    if not user_ks.get("study_cards"):
+        print(f"  [{email}] No study cards in user table, skipping")
+        return {"action": "skip", "email": email, "reason": "empty user ks"}
 
     # Convert user's reviews → counters first (old format → new format)
     user_ks, migrated = migrate_knowledge_set(user_ks)
 
-    if not domain_ks_raw or domain_ks_raw == '{"study_cards":{},"lesson_history":[]}':
+    if not domain_ks_raw:
         # domain_user is empty — just take user's migrated KS
         merged_ks = user_ks
         user_card_count = len(user_ks.get("study_cards", {}))
         print(f"  [{email}] domain_user empty, importing {user_card_count} cards")
     else:
         domain_ks = decode_knowledge_set(domain_ks_raw)
-        # Merge: domain_user is "local" (current), user is "remote" (incoming)
-        merged_ks = merge_knowledge_sets(domain_ks, user_ks)
-        domain_card_count = len(domain_ks.get("study_cards", {}))
-        user_card_count = len(user_ks.get("study_cards", {}))
-        merged_card_count = len(merged_ks.get("study_cards", {}))
-        print(
-            f"  [{email}] MERGE: domain={domain_card_count} cards, "
-            f"user={user_card_count} cards → {merged_card_count} cards"
-        )
+        if not domain_ks.get("study_cards"):
+            # domain_user is empty — just take user's migrated KS
+            merged_ks = user_ks
+            user_card_count = len(user_ks.get("study_cards", {}))
+            print(f"  [{email}] domain_user empty, importing {user_card_count} cards")
+        else:
+            # Merge: domain_user is "local" (current), user is "remote" (incoming)
+            merged_ks = merge_knowledge_sets(domain_ks, user_ks)
+            domain_card_count = len(domain_ks.get("study_cards", {}))
+            user_card_count = len(user_ks.get("study_cards", {}))
+            merged_card_count = len(merged_ks.get("study_cards", {}))
+            print(
+                f"  [{email}] MERGE: domain={domain_card_count} cards, "
+                f"user={user_card_count} cards → {merged_card_count} cards"
+            )
 
     new_ks_raw = encode_knowledge_set(merged_ks)
 
@@ -298,11 +328,10 @@ def _merge_user_into_domain(
 _BASE_URL: str = ""
 _SESSION: requests.Session = requests.Session()  # type: ignore[assignment]
 _TABLE_DOMAIN: str = "domain_user"
-_TABLE_SOURCE: str = "user"
 
 
 def main() -> None:
-    global _BASE_URL, _SESSION, _TABLE_DOMAIN, _TABLE_SOURCE
+    global _BASE_URL, _SESSION, _TABLE_DOMAIN
 
     parser = argparse.ArgumentParser(
         description="Sync users from `user` table into `domain_user` table"
@@ -335,7 +364,6 @@ def main() -> None:
         sys.exit(1)
 
     _BASE_URL = base_url
-    _TABLE_SOURCE = args.source_table
     _TABLE_DOMAIN = args.target_table
 
     _SESSION = requests.Session()
@@ -360,18 +388,20 @@ def main() -> None:
     print(f"  {len(domain_records)} records")
     print()
 
-    # Index domain_user by email
+    # Index domain_user by email (case-insensitive — RFC 5321 local-part
+    # is technically case-sensitive but email providers treat it as
+    # case-insensitive; normalizing prevents duplicate-user bugs)
     domain_by_email: dict[str, dict[str, Any]] = {}
     for row in domain_records:
         email = row.get("email")
         if email:
-            domain_by_email[email] = row
+            domain_by_email[email.lower()] = row
 
     # Process each user
     results: list[dict[str, Any]] = []
     for user_row in user_records:
         email = user_row.get("email", "?")
-        domain_row = domain_by_email.get(email)
+        domain_row = domain_by_email.get(email.lower())
         result = sync_user_to_domain(user_row, domain_row, args.apply)
         results.append(result)
 

--- a/scripts/test_sync_logic.py
+++ b/scripts/test_sync_logic.py
@@ -157,9 +157,7 @@ def test_migrate_preserves_current_state():
 
 def test_migrate_idempotent():
     """Double-migrating produces the same result."""
-    mem = make_memory_with_reviews(
-        [(YESTERDAY, "Good"), (NOW, "Again"), (NOW, "Easy")]
-    )
+    mem = make_memory_with_reviews([(YESTERDAY, "Good"), (NOW, "Again"), (NOW, "Easy")])
     once = migrate_memory_history(mem)
     # No "reviews" key → migrate_memory_history should handle gracefully
     twice = {
@@ -229,14 +227,24 @@ def test_merge_memory_history_keeps_older_if_local_newer():
 def test_merge_memory_history_idempotent():
     """Double-merge = single merge."""
     local = make_memory_with_counters(
-        reps=3, lapses=1, easy_count=1, good_count=2,
-        last_review_date=YESTERDAY, last_rating="Good",
-        stability=5.0, difficulty=3.0,
+        reps=3,
+        lapses=1,
+        easy_count=1,
+        good_count=2,
+        last_review_date=YESTERDAY,
+        last_rating="Good",
+        stability=5.0,
+        difficulty=3.0,
     )
     remote = make_memory_with_counters(
-        reps=1, lapses=0, easy_count=1, good_count=0,
-        last_review_date=NOW, last_rating="Easy",
-        stability=10.0, difficulty=7.0,
+        reps=1,
+        lapses=0,
+        easy_count=1,
+        good_count=0,
+        last_review_date=NOW,
+        last_rating="Easy",
+        stability=10.0,
+        difficulty=7.0,
     )
 
     once = merge_memory_history(local, remote)
@@ -250,12 +258,8 @@ def test_merge_memory_history_idempotent():
 
 def test_merge_study_card_favorite_lww():
     """Favorite: LWW by favorite_changed_at — unfavorite wins with newer ts."""
-    local = make_study_card(
-        is_favorite=True, favorite_changed_at=YESTERDAY, streak=2
-    )
-    remote = make_study_card(
-        is_favorite=False, favorite_changed_at=NOW, streak=0
-    )
+    local = make_study_card(is_favorite=True, favorite_changed_at=YESTERDAY, streak=2)
+    remote = make_study_card(is_favorite=False, favorite_changed_at=NOW, streak=0)
 
     result = merge_study_card(local, remote)
 
@@ -266,12 +270,8 @@ def test_merge_study_card_favorite_lww():
 
 def test_merge_study_card_favorite_keeps_newer_favorite():
     """Newer favorite=true wins over older favorite=false."""
-    local = make_study_card(
-        is_favorite=False, favorite_changed_at=YESTERDAY, streak=0
-    )
-    remote = make_study_card(
-        is_favorite=True, favorite_changed_at=NOW, streak=3
-    )
+    local = make_study_card(is_favorite=False, favorite_changed_at=YESTERDAY, streak=0)
+    remote = make_study_card(is_favorite=True, favorite_changed_at=NOW, streak=3)
 
     result = merge_study_card(local, remote)
 
@@ -412,8 +412,12 @@ def test_merge_knowledge_set_idempotent():
             "card_a": make_study_card(
                 "card_a",
                 memory=make_memory_with_counters(
-                    reps=5, lapses=1, last_review_date=YESTERDAY,
-                    last_rating="Good", stability=3.0, difficulty=2.0,
+                    reps=5,
+                    lapses=1,
+                    last_review_date=YESTERDAY,
+                    last_rating="Good",
+                    stability=3.0,
+                    difficulty=2.0,
                 ),
             ),
         },
@@ -426,8 +430,12 @@ def test_merge_knowledge_set_idempotent():
             "card_a": make_study_card(
                 "card_a",
                 memory=make_memory_with_counters(
-                    reps=3, lapses=0, last_review_date=NOW,
-                    last_rating="Easy", stability=10.0, difficulty=5.0,
+                    reps=3,
+                    lapses=0,
+                    last_review_date=NOW,
+                    last_rating="Easy",
+                    stability=10.0,
+                    difficulty=5.0,
                 ),
             ),
             "card_b": make_study_card("card_b", word="犬"),
@@ -557,9 +565,14 @@ def test_cross_format_merge():
             "card_a": make_study_card(
                 "card_a",
                 memory=make_memory_with_counters(
-                    reps=5, lapses=0, easy_count=2, good_count=3,
-                    last_review_date=NOW, last_rating="Good",
-                    stability=10.0, difficulty=4.0,
+                    reps=5,
+                    lapses=0,
+                    easy_count=2,
+                    good_count=3,
+                    last_review_date=NOW,
+                    last_rating="Good",
+                    stability=10.0,
+                    difficulty=4.0,
                 ),
             ),
         },

--- a/scripts/test_sync_logic.py
+++ b/scripts/test_sync_logic.py
@@ -1,0 +1,636 @@
+"""Unit tests for _knowledge_set_codec merge logic.
+
+Each test mirrors a Rust domain test, verifying that the Python merge
+produces the same result as the corresponding Rust implementation:
+
+  - migrate_memory_history  ← MemoryHistory counters
+  - merge_memory_history    ← MemoryHistory::merge
+  - merge_study_card        ← StudyCard::merge
+  - merge_knowledge_sets    ← KnowledgeSet::merge
+  - merge_lesson_history    ← StatsTracker::merge / DailyHistoryItem::merge_with
+
+Run: python scripts/test_sync_logic.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from _knowledge_set_codec import (  # noqa: E402
+    decode_knowledge_set,
+    encode_knowledge_set,
+    merge_lesson_history,
+    migrate_memory_history,
+    merge_daily_history_item,
+    merge_knowledge_sets,
+    merge_memory_history,
+    merge_study_card,
+)
+
+# ─── Test helpers ─────────────────────────────────────────────────────
+
+NOW = "2026-08-10T12:00:00Z"
+YESTERDAY = "2026-08-09T12:00:00Z"
+TOMORROW = "2026-08-11T12:00:00Z"
+
+
+def make_memory_with_counters(
+    reps: int = 0,
+    lapses: int = 0,
+    easy_count: int = 0,
+    good_count: int = 0,
+    last_review_date: str | None = None,
+    last_rating: str | None = None,
+    stability: float | None = None,
+    difficulty: float | None = None,
+) -> dict:
+    """Create a counter-format memory_history (new client format)."""
+    mem = {
+        "current_state": None,
+        "reps": reps,
+        "lapses": lapses,
+        "easy_count": easy_count,
+        "good_count": good_count,
+        "last_review_date": last_review_date,
+        "last_rating": last_rating,
+    }
+    if stability is not None and difficulty is not None:
+        mem["current_state"] = {
+            "stability": {"value": stability},
+            "difficulty": {"value": difficulty},
+            "next_review_date": last_review_date or NOW,
+            "card_state": "Review",
+        }
+    return mem
+
+
+def make_memory_with_reviews(ratings: list[tuple[str, str]]) -> dict:
+    """Create a reviews-format memory_history (old client format).
+
+    ratings: list of (timestamp, rating) pairs, chronological.
+    """
+    reviews = []
+    for i, (ts, rating) in enumerate(ratings):
+        reviews.append(
+            {
+                "id": f"01J000000000000000000000{i:02d}",
+                "rating": rating,
+                "timestamp": ts,
+                "interval": {"secs": 86400, "nanos": 0},
+            }
+        )
+    return {
+        "current_state": {
+            "stability": {"value": 5.0},
+            "difficulty": {"value": 3.0},
+            "next_review_date": ratings[-1][0] if ratings else NOW,
+            "card_state": "Review",
+        }
+        if ratings
+        else None,
+        "reviews": reviews,
+    }
+
+
+def make_study_card(
+    card_id: str = "01J0000000000000000000001A",
+    memory: dict | None = None,
+    is_favorite: bool = False,
+    favorite_changed_at: str | None = None,
+    streak: int = 0,
+    word: str = "猫",
+) -> dict:
+    return {
+        "card_id": card_id,
+        "card": {"Vocabulary": {"word": {"text": word}}},
+        "memory_history": memory or make_memory_with_counters(),
+        "is_favorite": is_favorite,
+        "perfect_streak_since_known": streak,
+        "favorite_changed_at": favorite_changed_at,
+    }
+
+
+# ─── Reviews → Counters ──────────────────────────────────────────────
+
+
+def test_migrate_basic():
+    """Reviews array correctly converts to counters."""
+    mem = make_memory_with_reviews(
+        [(YESTERDAY, "Good"), (NOW, "Easy"), (NOW, "Again"), (NOW, "Good")]
+    )
+    result = migrate_memory_history(mem)
+
+    assert result["reps"] == 4
+    assert result["lapses"] == 1
+    assert result["easy_count"] == 1
+    assert result["good_count"] == 2
+    assert result["last_rating"] == "Good"
+    assert result["current_state"] is not None
+
+
+def test_migrate_empty_reviews():
+    """Empty reviews array produces zero counters."""
+    mem = {"current_state": None, "reviews": []}
+    result = migrate_memory_history(mem)
+
+    assert result["reps"] == 0
+    assert result["lapses"] == 0
+    assert result["last_review_date"] is None
+    assert result["last_rating"] is None
+
+
+def test_migrate_preserves_current_state():
+    """current_state is passed through unchanged."""
+    state = {
+        "stability": {"value": 10.0},
+        "difficulty": {"value": 2.0},
+        "next_review_date": NOW,
+        "card_state": "Review",
+    }
+    mem = {"current_state": state, "reviews": []}
+    result = migrate_memory_history(mem)
+
+    assert result["current_state"] == state
+
+
+def test_migrate_idempotent():
+    """Double-migrating produces the same result."""
+    mem = make_memory_with_reviews(
+        [(YESTERDAY, "Good"), (NOW, "Again"), (NOW, "Easy")]
+    )
+    once = migrate_memory_history(mem)
+    # No "reviews" key → migrate_memory_history should handle gracefully
+    twice = {
+        "current_state": once["current_state"],
+    }
+    twice.update({k: v for k, v in once.items() if k != "current_state"})
+
+    assert once == twice
+
+
+# ─── MemoryHistory merge ─────────────────────────────────────────────
+
+
+def test_merge_memory_history_max_counters():
+    """Counters merge via max() — mirrors merge_combines_counters_via_max."""
+    local = make_memory_with_counters(
+        reps=3, lapses=1, easy_count=1, good_count=2, last_review_date=YESTERDAY
+    )
+    remote = make_memory_with_counters(
+        reps=1, lapses=0, easy_count=1, good_count=0, last_review_date=NOW
+    )
+
+    result = merge_memory_history(local, remote)
+
+    assert result["reps"] == 3  # max(3, 1)
+    assert result["lapses"] == 1  # max(1, 0)
+    assert result["easy_count"] == 1  # max(1, 1)
+    assert result["good_count"] == 2  # max(2, 0)
+
+
+def test_merge_memory_history_takes_newer_rating():
+    """last_rating from the newer side — mirrors merge_takes_last_rating_from_newer_side."""
+    local = make_memory_with_counters(
+        last_review_date=YESTERDAY, last_rating="Good", stability=3.0, difficulty=2.0
+    )
+    remote = make_memory_with_counters(
+        last_review_date=NOW, last_rating="Easy", stability=5.0, difficulty=4.0
+    )
+
+    result = merge_memory_history(local, remote)
+
+    assert result["last_rating"] == "Easy"
+    assert result["current_state"]["stability"]["value"] == 5.0
+
+
+def test_merge_memory_history_keeps_older_if_local_newer():
+    """If local is newer, local state is preserved."""
+    local = make_memory_with_counters(
+        last_review_date=NOW,
+        last_rating="Good",
+        stability=10.0,
+        difficulty=5.0,
+    )
+    remote = make_memory_with_counters(
+        last_review_date=YESTERDAY,
+        last_rating="Easy",
+        stability=2.0,
+        difficulty=1.0,
+    )
+
+    result = merge_memory_history(local, remote)
+
+    assert result["last_rating"] == "Good"
+    assert result["current_state"]["stability"]["value"] == 10.0
+
+
+def test_merge_memory_history_idempotent():
+    """Double-merge = single merge."""
+    local = make_memory_with_counters(
+        reps=3, lapses=1, easy_count=1, good_count=2,
+        last_review_date=YESTERDAY, last_rating="Good",
+        stability=5.0, difficulty=3.0,
+    )
+    remote = make_memory_with_counters(
+        reps=1, lapses=0, easy_count=1, good_count=0,
+        last_review_date=NOW, last_rating="Easy",
+        stability=10.0, difficulty=7.0,
+    )
+
+    once = merge_memory_history(local, remote)
+    twice = merge_memory_history(once, remote)
+
+    assert once == twice
+
+
+# ─── StudyCard merge ─────────────────────────────────────────────────
+
+
+def test_merge_study_card_favorite_lww():
+    """Favorite: LWW by favorite_changed_at — unfavorite wins with newer ts."""
+    local = make_study_card(
+        is_favorite=True, favorite_changed_at=YESTERDAY, streak=2
+    )
+    remote = make_study_card(
+        is_favorite=False, favorite_changed_at=NOW, streak=0
+    )
+
+    result = merge_study_card(local, remote)
+
+    assert result["is_favorite"] is False
+    assert result["favorite_changed_at"] == NOW
+    assert result["perfect_streak_since_known"] == 0  # unfavorite resets streak
+
+
+def test_merge_study_card_favorite_keeps_newer_favorite():
+    """Newer favorite=true wins over older favorite=false."""
+    local = make_study_card(
+        is_favorite=False, favorite_changed_at=YESTERDAY, streak=0
+    )
+    remote = make_study_card(
+        is_favorite=True, favorite_changed_at=NOW, streak=3
+    )
+
+    result = merge_study_card(local, remote)
+
+    assert result["is_favorite"] is True
+    assert result["perfect_streak_since_known"] == 3  # max(0, 3)
+
+
+def test_merge_study_card_streak_max():
+    """favorite_easy_streak takes max."""
+    local = make_study_card(is_favorite=True, streak=4)
+    remote = make_study_card(is_favorite=True, streak=2)
+
+    result = merge_study_card(local, remote)
+
+    assert result["perfect_streak_since_known"] == 4  # max(4, 2)
+
+
+def test_merge_study_card_legacy_no_timestamps():
+    """No timestamps → OR fallback for is_favorite."""
+    local = make_study_card(is_favorite=False, favorite_changed_at=None)
+    remote = make_study_card(is_favorite=True, favorite_changed_at=None)
+
+    result = merge_study_card(local, remote)
+
+    assert result["is_favorite"] is True  # False OR True
+
+
+# ─── KnowledgeSet merge ──────────────────────────────────────────────
+
+
+def test_merge_knowledge_set_new_cards_added():
+    """Cards in remote that aren't in local are added (unique content_key)."""
+    local_ks = {
+        "study_cards": {"card_a": make_study_card("card_a")},
+        "lesson_history": [],
+    }
+    remote_ks = {
+        "study_cards": {
+            "card_a": make_study_card("card_a"),
+            "card_b": make_study_card("card_b", word="犬"),
+        },
+        "lesson_history": [],
+    }
+
+    result = merge_knowledge_sets(local_ks, remote_ks)
+
+    assert "card_a" in result["study_cards"]
+    assert "card_b" in result["study_cards"]
+
+
+def test_merge_knowledge_set_duplicate_content_blocked():
+    """A new card with same content_key as existing is NOT added.
+
+    Mirrors Rust KnowledgeSet::merge → validate_unique_card gate.
+    Both cards are Vocabulary with word "猫", but different card_ids.
+    """
+    local_ks = {
+        "study_cards": {"card_a": make_study_card("card_a")},
+        "lesson_history": [],
+    }
+    remote_ks = {
+        "study_cards": {
+            "card_b": make_study_card("card_b"),  # same word "猫"
+        },
+        "lesson_history": [],
+    }
+
+    result = merge_knowledge_sets(local_ks, remote_ks)
+
+    # card_b NOT added — duplicate word "猫"
+    assert "card_a" in result["study_cards"]
+    assert "card_b" not in result["study_cards"]
+
+
+def test_merge_knowledge_set_tombstone_removes_card():
+    """deleted_cards union removes matching study_cards."""
+    local_ks = {
+        "study_cards": {
+            "card_a": make_study_card("card_a"),
+            "card_b": make_study_card("card_b"),
+        },
+        "deleted_cards": [],
+        "lesson_history": [],
+    }
+    remote_ks = {
+        "study_cards": {},
+        "deleted_cards": ["card_a"],
+        "lesson_history": [],
+    }
+
+    result = merge_knowledge_sets(local_ks, remote_ks)
+
+    assert "card_a" not in result["study_cards"]
+    assert "card_b" in result["study_cards"]
+    assert "card_a" in result["deleted_cards"]
+
+
+def test_merge_knowledge_set_tombstone_prevents_re_add():
+    """A card in deleted_cards is not re-added from remote study_cards."""
+    local_ks = {
+        "study_cards": {},
+        "deleted_cards": ["card_x"],
+        "lesson_history": [],
+    }
+    remote_ks = {
+        "study_cards": {"card_x": make_study_card("card_x")},
+        "deleted_cards": [],
+        "lesson_history": [],
+    }
+
+    result = merge_knowledge_sets(local_ks, remote_ks)
+
+    assert "card_x" not in result["study_cards"]
+
+
+def test_merge_knowledge_set_companion_words_union():
+    """deleted_companion_words are unioned."""
+    local_ks = {
+        "study_cards": {},
+        "deleted_companion_words": ["犬"],
+        "lesson_history": [],
+    }
+    remote_ks = {
+        "study_cards": {},
+        "deleted_companion_words": ["猫", "犬"],
+        "lesson_history": [],
+    }
+
+    result = merge_knowledge_sets(local_ks, remote_ks)
+
+    assert set(result["deleted_companion_words"]) == {"犬", "猫"}
+
+
+def test_merge_knowledge_set_idempotent():
+    """Double-merge = single merge — critical for repeatable sync."""
+    local_ks = {
+        "study_cards": {
+            "card_a": make_study_card(
+                "card_a",
+                memory=make_memory_with_counters(
+                    reps=5, lapses=1, last_review_date=YESTERDAY,
+                    last_rating="Good", stability=3.0, difficulty=2.0,
+                ),
+            ),
+        },
+        "deleted_cards": [],
+        "deleted_companion_words": ["犬"],
+        "lesson_history": [],
+    }
+    remote_ks = {
+        "study_cards": {
+            "card_a": make_study_card(
+                "card_a",
+                memory=make_memory_with_counters(
+                    reps=3, lapses=0, last_review_date=NOW,
+                    last_rating="Easy", stability=10.0, difficulty=5.0,
+                ),
+            ),
+            "card_b": make_study_card("card_b", word="犬"),
+        },
+        "deleted_cards": [],
+        "deleted_companion_words": ["猫"],
+        "lesson_history": [],
+    }
+
+    once = merge_knowledge_sets(local_ks, remote_ks)
+    twice = merge_knowledge_sets(once, remote_ks)
+
+    assert once == twice
+
+
+# ─── Lesson history merge ────────────────────────────────────────────
+
+
+def test_merge_lesson_history_different_days():
+    """History items from different days are both kept."""
+    local = [
+        {"timestamp": NOW, "lessons_completed": 3, "positive_ratings": 10},
+    ]
+    remote = [
+        {"timestamp": YESTERDAY, "lessons_completed": 2, "positive_ratings": 5},
+    ]
+
+    result = merge_lesson_history(local, remote)
+
+    assert len(result) == 2
+    timestamps = [item["timestamp"] for item in result]
+    assert timestamps == sorted(timestamps)
+
+
+def test_merge_lesson_history_same_day_max():
+    """Same-day items merge via max() for counters."""
+    local = [
+        {
+            "timestamp": NOW,
+            "lessons_completed": 3,
+            "positive_ratings": 10,
+            "new_cards_studied_today": 5,
+        },
+    ]
+    remote = [
+        {
+            "timestamp": NOW,
+            "lessons_completed": 5,
+            "positive_ratings": 7,
+            "new_cards_studied_today": 3,
+        },
+    ]
+
+    result = merge_lesson_history(local, remote)
+
+    assert len(result) == 1
+    assert result[0]["lessons_completed"] == 5  # max(3, 5)
+    assert result[0]["positive_ratings"] == 10  # max(10, 7)
+    assert result[0]["new_cards_studied_today"] == 5  # max(5, 3)
+
+
+def test_merge_daily_history_snapshot_lww():
+    """avg_stability/avg_difficulty: LWW by timestamp."""
+    local = {
+        "timestamp": YESTERDAY,
+        "avg_stability": 3.0,
+        "avg_difficulty": 5.0,
+        "lessons_completed": 2,
+    }
+    other = {
+        "timestamp": NOW,
+        "avg_stability": 10.0,
+        "avg_difficulty": 2.0,
+        "lessons_completed": 1,
+    }
+
+    merge_daily_history_item(local, other)
+
+    assert local["avg_stability"] == 10.0  # newer wins
+    assert local["avg_difficulty"] == 2.0
+    assert local["lessons_completed"] == 2  # max(2, 1)
+
+
+# ─── Codec round-trip ────────────────────────────────────────────────
+
+
+def test_codec_roundtrip():
+    """Encode → decode preserves data."""
+    ks = {
+        "study_cards": {"card_a": make_study_card("card_a")},
+        "lesson_history": [{"timestamp": NOW, "lessons_completed": 1}],
+        "deleted_cards": ["card_x"],
+    }
+    encoded = encode_knowledge_set(ks)
+    decoded = decode_knowledge_set(encoded)
+
+    assert decoded == ks
+
+
+def test_codec_deflate_prefix():
+    """Encoded blob starts with DEFLATE; prefix."""
+    encoded = encode_knowledge_set({"study_cards": {}, "lesson_history": []})
+    assert encoded.startswith("DEFLATE;")
+
+
+def test_decode_corrupt_returns_empty():
+    """Corrupt blob → empty KnowledgeSet (recovering policy)."""
+    result = decode_knowledge_set("DEFLATE;!!!corrupt!!!")
+    assert result == {"study_cards": {}, "lesson_history": []}
+
+
+# ─── Cross-format merge (old user + new domain_user) ─────────────────
+
+
+def test_cross_format_merge():
+    """User has reviews format, domain_user has counters → merge works.
+
+    This is the core sync scenario: old client wrote reviews, new client
+    has counters. The sync script converts user's reviews → counters
+    first (via migrate_knowledge_set), then merges.
+    """
+    from _knowledge_set_codec import migrate_knowledge_set
+
+    # domain_user (new format): 1 card with 5 reps
+    domain_ks = {
+        "study_cards": {
+            "card_a": make_study_card(
+                "card_a",
+                memory=make_memory_with_counters(
+                    reps=5, lapses=0, easy_count=2, good_count=3,
+                    last_review_date=NOW, last_rating="Good",
+                    stability=10.0, difficulty=4.0,
+                ),
+            ),
+        },
+        "lesson_history": [],
+    }
+
+    # user (old format): same card with 3 reviews, 1 lapse, newer last_review
+    user_ks = {
+        "study_cards": {
+            "card_a": {
+                "card_id": "card_a",
+                "card": {"Vocabulary": {"word": {"text": "猫"}}},
+                "memory_history": make_memory_with_reviews(
+                    [(YESTERDAY, "Good"), (YESTERDAY, "Again"), (TOMORROW, "Easy")]
+                ),
+                "is_favorite": False,
+                "perfect_streak_since_known": 0,
+                "favorite_changed_at": None,
+            },
+        },
+        "lesson_history": [],
+    }
+
+    # Convert user's reviews → counters
+    user_ks_converted, migrated = migrate_knowledge_set(user_ks)
+    assert migrated == 1
+
+    # Merge
+    result = merge_knowledge_sets(domain_ks, user_ks_converted)
+    card = result["study_cards"]["card_a"]
+    mem = card["memory_history"]
+
+    # Counters: max(5, 3) = 5 reps
+    assert mem["reps"] == 5
+    # Lapses: max(0, 1) = 1
+    assert mem["lapses"] == 1
+    # easy_count: max(2, 1) = 2
+    assert mem["easy_count"] == 2
+    # good_count: max(3, 1) = 3
+    assert mem["good_count"] == 3
+    # last_review_date: TOMORROW is newer than NOW → remote wins
+    assert mem["last_review_date"] == TOMORROW
+    assert mem["last_rating"] == "Easy"
+
+
+# ─── Run ─────────────────────────────────────────────────────────────
+
+ALL_TESTS = [
+    v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)
+]
+
+
+def main() -> None:
+    passed = 0
+    failed = 0
+    for test in ALL_TESTS:
+        try:
+            test()
+            print(f"  ✓ {test.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  ✗ {test.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ✗ {test.__name__}: {type(e).__name__}: {e}")
+            failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Rolling-deployment migration (PR #350): the old client keeps writing to `user`, the new client writes to `domain_user`. While testing was underway, old-client users generated fresh data in `user` that isn't in `domain_user`.

New script `sync_user_to_domain_user.py` merges any fresh data from `user` into `domain_user`:

- **Case A** (user in both tables): merge — convert reviews → counters, then LWW/max/union per Rust contracts
- **Case B** (user only in `user`): create in `domain_user` with full reviews → counters migration
- **Case C** (user only in `domain_user`): skip

## Why

App Store rollout takes ~1 week. During that window, users who reviewed cards on an old-client device will have data in `user` that's missing from `domain_user`. This script syncs it across. Idempotent (LWW + max + union) — safe to run now and again after rollout completes.

## Bugfix

`zlib.deinflate` → `zlib.decompress` in `migrate_reviews_to_counters.py` — a typo that silently returned empty KnowledgeSet on every decode (the `except` swallowed the `AttributeError`).

## Refactor

Extracted shared codec + merge logic into `_knowledge_set_codec.py`, used by both `migrate_reviews_to_counters.py` and the new sync script. All merge functions mirror the Rust domain contracts exactly:

- `MemoryHistory::merge` — LWW state + max counters
- `StudyCard::merge` — LWW favorites + max streak
- `KnowledgeSet::merge` — union tombstones + per-card merge + `validate_unique_card` gate
- `StatsTracker::merge` — per-date lesson history

## Usage

```bash
# Dry run (default) — shows what would change
TRAILBASE_URL=https://app.origa.uwuwu.net TRAILBASE_ADMIN_TOKEN=... python scripts/sync_user_to_domain_user.py

# Apply
python scripts/sync_user_to_domain_user.py --apply
```

## Test plan

- [x] 25 unit tests pass (`python scripts/test_sync_logic.py`)
- [x] `ruff check` clean
- [x] `qlty check` clean
- [ ] Manual dry-run against production TrailBase
- [ ] Apply before release
- [ ] Re-run after App Store rollout (~1 week)