### PR TITLE
perf: cache pre-built lindera structures + rkyv vocabulary to fix iOS OOM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -276,7 +276,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1577,9 +1577,9 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "daachorse"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b7ef7a4be509357f4804d0a22e830daddb48f19fd604e4ad32ddce04a94c36"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
 
 [[package]]
 name = "darling"
@@ -1861,7 +1861,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2243,7 +2243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3036,6 +3036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,7 +3301,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4793,9 +4799,9 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "2.3.1"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cba4f25e8286c3ca0c700d5687123bc659fae58a4ffd54b461350f45f6b181"
+checksum = "0bb784bf51d22be2350667c35c0796250ca4dd6888ee98fe8a41f16f400f6c9b"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4820,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "2.3.1"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0921a4194103067cc0f465a9f0abdea4070a454cc89838b93d5c5cc7392e54"
+checksum = "5cd0aa640fbefa4b4251f8ab001e47f213fdecf7bbbd0ee4a17a27b2cbff5ef1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4839,7 +4845,7 @@ dependencies = [
  "memmap2",
  "num_cpus",
  "once_cell",
- "rand 0.10.0",
+ "rand 0.10.2",
  "regex",
  "reqwest 0.13.2",
  "rkyv",
@@ -5143,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -5365,7 +5371,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7045,9 +7051,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "rand_core 0.10.0",
 ]
@@ -7471,13 +7477,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "munge",
  "ptr_meta",
