### PR TITLE
fix(lesson): reversed card answer body shows translation not Japanese

### DIFF
--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -301,7 +301,7 @@ pub fn LessonCard(
                 <Show when=move || show_answer.get()>
                     <LessonCardAnswer
                         question_text=answer_heading.get_value()
-                        answer_text=answer.get_value()
+                        answer_text=if is_reversed { question.get_value() } else { answer.get_value() }
                         answer_translations=answer_translations_stored.get_value()
                         answer_description=answer_description_stored.get_value()
                         is_expanded=is_expanded


### PR DESCRIPTION
## Fix

Reversed vocab cards showed Japanese in BOTH the heading AND the body of the answer screen — a duplicate. Root cause: PR #375 changed `answer_text` to `answer.get_value()` (= `tts_text`), which is Japanese for reversed cards.

```
BEFORE (broken):                    AFTER (fixed):
┌─ ANSWER SCREEN (reversed) ─┐     ┌─ ANSWER SCREEN (reversed) ─┐
│ Heading: 静か               │     │ Heading: 静か               │
│ Body:    静か  ← duplicate │     │ Body:    'тихий' ← correct │
└────────────────────────────┘     └────────────────────────────┘
```

One-line fix: `answer_text=if is_reversed { question.get_value() } else { answer.get_value() }`