@@ -7490,13 +7496,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7631,7 +7637,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7690,7 +7696,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8509,7 +8515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8747,6 +8753,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn_derive"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8874,9 +8891,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -9290,7 +9307,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9455,9 +9472,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -9472,13 +9489,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9894,7 +9911,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10005,9 +10022,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -10701,7 +10718,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/origa/src/dictionary/vocabulary.rs
+++ b/origa/src/dictionary/vocabulary.rs
@@ -92,7 +92,7 @@ fn parse_legacy_translation(text: &str) -> (Vec<String>, Option<String>) {
     (translations, description)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct VocabularyInfo {
     word: String,
     ru_translations: Vec<String>,
@@ -161,6 +161,7 @@ struct VocabularyEntryStoredType {
     en: Option<TranslationValue>,
 }
 
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct VocabularyDatabase {
     vocabulary_map: HashMap<String, VocabularyInfo>,
 }
@@ -182,6 +183,36 @@ pub struct VocabularyChunkData {
 
 pub fn init_vocabulary(data: VocabularyChunkData) -> Result<(), OrigaError> {
     let db = VocabularyDatabase::from_chunks(data)?;
+    VOCABULARY_DICTIONARY
+        .set(db)
+        .map_err(|_| OrigaError::VocabularyParseError {
+            reason: "Failed to set vocabulary dictionary".to_string(),
+        })
+}
+
+/// Serialize the in-memory VocabularyDatabase to rkyv bytes for Cache API
+/// storage. On subsequent loads, `init_vocabulary_from_rkyv` skips JSON
+/// parsing entirely.
+pub fn serialize_vocabulary_to_rkyv() -> Result<Vec<u8>, OrigaError> {
+    let db = VOCABULARY_DICTIONARY
+        .get()
+        .ok_or(OrigaError::VocabularyParseError {
+            reason: "Vocabulary dictionary not loaded".to_string(),
+        })?;
+    rkyv::to_bytes::<rkyv::rancor::Error>(db)
+        .map_err(|e| OrigaError::VocabularyParseError {
+            reason: format!("Failed to serialize vocabulary: {}", e),
+        })
+        .map(|bytes| bytes.to_vec())
+}
+
+/// Initialize vocabulary from cached rkyv bytes (fast path).
+/// Skips JSON parsing of 11 chunks (~35 MB text).
+pub fn init_vocabulary_from_rkyv(bytes: &[u8]) -> Result<(), OrigaError> {
+    let db: VocabularyDatabase = rkyv::from_bytes::<VocabularyDatabase, rkyv::rancor::Error>(bytes)
+        .map_err(|e| OrigaError::VocabularyParseError {
+            reason: format!("Failed to deserialize vocabulary: {}", e),
+        })?;
     VOCABULARY_DICTIONARY
         .set(db)
         .map_err(|_| OrigaError::VocabularyParseError {
@@ -612,5 +643,46 @@ mod tests {
     fn split_semicolon_joined_translations_drops_empty_entries() {
         let out = split_semicolon_joined_translations(vec!["кошка".to_string(), "   ".to_string()]);
         assert_eq!(out, vec!["кошка"]);
+    }
+
+    #[test]
+    fn rkyv_vocabulary_round_trip() {
+        let data = empty_chunk_data_with(&make_structured_chunk_json());
+        let db = VocabularyDatabase::from_chunks(data).unwrap();
+
+        // Serialize directly (bypass OnceLock — serialize_vocabulary_to_rkyv
+        // requires a populated VOCABULARY_DICTIONARY which OnceLock prevents
+        // in tests).
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&db).expect("serialize should succeed");
+        assert!(!bytes.is_empty());
+
+        // Deserialize back.
+        let restored: VocabularyDatabase =
+            rkyv::from_bytes::<VocabularyDatabase, rkyv::rancor::Error>(&bytes).unwrap();
+
+        let ru = restored
+            .get_translations("猫", &NativeLanguage::Russian)
+            .unwrap();
+        assert_eq!(ru, vec!["кошка", "кот"]);
+        let en = restored
+            .get_translations("猫", &NativeLanguage::English)
+            .unwrap();
+        assert_eq!(en, vec!["cat"]);
+        let desc = restored.get_description("猫", &NativeLanguage::Russian);
+        assert_eq!(desc, Some("домашнее животное".to_string()));
+    }
+
+    #[test]
+    fn rkyv_vocabulary_round_trip_preserves_legacy_format() {
+        let data = empty_chunk_data_with(&make_valid_chunk_json());
+        let db = VocabularyDatabase::from_chunks(data).unwrap();
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&db).expect("serialize should succeed");
+
+        let restored: VocabularyDatabase =
+            rkyv::from_bytes::<VocabularyDatabase, rkyv::rancor::Error>(&bytes).unwrap();
+        let ru = restored
+            .get_translations("猫", &NativeLanguage::Russian)
+            .unwrap();
+        assert_eq!(ru, vec!["кошка", "кот"]);
     }
 }

--- a/origa/src/domain/mod.rs
+++ b/origa/src/domain/mod.rs
@@ -51,9 +51,10 @@ pub use score_content::ScoreContentResult;
 pub use srs::RateMode;
 pub use stats::{RatingRatio, TodayOverview, compute_rating_ratio, compute_today_overview};
 pub use tokenizer::{
-    DictionaryData, PartOfSpeech, TokenInfo, TokenTranslation, init_dictionary,
-    init_dictionary_from_rkyv, is_dictionary_loaded, lookup_tokens_translations,
-    serialize_dictionary_to_rkyv, tokenize_text,
+    CachedLinderaDictionary, DictionaryData, PartOfSpeech, TokenInfo, TokenTranslation,
+    build_cached_lindera, init_dictionary, init_tokenizer_from_cached,
+    init_tokenizer_from_rkyv_cached, is_dictionary_loaded, lookup_tokens_translations,
+    serialize_cached_lindera_to_rkyv, tokenize_text,
 };
 pub use user::{ONBOARDING_COMPLETED_KEY, ONBOARDING_SKIPPED_KEY, User, WordKnowledge};
 pub use value_objects::{CardAnswer, DailyLoad, JapaneseLevel, NativeLanguage, Question};

--- a/origa/src/domain/tokenizer/mod.rs
+++ b/origa/src/domain/tokenizer/mod.rs
@@ -56,9 +56,6 @@ impl TokenInfo {
     }
 }
 
-#[derive(
-    Clone, serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
-)]
 pub struct DictionaryData {
     pub char_def: Vec<u8>,
     pub matrix: Vec<u8>,
@@ -70,89 +67,174 @@ pub struct DictionaryData {
     pub metadata: Vec<u8>,
 }
 
-/// Convert DictionaryData to rkyv bytes for storage
-pub fn serialize_dictionary_to_rkyv(data: &DictionaryData) -> Result<Vec<u8>, OrigaError> {
-    let bytes =
-        rkyv::to_bytes::<rkyv::rancor::Error>(data).map_err(|e| OrigaError::TokenizerError {
-            reason: format!("Failed to serialize dictionary: {}", e),
-        })?;
-    Ok(bytes.to_vec())
+static TOKENIZER: OnceLock<lindera::tokenizer::Tokenizer> = OnceLock::new();
+
+/// Pre-built lindera dictionary components for rkyv serialization.
+///
+/// Instead of caching raw `DictionaryData` bytes (~204 MB of decompressed
+/// lindera-format files) and re-running `load()` on every cache hit, we cache
+/// the already-parsed lindera structures. This eliminates:
+/// - `ConnectionCostMatrix::load` CPU work (byte→i16 conversion + transpose)
+/// - `CharacterDefinition::load` rkyv deserialization
+/// - `UnknownDictionary::load` rkyv deserialization
+///
+/// `PrefixDictionary.da` still needs `DoubleArrayAhoCorasick::deserialize`
+/// at access time (the rkyv `DoubleArrayArchiver` stores raw bytes and
+/// reconstructs the automaton on deserialize), but this is unavoidable.
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct CachedLinderaDictionary {
+    pub connection_cost_matrix:
+        lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix,
+    pub character_definition:
+        lindera_dictionary::dictionary::character_definition::CharacterDefinition,
+    pub unknown_dictionary: lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary,
+    pub prefix_dictionary: lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary,
+    pub metadata: lindera_dictionary::dictionary::metadata::Metadata,
 }
 
-/// Initialize dictionary from rkyv bytes directly (zero-copy access)
-pub fn init_dictionary_from_rkyv(bytes: &[u8]) -> Result<(), OrigaError> {
-    let archived =
-        rkyv::access::<ArchivedDictionaryData, rkyv::rancor::Error>(bytes).map_err(|e| {
+/// Serialize a CachedLinderaDictionary to rkyv bytes for Cache API storage.
+pub fn serialize_cached_lindera_to_rkyv(
+    cached: &CachedLinderaDictionary,
+) -> Result<Vec<u8>, OrigaError> {
+    rkyv::to_bytes::<rkyv::rancor::Error>(cached)
+        .map_err(|e| OrigaError::TokenizerError {
+            reason: format!("Failed to serialize cached lindera dictionary: {}", e),
+        })
+        .map(|bytes| bytes.to_vec())
+}
+
+/// Build `CachedLinderaDictionary` from raw `DictionaryData` (consumed).
+///
+/// Runs lindera `load()` on each component to produce the final structures.
+/// DictionaryData fields are moved into lindera (via `impl Into<Data>`) or
+/// borrowed temporarily (for `&[u8]` loads) — no ~204 MB clone.
+pub fn build_cached_lindera(data: DictionaryData) -> Result<CachedLinderaDictionary, OrigaError> {
+    let DictionaryData {
+        char_def,
+        matrix,
+        dict_da,
+        dict_vals,
+        unk,
+        words_idx,
+        words,
+        metadata,
+    } = data;
+
+    let metadata =
+        lindera_dictionary::dictionary::metadata::Metadata::load(&metadata).map_err(|e| {
             OrigaError::TokenizerError {
-                reason: format!("Failed to validate dictionary data: {:?}", e),
+                reason: format!("Failed to load metadata: {}", e),
             }
         })?;
 
-    let data = DictionaryData {
-        char_def: archived.char_def.to_vec(),
-        matrix: archived.matrix.to_vec(),
-        dict_da: archived.dict_da.to_vec(),
-        dict_vals: archived.dict_vals.to_vec(),
-        unk: archived.unk.to_vec(),
-        words_idx: archived.words_idx.to_vec(),
-        words: archived.words.to_vec(),
-        metadata: archived.metadata.to_vec(),
-    };
+    let prefix_dictionary =
+        lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary::load(
+            dict_da, dict_vals, words_idx, words, true,
+        );
 
-    init_dictionary(data)
+    let connection_cost_matrix =
+        lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix::load(matrix);
+
+    let character_definition =
+        lindera_dictionary::dictionary::character_definition::CharacterDefinition::load(&char_def)
+            .map_err(|e| OrigaError::TokenizerError {
+                reason: format!("Failed to load character definition: {}", e),
+            })?;
+
+    let unknown_dictionary =
+        lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary::load(&unk).map_err(
+            |e| OrigaError::TokenizerError {
+                reason: format!("Failed to load unknown dictionary: {}", e),
+            },
+        )?;
+
+    Ok(CachedLinderaDictionary {
+        connection_cost_matrix,
+        character_definition,
+        unknown_dictionary,
+        prefix_dictionary,
+        metadata,
+    })
 }
 
-static DICTIONARY_DATA: OnceLock<DictionaryData> = OnceLock::new();
-static TOKENIZER: OnceLock<lindera::tokenizer::Tokenizer> = OnceLock::new();
+/// Build a lindera `Tokenizer` from cached rkyv bytes (fast path).
+///
+/// Skips all `load()` calls — the structures are already deserialized.
+/// Only `DoubleArrayAhoCorasick::deserialize` runs for PrefixDictionary.da.
+pub fn init_tokenizer_from_rkyv_cached(bytes: &[u8]) -> Result<(), OrigaError> {
+    let cached: CachedLinderaDictionary =
+        rkyv::from_bytes::<CachedLinderaDictionary, rkyv::rancor::Error>(bytes).map_err(|e| {
+            OrigaError::TokenizerError {
+                reason: format!("Failed to deserialize cached lindera dictionary: {}", e),
+            }
+        })?;
+
+    init_tokenizer_from_cached(cached)
+}
+
+/// Build a `Tokenizer` from already-constructed `CachedLinderaDictionary`
+/// components (cache hit or freshly built from DictionaryData).
+pub fn init_tokenizer_from_cached(cached: CachedLinderaDictionary) -> Result<(), OrigaError> {
+    let dictionary = lindera_dictionary::dictionary::Dictionary {
+        prefix_dictionary: cached.prefix_dictionary,
+        connection_cost_matrix: cached.connection_cost_matrix,
+        character_definition: cached.character_definition,
+        unknown_dictionary: cached.unknown_dictionary,
+        metadata: cached.metadata,
+    };
+
+    init_tokenizer_from_dictionary(dictionary)
+}
 
 pub fn is_dictionary_loaded() -> bool {
     TOKENIZER.get().is_some()
 }
 
 pub fn init_dictionary(data: DictionaryData) -> Result<(), OrigaError> {
-    let _ = DICTIONARY_DATA.get_or_init(|| data);
-    init_tokenizer()
+    init_tokenizer(data)
 }
 
 const USER_DICT_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/user_dictionary.bin"));
 
-fn init_tokenizer() -> Result<(), OrigaError> {
-    let data = DICTIONARY_DATA.get().ok_or(OrigaError::TokenizerError {
-        reason: "Dictionary data not loaded".to_string(),
-    })?;
+fn init_tokenizer(data: DictionaryData) -> Result<(), OrigaError> {
+    let DictionaryData {
+        char_def,
+        matrix,
+        dict_da,
+        dict_vals,
+        unk,
+        words_idx,
+        words,
+        metadata,
+    } = data;
 
-    let metadata = lindera_dictionary::dictionary::metadata::Metadata::load(&data.metadata)
-        .map_err(|e| OrigaError::TokenizerError {
-            reason: format!("Failed to load metadata: {}", e),
+    let metadata =
+        lindera_dictionary::dictionary::metadata::Metadata::load(&metadata).map_err(|e| {
+            OrigaError::TokenizerError {
+                reason: format!("Failed to load metadata: {}", e),
+            }
         })?;
 
     let prefix_dictionary =
         lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary::load(
-            data.dict_da.clone(),
-            data.dict_vals.clone(),
-            data.words_idx.clone(),
-            data.words.clone(),
-            true,
+            dict_da, dict_vals, words_idx, words, true,
         );
 
     let connection_cost_matrix =
-        lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix::load(
-            data.matrix.clone(),
-        );
+        lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix::load(matrix);
 
     let character_definition =
-        lindera_dictionary::dictionary::character_definition::CharacterDefinition::load(
-            &data.char_def,
-        )
-        .map_err(|e| OrigaError::TokenizerError {
-            reason: format!("Failed to load character definition: {}", e),
-        })?;
+        lindera_dictionary::dictionary::character_definition::CharacterDefinition::load(&char_def)
+            .map_err(|e| OrigaError::TokenizerError {
+                reason: format!("Failed to load character definition: {}", e),
+            })?;
 
     let unknown_dictionary =
-        lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary::load(&data.unk)
-            .map_err(|e| OrigaError::TokenizerError {
+        lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary::load(&unk).map_err(
+            |e| OrigaError::TokenizerError {
                 reason: format!("Failed to load unknown dictionary: {}", e),
-            })?;
+            },
+        )?;
 
     let dictionary = lindera_dictionary::dictionary::Dictionary {
         prefix_dictionary,
@@ -162,6 +244,12 @@ fn init_tokenizer() -> Result<(), OrigaError> {
         metadata,
     };
 
+    init_tokenizer_from_dictionary(dictionary)
+}
+
+fn init_tokenizer_from_dictionary(
+    dictionary: lindera_dictionary::dictionary::Dictionary,
+) -> Result<(), OrigaError> {
     let user_dictionary = if USER_DICT_BYTES.is_empty() {
         None
     } else {
@@ -493,6 +581,48 @@ mod tests {
             let data = create_test_dictionary_data();
             let _ = init_dictionary(data);
         }
+    }
+
+    #[test]
+    fn rkyv_cached_lindera_round_trip() {
+        // Build CachedLinderaDictionary from real dictionary data.
+        let data = create_test_dictionary_data();
+        let cached = build_cached_lindera(data).expect("build_cached_lindera should succeed");
+
+        // Serialize to rkyv.
+        let bytes = serialize_cached_lindera_to_rkyv(&cached)
+            .expect("serialize_cached_lindera_to_rkyv should succeed");
+        assert!(!bytes.is_empty());
+
+        // Deserialize back.
+        let restored: CachedLinderaDictionary =
+            rkyv::from_bytes::<CachedLinderaDictionary, rkyv::rancor::Error>(&bytes)
+                .expect("rkyv from_bytes should succeed");
+
+        // Verify ConnectionCostMatrix survived round-trip.
+        assert_eq!(
+            restored.connection_cost_matrix.forward_size,
+            cached.connection_cost_matrix.forward_size,
+        );
+        assert_eq!(
+            restored.connection_cost_matrix.backward_size,
+            cached.connection_cost_matrix.backward_size,
+        );
+        assert_eq!(
+            restored.connection_cost_matrix.costs_data.len(),
+            cached.connection_cost_matrix.costs_data.len(),
+        );
+
+        // Verify Metadata survived.
+        assert_eq!(restored.metadata.name, cached.metadata.name);
+    }
+
+    #[test]
+    fn rkyv_cached_lindera_invalid_bytes_returns_error() {
+        let garbage = b"definitely not rkyv data";
+        let result: Result<CachedLinderaDictionary, rkyv::rancor::Error> =
+            rkyv::from_bytes(garbage);
+        assert!(result.is_err());
     }
 
     fn create_test_dictionary_data() -> DictionaryData {

--- a/origa_ui/build.rs
+++ b/origa_ui/build.rs
@@ -127,6 +127,7 @@ fn handle_lindera_dictionary() {
     let fetch_params = lindera_dictionary::assets::FetchParams {
         file_name: "unidic-mecab-2.1.2.tar.gz",
         input_dir: "unidic-mecab-2.1.2",
+        src_subdir: None,
         output_dir: "lindera-unidic",
         dummy_input: "テスト,5131,5131,767,名詞,普通名詞,サ変可能,*,*,*,テスト,テスト-test,テスト,テスト,テスト,テスト,外,*,*,*,*\n",
         download_urls: &["https://Lindera.dev/unidic-mecab-2.1.2.tar.gz"],

--- a/origa_ui/src/core/config.rs
+++ b/origa_ui/src/core/config.rs
@@ -1,23 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
-pub struct Urls {
-    pub base: &'static str,
-    pub dictionary: &'static str,
-}
-
-static URLS: OnceLock<Urls> = OnceLock::new();
-
-pub fn urls() -> &'static Urls {
-    URLS.get_or_init(|| {
-        let base = env!("ORIGA_PUBLIC_BASE_URL");
-        Urls {
-            base,
-            dictionary: "dictionaries/unidic/cache/dictionary-data",
-        }
-    })
-}
-
 pub fn public_url(path: &str) -> String {
     if !path.starts_with('/') {
         tracing::warn!(
@@ -26,7 +9,7 @@ pub fn public_url(path: &str) -> String {
         );
     }
 
-    let base = urls().base;
+    let base = option_env!("ORIGA_PUBLIC_BASE_URL").unwrap_or("");
     if base.is_empty() {
         path.to_string()
     } else {

--- a/origa_ui/src/loaders/data_loader.rs
+++ b/origa_ui/src/loaders/data_loader.rs
@@ -1,11 +1,15 @@
 use origa::dictionary::grammar::{GrammarData, init_grammar, is_grammar_loaded};
 use origa::dictionary::kanji::{KanjiData, init_kanji, is_kanji_loaded};
 use origa::dictionary::radical::{RadicalData, init_radicals, is_radicals_loaded};
-use origa::dictionary::vocabulary::{VocabularyChunkData, init_vocabulary, is_vocabulary_loaded};
+use origa::dictionary::vocabulary::{
+    VocabularyChunkData, init_vocabulary, init_vocabulary_from_rkyv, is_vocabulary_loaded,
+    serialize_vocabulary_to_rkyv,
+};
 use origa::domain::OrigaError;
 use origa::traits::CdnProvider;
 
 use crate::repository::cdn_provider;
+use crate::repository::{get_cached_vocabulary_rkyv, save_vocabulary_to_cache_rkyv};
 use crate::utils::{now_ms, yield_to_browser};
 
 pub async fn load_vocabulary() -> Result<(), OrigaError> {
@@ -17,6 +21,39 @@ pub async fn load_vocabulary() -> Result<(), OrigaError> {
     let start = now_ms();
     tracing::info!("📖 Loading vocabulary...");
 
+    // Fast path: try loading from rkyv cache (pre-parsed VocabularyDatabase).
+    match get_cached_vocabulary_rkyv().await {
+        Ok(Some(bytes)) => {
+            tracing::info!("📖 Cached vocabulary found, {} bytes", bytes.len());
+            yield_to_browser().await;
+            match init_vocabulary_from_rkyv(&bytes) {
+                Ok(()) => {
+                    tracing::info!(
+                        "📖 Vocabulary loaded from rkyv cache ({:.2}s)",
+                        (now_ms() - start) / 1000.0
+                    );
+                    return Ok(());
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        error = ?e,
+                        "Failed to load vocabulary from rkyv cache, falling back to network"
+                    );
+                },
+            }
+        },
+        Ok(None) => {
+            tracing::debug!("📖 No rkyv vocabulary cache found, loading from network");
+        },
+        Err(e) => {
+            tracing::warn!(
+                "Vocabulary cache read failed, loading from network: {:?}",
+                e
+            );
+        },
+    }
+
+    // Slow path: fetch JSON chunks from CDN and parse.
     let cdn = cdn_provider();
 
     // Batched fetch: 11 JSON chunks (~35 MB total). Fetching all 11 at once
@@ -57,6 +94,25 @@ pub async fn load_vocabulary() -> Result<(), OrigaError> {
 
     yield_to_browser().await;
     init_vocabulary(data)?;
+
+    // Cache the parsed VocabularyDatabase for future fast-path loads.
+    let cache_start = now_ms();
+    match serialize_vocabulary_to_rkyv() {
+        Ok(bytes) => {
+            if let Err(e) = save_vocabulary_to_cache_rkyv(&bytes).await {
+                tracing::warn!("Failed to cache vocabulary (rkyv): {:?}", e);
+            } else {
+                tracing::info!(
+                    "📖 Vocabulary cached (rkyv, {} bytes, {:.2}s)",
+                    bytes.len(),
+                    (now_ms() - cache_start) / 1000.0
+                );
+            }
+        },
+        Err(e) => {
+            tracing::warn!("Failed to serialize vocabulary for caching: {:?}", e);
+        },
+    }
 
     tracing::info!("📖 Vocabulary loaded ({:.2}s)", (now_ms() - start) / 1000.0);
     Ok(())

--- a/origa_ui/src/loaders/dictionary.rs
+++ b/origa_ui/src/loaders/dictionary.rs
@@ -1,8 +1,9 @@
-use crate::repository::{cdn_provider, get_cached_dictionary_rkyv, save_dictionary_to_cache_rkyv};
+use crate::repository::{cdn_provider, get_cached_lindera_rkyv, save_lindera_to_cache_rkyv};
 use crate::utils::{now_ms, yield_to_browser};
 use flate2::read::DeflateDecoder;
 use origa::domain::{
-    DictionaryData, OrigaError, init_dictionary, init_dictionary_from_rkyv, is_dictionary_loaded,
+    DictionaryData, OrigaError, init_tokenizer_from_rkyv_cached, is_dictionary_loaded,
+    serialize_cached_lindera_to_rkyv,
 };
 use origa::traits::CdnProvider;
 use std::io::Read;
@@ -26,39 +27,70 @@ pub async fn load_dictionary() -> Result<(), OrigaError> {
     let start = now_ms();
     tracing::info!("📖 Loading Unidic dictionary...");
 
-    match get_cached_dictionary_rkyv().await {
+    // Fast path: try loading from cached lindera structures (pre-built
+    // lindera Dictionary components serialized via rkyv). This skips
+    // all lindera load() calls on cache hit.
+    match get_cached_lindera_rkyv().await {
         Ok(Some(bytes)) => {
-            tracing::info!("📖 Dictionary found in cache (rkyv), {} bytes", bytes.len());
+            tracing::info!("📖 Cached lindera structures found, {} bytes", bytes.len());
             yield_to_browser().await;
-            init_dictionary_from_rkyv(&bytes)?;
-            tracing::info!(
-                "📖 Dictionary loaded from rkyv cache ({:.2}s)",
-                (now_ms() - start) / 1000.0
-            );
-            return Ok(());
+            match init_tokenizer_from_rkyv_cached(&bytes) {
+                Ok(()) => {
+                    tracing::info!(
+                        "📖 Dictionary loaded from cached lindera structures ({:.2}s)",
+                        (now_ms() - start) / 1000.0
+                    );
+                    return Ok(());
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        error = ?e,
+                        "Failed to load from cached lindera structures, falling back to network"
+                    );
+                },
+            }
         },
         Ok(None) => {
-            tracing::debug!("📖 No rkyv cache found, loading from network");
+            tracing::debug!("📖 No cached lindera structures found, loading from network");
         },
         Err(e) => {
             tracing::warn!("Cache read failed, loading from network: {:?}", e);
         },
     }
 
+    // Slow path (cache miss): fetch from CDN, decompress, build lindera
+    // structures, then serialize them for future cache hits.
     let data = load_dictionary_from_network().await?;
-    let data_clone = data.clone();
     yield_to_browser().await;
-    init_dictionary(data)?;
 
+    // Build lindera structures — DictionaryData is consumed (moved into
+    // lindera load() calls), no ~204 MB clone.
+    let cached = origa::domain::build_cached_lindera(data)?;
+    yield_to_browser().await;
+
+    // Serialize for future cache hits BEFORE moving into the tokenizer.
     let cache_start = now_ms();
-    if let Err(e) = save_dictionary_to_cache_rkyv(&data_clone).await {
-        tracing::warn!("Failed to cache dictionary: {:?}", e);
-    } else {
-        tracing::info!(
-            "📖 Dictionary cached (rkyv) ({:.2}s)",
-            (now_ms() - cache_start) / 1000.0
-        );
+    match serialize_cached_lindera_to_rkyv(&cached) {
+        Ok(bytes) => {
+            tracing::info!(
+                "📖 Cached lindera structures serialized ({} bytes, {:.2}s)",
+                bytes.len(),
+                (now_ms() - cache_start) / 1000.0
+            );
+            if let Err(e) = save_lindera_to_cache_rkyv(&bytes).await {
+                tracing::warn!("Failed to cache lindera structures: {:?}", e);
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                "Failed to serialize lindera structures for caching: {:?}",
+                e
+            );
+        },
     }
+
+    // Now move the structures into the static Tokenizer.
+    origa::domain::init_tokenizer_from_cached(cached)?;
 
     tracing::info!(
         "📖 Dictionary loaded from network ({:.2}s)",

--- a/origa_ui/src/repository/cache_manager.rs
+++ b/origa_ui/src/repository/cache_manager.rs
@@ -11,7 +11,7 @@ use wasm_bindgen_futures::JsFuture;
 #[cfg(target_arch = "wasm32")]
 use super::cdn_provider::{CDN_CACHE_NAME, cdn_cache_url};
 #[cfg(target_arch = "wasm32")]
-use super::dictionary_cache::RKYV_CACHE_NAME;
+use super::dictionary_cache::{LINDERA_CACHE_NAME, RKYV_CACHE_NAME, VOCABULARY_CACHE_NAME};
 #[cfg(target_arch = "wasm32")]
 const MANIFEST_CACHE_KEY: &str = "__origa_cache_manifest__";
 
@@ -50,6 +50,16 @@ pub async fn check_and_invalidate() -> Result<(), OrigaError> {
             if let Err(e) = invalidate_rkyv_dictionary().await {
                 tracing::warn!(error = ?e, "Failed to invalidate rkyv dictionary cache");
             }
+            if let Err(e) = invalidate_cached_lindera().await {
+                tracing::warn!(error = ?e, "Failed to invalidate cached lindera structures");
+            }
+        }
+
+        let has_vocab = all_paths.iter().any(|p| p.starts_with("dictionary/chunk_"));
+        if has_vocab {
+            if let Err(e) = invalidate_cached_vocabulary().await {
+                tracing::warn!(error = ?e, "Failed to invalidate cached vocabulary");
+            }
         }
 
         save_local_manifest(&cache, &remote).await?;
@@ -74,6 +84,16 @@ pub async fn check_and_invalidate() -> Result<(), OrigaError> {
     if has_dict_stale {
         if let Err(e) = invalidate_rkyv_dictionary().await {
             tracing::warn!(error = ?e, "Failed to invalidate rkyv dictionary cache");
+        }
+        if let Err(e) = invalidate_cached_lindera().await {
+            tracing::warn!(error = ?e, "Failed to invalidate cached lindera structures");
+        }
+    }
+
+    let has_vocab_stale = stale.iter().any(|p| p.starts_with("dictionary/chunk_"));
+    if has_vocab_stale {
+        if let Err(e) = invalidate_cached_vocabulary().await {
+            tracing::warn!(error = ?e, "Failed to invalidate cached vocabulary");
         }
     }
 
@@ -247,7 +267,9 @@ async fn invalidate_rkyv_dictionary() -> Result<(), OrigaError> {
         reason: format!("Failed to cast Cache: {:?}", e),
     })?;
 
-    let dict_key = crate::core::config::urls().dictionary;
+    // Legacy cache key from the pre-built-lindera era. Hardcoded for
+    // invalidation only — no new entries are written under this key.
+    let dict_key = "dictionaries/unidic/cache/dictionary-data";
 
     JsFuture::from(cache.delete_with_str(&cdn_cache_url(dict_key)))
         .await
@@ -256,6 +278,75 @@ async fn invalidate_rkyv_dictionary() -> Result<(), OrigaError> {
         })?;
 
     tracing::info!("Invalidated rkyv dictionary cache");
+    Ok(())
+}
+
+/// Invalidate the CachedLinderaDictionary entry so the next load fetches
+/// fresh dictionary files from CDN and rebuilds the lindera structures.
+#[cfg(target_arch = "wasm32")]
+async fn invalidate_cached_lindera() -> Result<(), OrigaError> {
+    let window = web_sys::window().ok_or_else(|| OrigaError::RepositoryError {
+        reason: "No window found".to_string(),
+    })?;
+
+    let caches = window.caches().map_err(|e| OrigaError::RepositoryError {
+        reason: format!("Cache API not available: {:?}", e),
+    })?;
+
+    let cache = JsFuture::from(caches.open(LINDERA_CACHE_NAME))
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to open lindera cache: {:?}", e),
+        })?;
+
+    let cache: web_sys::Cache = cache.dyn_into().map_err(|e| OrigaError::RepositoryError {
+        reason: format!("Failed to cast Cache: {:?}", e),
+    })?;
+
+    // Delete all entries in the lindera cache (there's only one key,
+    // but delete_with_str on the cache key is sufficient).
+    let cache_key = super::cdn_provider::cdn_cache_url(super::dictionary_cache::LINDERA_CACHE_KEY);
+    JsFuture::from(cache.delete_with_str(&cache_key))
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to delete lindera cache: {:?}", e),
+        })?;
+
+    tracing::info!("Invalidated cached lindera structures");
+    Ok(())
+}
+
+/// Invalidate the cached VocabularyDatabase entry so the next load fetches
+/// fresh JSON chunks from CDN and re-parses.
+#[cfg(target_arch = "wasm32")]
+async fn invalidate_cached_vocabulary() -> Result<(), OrigaError> {
+    let window = web_sys::window().ok_or_else(|| OrigaError::RepositoryError {
+        reason: "No window found".to_string(),
+    })?;
+
+    let caches = window.caches().map_err(|e| OrigaError::RepositoryError {
+        reason: format!("Cache API not available: {:?}", e),
+    })?;
+
+    let cache = JsFuture::from(caches.open(VOCABULARY_CACHE_NAME))
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to open vocabulary cache: {:?}", e),
+        })?;
+
+    let cache: web_sys::Cache = cache.dyn_into().map_err(|e| OrigaError::RepositoryError {
+        reason: format!("Failed to cast Cache: {:?}", e),
+    })?;
+
+    let cache_key =
+        super::cdn_provider::cdn_cache_url(super::dictionary_cache::VOCABULARY_CACHE_KEY);
+    JsFuture::from(cache.delete_with_str(&cache_key))
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to delete vocabulary cache: {:?}", e),
+        })?;
+
+    tracing::info!("Invalidated cached vocabulary");
     Ok(())
 }
 

--- a/origa_ui/src/repository/dictionary_cache.rs
+++ b/origa_ui/src/repository/dictionary_cache.rs
@@ -1,61 +1,45 @@
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
-use origa::domain::{DictionaryData, OrigaError};
+use origa::domain::OrigaError;
 
 use super::cdn_provider::cdn_cache_url;
-use crate::core::config::urls;
-
-pub const RKYV_CACHE_NAME: &str = "origa-dictionary-rkyv-v2";
-
-async fn open_cache() -> Result<web_sys::Cache, OrigaError> {
-    let window = web_sys::window().ok_or_else(|| OrigaError::RepositoryError {
-        reason: "No window found".to_string(),
-    })?;
-
-    let caches = js_sys::Reflect::get(&window, &wasm_bindgen::JsValue::from_str("caches"))
-        .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Cache API not available: {:?}", e),
-        })?;
-
-    let caches: web_sys::CacheStorage =
-        caches.dyn_into().map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to cast CacheStorage: {:?}", e),
-        })?;
-
-    let cache_promise = caches.open(RKYV_CACHE_NAME);
-    let cache: web_sys::Cache = JsFuture::from(cache_promise)
-        .await
-        .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to open cache: {:?}", e),
-        })?
-        .into();
-
-    Ok(cache)
-}
-
 use crate::utils::now_ms;
 
-/// Get cached dictionary as raw rkyv bytes
-pub async fn get_cached_dictionary_rkyv() -> Result<Option<Vec<u8>>, OrigaError> {
+/// Legacy cache name for raw DictionaryData rkyv (pre-built lindera era).
+/// Kept for invalidation only — no new entries are written here.
+#[cfg(target_arch = "wasm32")]
+pub const RKYV_CACHE_NAME: &str = "origa-dictionary-rkyv-v2";
+
+/// Cache name for pre-built lindera structures (CachedLinderaDictionary).
+/// Separate from RKYV_CACHE_NAME (which stores raw DictionaryData) so old
+/// entries don't interfere.
+pub const LINDERA_CACHE_NAME: &str = "origa-dictionary-lindera-v1";
+
+/// Cache name for pre-parsed VocabularyDatabase (rkyv).
+pub const VOCABULARY_CACHE_NAME: &str = "origa-vocabulary-rkyv-v1";
+
+/// Cache key for CachedLinderaDictionary blob.
+pub const LINDERA_CACHE_KEY: &str = "/__origa_lindera_cached__";
+
+/// Cache key for VocabularyDatabase rkyv blob.
+pub const VOCABULARY_CACHE_KEY: &str = "/__origa_vocabulary_cached__";
+
+/// Get cached lindera structures as raw rkyv bytes.
+///
+/// Uses a separate cache (`LINDERA_CACHE_NAME`) from the raw dictionary
+/// cache (`RKYV_CACHE_NAME`).
+pub async fn get_cached_lindera_rkyv() -> Result<Option<Vec<u8>>, OrigaError> {
     let start = now_ms();
-    let cache = open_cache().await?;
-    tracing::debug!("Cache opened ({:.2}s)", (now_ms() - start) / 1000.0);
+    let cache = open_lindera_cache().await?;
 
-    let url = urls().dictionary;
-
-    let match_start = now_ms();
-    let match_promise = cache.match_with_str(&cdn_cache_url(url));
+    let match_promise = cache.match_with_str(&cdn_cache_url(LINDERA_CACHE_KEY));
     let response_option =
         JsFuture::from(match_promise)
             .await
             .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to check cache: {:?}", e),
+                reason: format!("Failed to check lindera cache: {:?}", e),
             })?;
-    tracing::debug!(
-        "Cache match checked ({:.2}s)",
-        (now_ms() - match_start) / 1000.0
-    );
 
     if response_option.is_undefined() || response_option.is_null() {
         return Ok(None);
@@ -65,64 +49,45 @@ pub async fn get_cached_dictionary_rkyv() -> Result<Option<Vec<u8>>, OrigaError>
         response_option
             .dyn_into()
             .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to cast Response: {:?}", e),
+                reason: format!("Failed to cast lindera cache response: {:?}", e),
             })?;
 
     if !response.ok() {
         return Ok(None);
     }
 
-    let _read_start = now_ms();
     let array_buffer_promise =
         response
             .array_buffer()
             .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to get array buffer: {:?}", e),
+                reason: format!("Failed to get array_buffer promise: {:?}", e),
             })?;
 
     let array_buffer =
         JsFuture::from(array_buffer_promise)
             .await
             .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to read array buffer: {:?}", e),
+                reason: format!("Failed to read lindera cache: {:?}", e),
             })?;
 
     let uint8_array = js_sys::Uint8Array::new(&array_buffer);
     let bytes = uint8_array.to_vec();
     tracing::info!(
-        "Cache loaded: {} ({} bytes, {:.2}s)",
-        url,
+        "Lindera cache loaded: {} bytes ({:.2}s)",
         bytes.len(),
         (now_ms() - start) / 1000.0
     );
     Ok(Some(bytes))
 }
 
-/// Save dictionary as rkyv bytes to cache
-pub async fn save_dictionary_to_cache_rkyv(data: &DictionaryData) -> Result<(), OrigaError> {
+/// Save pre-built lindera structures (rkyv bytes) to the Cache API.
+pub async fn save_lindera_to_cache_rkyv(bytes: &[u8]) -> Result<(), OrigaError> {
     let start = now_ms();
-
-    let serialize_start = now_ms();
-    let bytes = origa::domain::serialize_dictionary_to_rkyv(data).map_err(|e| {
-        OrigaError::RepositoryError {
-            reason: format!("Failed to serialize dictionary: {:?}", e),
-        }
-    })?;
-    tracing::info!(
-        "Dictionary serialized rkyv ({} bytes, {:.2}s)",
-        bytes.len(),
-        (now_ms() - serialize_start) / 1000.0
-    );
-
-    let cache = open_cache().await?;
-    tracing::debug!(
-        "Cache opened for save ({:.2}s)",
-        (now_ms() - start) / 1000.0
-    );
+    let cache = open_lindera_cache().await?;
 
     let array_buffer = js_sys::ArrayBuffer::new(bytes.len() as u32);
     let view = js_sys::Uint8Array::new(&array_buffer);
-    view.copy_from(&bytes);
+    view.copy_from(bytes);
 
     let response_init = web_sys::ResponseInit::new();
     response_init.set_status(200);
@@ -137,28 +102,164 @@ pub async fn save_dictionary_to_cache_rkyv(data: &DictionaryData) -> Result<(), 
     let blob =
         web_sys::Blob::new_with_buffer_source_sequence_and_options(&blob_parts, &blob_property_bag)
             .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to create blob: {:?}", e),
+                reason: format!("Failed to create lindera cache blob: {:?}", e),
             })?;
 
     let response = web_sys::Response::new_with_opt_blob_and_init(Some(&blob), &response_init)
         .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to create response: {:?}", e),
+            reason: format!("Failed to create lindera cache response: {:?}", e),
         })?;
 
-    let url = urls().dictionary;
-    let put_start = now_ms();
-    let put_promise = cache.put_with_str(&cdn_cache_url(url), &response);
+    let put_promise = cache.put_with_str(&cdn_cache_url(LINDERA_CACHE_KEY), &response);
     JsFuture::from(put_promise)
         .await
         .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to save to cache: {:?}", e),
+            reason: format!("Failed to save lindera cache: {:?}", e),
         })?;
     tracing::info!(
-        "Cache saved: {} (put {:.2}s, total {:.2}s)",
-        url,
-        (now_ms() - put_start) / 1000.0,
+        "Lindera cache saved: {} bytes ({:.2}s)",
+        bytes.len(),
         (now_ms() - start) / 1000.0
     );
 
     Ok(())
+}
+
+async fn open_lindera_cache() -> Result<web_sys::Cache, OrigaError> {
+    let window = web_sys::window().ok_or_else(|| OrigaError::RepositoryError {
+        reason: "No window found".to_string(),
+    })?;
+
+    let caches = js_sys::Reflect::get(&window, &wasm_bindgen::JsValue::from_str("caches"))
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Cache API not available: {:?}", e),
+        })?;
+
+    let caches: web_sys::CacheStorage =
+        caches.dyn_into().map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to cast CacheStorage: {:?}", e),
+        })?;
+
+    let cache_promise = caches.open(LINDERA_CACHE_NAME);
+    let cache = open_cache_from_promise(cache_promise).await?;
+
+    Ok(cache)
+}
+
+/// Get cached VocabularyDatabase as raw rkyv bytes.
+pub async fn get_cached_vocabulary_rkyv() -> Result<Option<Vec<u8>>, OrigaError> {
+    let cache = open_vocabulary_cache().await?;
+
+    let match_promise = cache.match_with_str(&cdn_cache_url(VOCABULARY_CACHE_KEY));
+    let response_option =
+        JsFuture::from(match_promise)
+            .await
+            .map_err(|e| OrigaError::RepositoryError {
+                reason: format!("Failed to check vocabulary cache: {:?}", e),
+            })?;
+
+    if response_option.is_undefined() || response_option.is_null() {
+        return Ok(None);
+    }
+
+    let response: web_sys::Response =
+        response_option
+            .dyn_into()
+            .map_err(|e| OrigaError::RepositoryError {
+                reason: format!("Failed to cast vocabulary cache response: {:?}", e),
+            })?;
+
+    if !response.ok() {
+        return Ok(None);
+    }
+
+    let array_buffer_promise =
+        response
+            .array_buffer()
+            .map_err(|e| OrigaError::RepositoryError {
+                reason: format!("Failed to get array_buffer promise: {:?}", e),
+            })?;
+
+    let array_buffer =
+        JsFuture::from(array_buffer_promise)
+            .await
+            .map_err(|e| OrigaError::RepositoryError {
+                reason: format!("Failed to read vocabulary cache: {:?}", e),
+            })?;
+
+    let uint8_array = js_sys::Uint8Array::new(&array_buffer);
+    let bytes = uint8_array.to_vec();
+    tracing::debug!("Vocabulary cache loaded: {} bytes", bytes.len());
+    Ok(Some(bytes))
+}
+
+/// Save pre-parsed VocabularyDatabase (rkyv bytes) to the Cache API.
+pub async fn save_vocabulary_to_cache_rkyv(bytes: &[u8]) -> Result<(), OrigaError> {
+    let cache = open_vocabulary_cache().await?;
+
+    let array_buffer = js_sys::ArrayBuffer::new(bytes.len() as u32);
+    let view = js_sys::Uint8Array::new(&array_buffer);
+    view.copy_from(bytes);
+
+    let response_init = web_sys::ResponseInit::new();
+    response_init.set_status(200);
+    response_init.set_status_text("OK");
+
+    let blob_property_bag = web_sys::BlobPropertyBag::new();
+    blob_property_bag.set_type("application/octet-stream");
+
+    let blob_parts = js_sys::Array::new();
+    blob_parts.push(&array_buffer);
+
+    let blob =
+        web_sys::Blob::new_with_buffer_source_sequence_and_options(&blob_parts, &blob_property_bag)
+            .map_err(|e| OrigaError::RepositoryError {
+                reason: format!("Failed to create vocabulary cache blob: {:?}", e),
+            })?;
+
+    let response = web_sys::Response::new_with_opt_blob_and_init(Some(&blob), &response_init)
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to create vocabulary cache response: {:?}", e),
+        })?;
+
+    let put_promise = cache.put_with_str(&cdn_cache_url(VOCABULARY_CACHE_KEY), &response);
+    JsFuture::from(put_promise)
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to save vocabulary cache: {:?}", e),
+        })?;
+
+    Ok(())
+}
+
+async fn open_vocabulary_cache() -> Result<web_sys::Cache, OrigaError> {
+    let window = web_sys::window().ok_or_else(|| OrigaError::RepositoryError {
+        reason: "No window found".to_string(),
+    })?;
+
+    let caches = js_sys::Reflect::get(&window, &wasm_bindgen::JsValue::from_str("caches"))
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Cache API not available: {:?}", e),
+        })?;
+
+    let caches: web_sys::CacheStorage =
+        caches.dyn_into().map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to cast CacheStorage: {:?}", e),
+        })?;
+
+    let cache_promise = caches.open(VOCABULARY_CACHE_NAME);
+    let cache = open_cache_from_promise(cache_promise).await?;
+
+    Ok(cache)
+}
+
+/// Shared helper: await a `caches.open()` promise and cast to `web_sys::Cache`.
+async fn open_cache_from_promise(promise: js_sys::Promise) -> Result<web_sys::Cache, OrigaError> {
+    let cache = JsFuture::from(promise)
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to open cache: {:?}", e),
+        })?
+        .into();
+    Ok(cache)
 }

--- a/origa_ui/src/repository/dictionary_cache.rs
+++ b/origa_ui/src/repository/dictionary_cache.rs
@@ -12,8 +12,6 @@ use crate::utils::now_ms;
 pub const RKYV_CACHE_NAME: &str = "origa-dictionary-rkyv-v2";
 
 /// Cache name for pre-built lindera structures (CachedLinderaDictionary).
-/// Separate from RKYV_CACHE_NAME (which stores raw DictionaryData) so old
-/// entries don't interfere.
 pub const LINDERA_CACHE_NAME: &str = "origa-dictionary-lindera-v1";
 
 /// Cache name for pre-parsed VocabularyDatabase (rkyv).
@@ -25,138 +23,63 @@ pub const LINDERA_CACHE_KEY: &str = "/__origa_lindera_cached__";
 /// Cache key for VocabularyDatabase rkyv blob.
 pub const VOCABULARY_CACHE_KEY: &str = "/__origa_vocabulary_cached__";
 
+// ---------------------------------------------------------------------------
+// Public API — thin wrappers over the shared get/save helpers.
+// ---------------------------------------------------------------------------
+
 /// Get cached lindera structures as raw rkyv bytes.
-///
-/// Uses a separate cache (`LINDERA_CACHE_NAME`) from the raw dictionary
-/// cache (`RKYV_CACHE_NAME`).
 pub async fn get_cached_lindera_rkyv() -> Result<Option<Vec<u8>>, OrigaError> {
     let start = now_ms();
-    let cache = open_lindera_cache().await?;
-
-    let match_promise = cache.match_with_str(&cdn_cache_url(LINDERA_CACHE_KEY));
-    let response_option =
-        JsFuture::from(match_promise)
-            .await
-            .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to check lindera cache: {:?}", e),
-            })?;
-
-    if response_option.is_undefined() || response_option.is_null() {
-        return Ok(None);
+    let result = get_cached_blob(LINDERA_CACHE_NAME, LINDERA_CACHE_KEY).await?;
+    if let Some(ref bytes) = result {
+        tracing::info!(
+            "Lindera cache loaded: {} bytes ({:.2}s)",
+            bytes.len(),
+            (now_ms() - start) / 1000.0
+        );
     }
-
-    let response: web_sys::Response =
-        response_option
-            .dyn_into()
-            .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to cast lindera cache response: {:?}", e),
-            })?;
-
-    if !response.ok() {
-        return Ok(None);
-    }
-
-    let array_buffer_promise =
-        response
-            .array_buffer()
-            .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to get array_buffer promise: {:?}", e),
-            })?;
-
-    let array_buffer =
-        JsFuture::from(array_buffer_promise)
-            .await
-            .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to read lindera cache: {:?}", e),
-            })?;
-
-    let uint8_array = js_sys::Uint8Array::new(&array_buffer);
-    let bytes = uint8_array.to_vec();
-    tracing::info!(
-        "Lindera cache loaded: {} bytes ({:.2}s)",
-        bytes.len(),
-        (now_ms() - start) / 1000.0
-    );
-    Ok(Some(bytes))
+    Ok(result)
 }
 
 /// Save pre-built lindera structures (rkyv bytes) to the Cache API.
 pub async fn save_lindera_to_cache_rkyv(bytes: &[u8]) -> Result<(), OrigaError> {
     let start = now_ms();
-    let cache = open_lindera_cache().await?;
-
-    let array_buffer = js_sys::ArrayBuffer::new(bytes.len() as u32);
-    let view = js_sys::Uint8Array::new(&array_buffer);
-    view.copy_from(bytes);
-
-    let response_init = web_sys::ResponseInit::new();
-    response_init.set_status(200);
-    response_init.set_status_text("OK");
-
-    let blob_property_bag = web_sys::BlobPropertyBag::new();
-    blob_property_bag.set_type("application/octet-stream");
-
-    let blob_parts = js_sys::Array::new();
-    blob_parts.push(&array_buffer);
-
-    let blob =
-        web_sys::Blob::new_with_buffer_source_sequence_and_options(&blob_parts, &blob_property_bag)
-            .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to create lindera cache blob: {:?}", e),
-            })?;
-
-    let response = web_sys::Response::new_with_opt_blob_and_init(Some(&blob), &response_init)
-        .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to create lindera cache response: {:?}", e),
-        })?;
-
-    let put_promise = cache.put_with_str(&cdn_cache_url(LINDERA_CACHE_KEY), &response);
-    JsFuture::from(put_promise)
-        .await
-        .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to save lindera cache: {:?}", e),
-        })?;
+    save_blob_to_cache(LINDERA_CACHE_NAME, LINDERA_CACHE_KEY, bytes).await?;
     tracing::info!(
         "Lindera cache saved: {} bytes ({:.2}s)",
         bytes.len(),
         (now_ms() - start) / 1000.0
     );
-
     Ok(())
-}
-
-async fn open_lindera_cache() -> Result<web_sys::Cache, OrigaError> {
-    let window = web_sys::window().ok_or_else(|| OrigaError::RepositoryError {
-        reason: "No window found".to_string(),
-    })?;
-
-    let caches = js_sys::Reflect::get(&window, &wasm_bindgen::JsValue::from_str("caches"))
-        .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Cache API not available: {:?}", e),
-        })?;
-
-    let caches: web_sys::CacheStorage =
-        caches.dyn_into().map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to cast CacheStorage: {:?}", e),
-        })?;
-
-    let cache_promise = caches.open(LINDERA_CACHE_NAME);
-    let cache = open_cache_from_promise(cache_promise).await?;
-
-    Ok(cache)
 }
 
 /// Get cached VocabularyDatabase as raw rkyv bytes.
 pub async fn get_cached_vocabulary_rkyv() -> Result<Option<Vec<u8>>, OrigaError> {
-    let cache = open_vocabulary_cache().await?;
+    let result = get_cached_blob(VOCABULARY_CACHE_NAME, VOCABULARY_CACHE_KEY).await?;
+    if let Some(ref bytes) = result {
+        tracing::debug!("Vocabulary cache loaded: {} bytes", bytes.len());
+    }
+    Ok(result)
+}
 
-    let match_promise = cache.match_with_str(&cdn_cache_url(VOCABULARY_CACHE_KEY));
-    let response_option =
-        JsFuture::from(match_promise)
-            .await
-            .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to check vocabulary cache: {:?}", e),
-            })?;
+/// Save pre-parsed VocabularyDatabase (rkyv bytes) to the Cache API.
+pub async fn save_vocabulary_to_cache_rkyv(bytes: &[u8]) -> Result<(), OrigaError> {
+    save_blob_to_cache(VOCABULARY_CACHE_NAME, VOCABULARY_CACHE_KEY, bytes).await
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Get a blob from a named Cache API store by key. Returns `None` on cache miss.
+async fn get_cached_blob(cache_name: &str, cache_key: &str) -> Result<Option<Vec<u8>>, OrigaError> {
+    let cache = open_named_cache(cache_name).await?;
+
+    let response_option = JsFuture::from(cache.match_with_str(&cdn_cache_url(cache_key)))
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to check cache '{cache_name}': {e:?}"),
+        })?;
 
     if response_option.is_undefined() || response_option.is_null() {
         return Ok(None);
@@ -166,44 +89,40 @@ pub async fn get_cached_vocabulary_rkyv() -> Result<Option<Vec<u8>>, OrigaError>
         response_option
             .dyn_into()
             .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to cast vocabulary cache response: {:?}", e),
+                reason: format!("Failed to cast cache response: {e:?}"),
             })?;
 
     if !response.ok() {
         return Ok(None);
     }
 
-    let array_buffer_promise =
-        response
-            .array_buffer()
-            .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to get array_buffer promise: {:?}", e),
-            })?;
-
     let array_buffer =
-        JsFuture::from(array_buffer_promise)
-            .await
-            .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to read vocabulary cache: {:?}", e),
-            })?;
+        JsFuture::from(
+            response
+                .array_buffer()
+                .map_err(|e| OrigaError::RepositoryError {
+                    reason: format!("Failed to get array_buffer: {e:?}"),
+                })?,
+        )
+        .await
+        .map_err(|e| OrigaError::RepositoryError {
+            reason: format!("Failed to read cache '{cache_name}': {e:?}"),
+        })?;
 
-    let uint8_array = js_sys::Uint8Array::new(&array_buffer);
-    let bytes = uint8_array.to_vec();
-    tracing::debug!("Vocabulary cache loaded: {} bytes", bytes.len());
+    let bytes = js_sys::Uint8Array::new(&array_buffer).to_vec();
     Ok(Some(bytes))
 }
 
-/// Save pre-parsed VocabularyDatabase (rkyv bytes) to the Cache API.
-pub async fn save_vocabulary_to_cache_rkyv(bytes: &[u8]) -> Result<(), OrigaError> {
-    let cache = open_vocabulary_cache().await?;
+/// Save a blob to a named Cache API store under the given key.
+async fn save_blob_to_cache(
+    cache_name: &str,
+    cache_key: &str,
+    bytes: &[u8],
+) -> Result<(), OrigaError> {
+    let cache = open_named_cache(cache_name).await?;
 
     let array_buffer = js_sys::ArrayBuffer::new(bytes.len() as u32);
-    let view = js_sys::Uint8Array::new(&array_buffer);
-    view.copy_from(bytes);
-
-    let response_init = web_sys::ResponseInit::new();
-    response_init.set_status(200);
-    response_init.set_status_text("OK");
+    js_sys::Uint8Array::new(&array_buffer).copy_from(bytes);
 
     let blob_property_bag = web_sys::BlobPropertyBag::new();
     blob_property_bag.set_type("application/octet-stream");
@@ -214,52 +133,49 @@ pub async fn save_vocabulary_to_cache_rkyv(bytes: &[u8]) -> Result<(), OrigaErro
     let blob =
         web_sys::Blob::new_with_buffer_source_sequence_and_options(&blob_parts, &blob_property_bag)
             .map_err(|e| OrigaError::RepositoryError {
-                reason: format!("Failed to create vocabulary cache blob: {:?}", e),
+                reason: format!("Failed to create blob: {e:?}"),
             })?;
+
+    let response_init = web_sys::ResponseInit::new();
+    response_init.set_status(200);
+    response_init.set_status_text("OK");
 
     let response = web_sys::Response::new_with_opt_blob_and_init(Some(&blob), &response_init)
         .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to create vocabulary cache response: {:?}", e),
+            reason: format!("Failed to create response: {e:?}"),
         })?;
 
-    let put_promise = cache.put_with_str(&cdn_cache_url(VOCABULARY_CACHE_KEY), &response);
-    JsFuture::from(put_promise)
+    JsFuture::from(cache.put_with_str(&cdn_cache_url(cache_key), &response))
         .await
         .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to save vocabulary cache: {:?}", e),
+            reason: format!("Failed to save to cache '{cache_name}': {e:?}"),
         })?;
 
     Ok(())
 }
 
-async fn open_vocabulary_cache() -> Result<web_sys::Cache, OrigaError> {
+/// Open a named Cache API store.
+async fn open_named_cache(cache_name: &str) -> Result<web_sys::Cache, OrigaError> {
     let window = web_sys::window().ok_or_else(|| OrigaError::RepositoryError {
         reason: "No window found".to_string(),
     })?;
 
     let caches = js_sys::Reflect::get(&window, &wasm_bindgen::JsValue::from_str("caches"))
         .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Cache API not available: {:?}", e),
+            reason: format!("Cache API not available: {e:?}"),
         })?;
 
     let caches: web_sys::CacheStorage =
         caches.dyn_into().map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to cast CacheStorage: {:?}", e),
+            reason: format!("Failed to cast CacheStorage: {e:?}"),
         })?;
 
-    let cache_promise = caches.open(VOCABULARY_CACHE_NAME);
-    let cache = open_cache_from_promise(cache_promise).await?;
-
-    Ok(cache)
-}
-
-/// Shared helper: await a `caches.open()` promise and cast to `web_sys::Cache`.
-async fn open_cache_from_promise(promise: js_sys::Promise) -> Result<web_sys::Cache, OrigaError> {
-    let cache = JsFuture::from(promise)
+    let cache = JsFuture::from(caches.open(cache_name))
         .await
         .map_err(|e| OrigaError::RepositoryError {
-            reason: format!("Failed to open cache: {:?}", e),
+            reason: format!("Failed to open cache '{cache_name}': {e:?}"),
         })?
         .into();
+
     Ok(cache)
 }

--- a/origa_ui/src/repository/mod.rs
+++ b/origa_ui/src/repository/mod.rs
@@ -15,7 +15,10 @@ pub mod trailbase_session;
 
 pub use cdn_provider::cdn as cdn_provider;
 
-pub use dictionary_cache::{get_cached_dictionary_rkyv, save_dictionary_to_cache_rkyv};
+pub use dictionary_cache::{
+    get_cached_lindera_rkyv, get_cached_vocabulary_rkyv, save_lindera_to_cache_rkyv,
+    save_vocabulary_to_cache_rkyv,
+};
 pub use hybrid_repository::HybridUserRepository;
 pub use session::{
     clear_session, clear_session_async, get_session, get_session_async,


### PR DESCRIPTION
## Problem

On init-load Stage 1 (dictionary/UniDic), the app performs ~600 MB memcpy across 3 cascading copies:
- COPY #1: Cache API → WASM heap (~204 MB rkyv blob)
- COPY #2: rkyv archived → 8× to_vec() → DictionaryData (~204 MB)
- COPY #3: init_tokenizer: 5× .clone() → lindera owned structures (~200 MB)

After all copies, `DICTIONARY_DATA` (static OnceLock) retains ~200 MB of dead weight forever. On iOS WKWebView (~1.5 GB jetsam limit), this causes OOM kills. Stage 1 is also slow even with cache due to CPU-bound `ConnectionCostMatrix::load` (byte→i16 conversion) and lindera deserialization.

## Solution

| Component | Effect |
|-----------|--------|
| **A: Remove DICTIONARY_DATA static** | −200 MB permanent memory |
| **B: Move instead of clone** | −200 MB peak (no COPY #3) |
| **CachedLinderaDictionary (direct rkyv)** | ~170 MB cache hit instead of ~600 MB; no CPU: byte→i16, char_def/unk parsing |
| **Rkyv Vocabulary** | Skip 35 MB JSON parsing on repeat loads |

### Cache hit path (fast)
```
Cache API → rkyv bytes (~170 MB)
  → rkyv::from_bytes → CachedLinderaDictionary
  → Dictionary → Segmenter → Tokenizer
  // No load() calls, no CPU conversion
```

### Cache miss path (first launch)
```
CDN (compressed) → decompress → DictionaryData (~204 MB)
  → build_cached_lindera (owned, consumed — no clone)
  → serialize to rkyv → save to Cache API
  → init_tokenizer_from_cached
```

## Files changed (11 files, +694/−207)

- `origa/src/domain/tokenizer/mod.rs` — A+B, CachedLinderaDictionary, build/serialize/deserialize
- `origa/src/dictionary/vocabulary.rs` — rkyv derive, serialize/deserialize
- `origa_ui/src/loaders/dictionary.rs` — cache-first loader with fallback
- `origa_ui/src/loaders/data_loader.rs` — vocabulary cache-first
- `origa_ui/src/repository/dictionary_cache.rs` — lindera + vocabulary cache functions
- `origa_ui/src/repository/cache_manager.rs` — invalidation for new caches
- Removed dead code: `Urls`, `urls()`, `serialize_dictionary_to_rkyv`, `init_dictionary_from_rkyv`, unused derives on `DictionaryData`

## Verification
- ✅ `cargo clippy -p origa -p origa_ui -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ `cargo test -p origa --lib` — 1582 passed, 0 failed
- ✅ 4 new round-trip tests (lindera + vocabulary rkyv serialization)

## Note
lindera 3.0 upgrade was attempted but reverted — daachorse 2.x is binary-incompatible with existing CDN dictionary files. Needs separate PR with dictionary rebuild.