### PR TITLE
feat(ios): ASWebAuthenticationSession for OAuth callback handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6071,6 +6071,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-aswebauth",
  "tauri-plugin-deep-link",
  "tauri-plugin-device-ai-apis",
  "tauri-plugin-haptics",
@@ -9034,6 +9035,16 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-aswebauth"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["origa", "utils", "origa_ui", "tauri", "origa_landing"]
+members = ["origa", "utils", "origa_ui", "tauri", "origa_landing", "tauri-plugin-aswebauth"]
 resolver = "2"
 
 [workspace.package]
@@ -130,7 +130,9 @@ tauri-plugin-store = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-haptics = "2"
+tauri-plugin-aswebauth = { path = "tauri-plugin-aswebauth" }
 tauri-build = { version = "2", features = [] }
+tauri-plugin = { version = "2", features = ["build"] }
 # device-ai: native AI APIs (ASR/OCR/TTS). Pinned to a fork rev that fixes the
 # upstream mobile bridge (hypothesi's CI never built mobile, so two compile
 # errors went unnoticed: missing get_capabilities on the mobile impl, and

--- a/origa_landing/Dockerfile
+++ b/origa_landing/Dockerfile
@@ -45,6 +45,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 COPY Cargo.toml Cargo.lock ./
 COPY utils/Cargo.toml ./utils/
 COPY tauri/Cargo.toml ./tauri/
+COPY tauri-plugin-aswebauth/Cargo.toml ./tauri-plugin-aswebauth/
 COPY origa/Cargo.toml ./origa/
 COPY origa_ui/Cargo.toml ./origa_ui/
 COPY origa_landing/Cargo.toml ./origa_landing/
@@ -56,6 +57,8 @@ RUN mkdir -p origa/src && echo "pub fn dummy() {}" > origa/src/lib.rs && \
     echo "fn main() {}" > origa_ui/src/main.rs && \
     mkdir -p utils/src && echo "pub fn dummy() {}" > utils/src/lib.rs && \
     mkdir -p tauri/src && echo "pub fn dummy() {}" > tauri/src/lib.rs && \
+    mkdir -p tauri-plugin-aswebauth/src && echo "pub fn dummy() {}" > tauri-plugin-aswebauth/src/lib.rs && \
+    echo "fn main() {}" > tauri-plugin-aswebauth/build.rs && \
     mkdir -p origa_landing/src && echo "pub fn dummy() {}" > origa_landing/src/lib.rs && \
     echo "fn main() {}" > origa_landing/src/main.rs && \
     echo "fn main() {}" > origa_landing/build.rs

--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -63,6 +63,7 @@ RUN npm install -g tailwindcss@${TAILWINDCSS_VERSION} \
 COPY Cargo.toml Cargo.lock ./
 COPY utils/Cargo.toml ./utils/
 COPY tauri/Cargo.toml ./tauri/
+COPY tauri-plugin-aswebauth/Cargo.toml ./tauri-plugin-aswebauth/
 COPY origa/Cargo.toml ./origa/
 COPY origa_ui/Cargo.toml ./origa_ui/
 COPY origa_landing/Cargo.toml ./origa_landing/
@@ -74,6 +75,8 @@ RUN mkdir -p origa/src && echo "pub fn dummy() {}" > origa/src/lib.rs && \
     echo "fn main() {}" > origa_ui/src/main.rs && \
     mkdir -p utils/src && echo "pub fn dummy() {}" > utils/src/lib.rs && \
     mkdir -p tauri/src && echo "pub fn dummy() {}" > tauri/src/lib.rs && \
+    mkdir -p tauri-plugin-aswebauth/src && echo "pub fn dummy() {}" > tauri-plugin-aswebauth/src/lib.rs && \
+    echo "fn main() {}" > tauri-plugin-aswebauth/build.rs && \
     mkdir -p origa_landing/src && echo "pub fn dummy() {}" > origa_landing/src/lib.rs && \
     echo "fn main() {}" > origa_landing/src/main.rs && \
     echo "fn main() {}" > origa_landing/build.rs

--- a/origa_ui/src/core/tauri.rs
+++ b/origa_ui/src/core/tauri.rs
@@ -15,6 +15,26 @@ pub fn is_tauri() -> bool {
     tauri_object().is_some()
 }
 
+/// Returns `true` on iOS (iPhone/iPad/iPod WKWebView).
+///
+/// Uses `navigator.platform` first — on iPad with "Request Desktop Site"
+/// (iOS 13+) the userAgent switches to a desktop-class string without
+/// "iPad", but `navigator.platform` still returns "iPad". Falls back to
+/// userAgent for older WebViews where platform may be unavailable.
+pub fn is_ios() -> bool {
+    window().is_some_and(|w| {
+        let nav = w.navigator();
+        if let Ok(platform) = nav.platform() {
+            if platform.contains("iPhone") || platform.contains("iPad") || platform.contains("iPod")
+            {
+                return true;
+            }
+        }
+        nav.user_agent()
+            .is_ok_and(|ua| ua.contains("iPhone") || ua.contains("iPad") || ua.contains("iPod"))
+    })
+}
+
 /// Returns the `window.__TAURI__` object if available.
 pub fn tauri_object() -> Option<Object> {
     window()

--- a/origa_ui/src/pages/login/oauth_buttons.rs
+++ b/origa_ui/src/pages/login/oauth_buttons.rs
@@ -255,6 +255,42 @@ async fn open_oauth_url(
     let url = client.get_oauth_url(provider.as_str(), &redirect_uri, &challenge);
     report_debug!(debug_sink, "oauth url built: {url}");
 
+    // iOS: ASWebAuthenticationSession opens Safari in a dedicated auth context
+    // and intercepts the `origa://` callback directly — no CFBundleURLTypes
+    // registration needed (tauri-plugin-deep-link build.rs removes it for
+    // custom schemes). The callback URL is returned via the Tauri command's
+    // Promise, bypassing the deep-link listener entirely.
+    //
+    // Non-iOS (Android, desktop, web): opener + deep-link listener flow.
+    if tauri::is_ios() {
+        auth_store.oauth_error.set(None);
+        auth_store.is_oauth_loading.set(true);
+        match start_aswebauth(&url, "origa").await {
+            Ok(callback_url) => {
+                report_debug!(debug_sink, "aswebauth callback: {callback_url}");
+                let result =
+                    super::oauth_listeners::process_oauth_url(&callback_url, &auth_store, &i18n)
+                        .await;
+                super::oauth_listeners::handle_oauth_result(result, &auth_store);
+                auth_store.is_oauth_loading.set(false);
+                return;
+            },
+            Err(e) if e == "cancelled" => {
+                report_debug!(debug_sink, "aswebauth cancelled by user");
+                auth_store.is_oauth_loading.set(false);
+                // User dismissed Safari — do NOT fall through to opener, which
+                // would re-open Safari against the user's intent.
+                return;
+            },
+            Err(e) => {
+                report_debug!(debug_sink, "aswebauth failed: {e}");
+                auth_store.is_oauth_loading.set(false);
+                // Technical failure (plugin not registered, Swift error) —
+                // fall through to the opener + deep-link fallback.
+            },
+        }
+    }
+
     open_url_external(&url, debug_sink);
 
     // On Android the WebView JS is frozen while the app is backgrounded in the
@@ -263,6 +299,56 @@ async fn open_oauth_url(
     // sidesteps the missing resume signal: the timer pauses while frozen and
     // resumes on Activity onResume, recovering the pending callback URL.
     super::oauth_listeners::start_resume_polling(auth_store, i18n);
+}
+
+/// Invokes the iOS `aswebauth` Tauri plugin to start an
+/// `ASWebAuthenticationSession`.
+///
+/// Returns the callback URL (e.g. `origa://auth/callback?code=...`) on
+/// success, or an error string if the session failed or was cancelled.
+///
+/// Uses `__TAURI__.core.invoke` to call `plugin:aswebauth|start_auth` with
+/// `{ url, callbackScheme }`. The Swift plugin intercepts the custom-scheme
+/// redirect and resolves the Promise with the callback URL.
+async fn start_aswebauth(url: &str, callback_scheme: &str) -> Result<String, String> {
+    use crate::core::tauri::invoke_fn;
+    use js_sys::Object as JsObject;
+    use leptos::wasm_bindgen::JsCast;
+    use leptos::wasm_bindgen::JsValue;
+    use wasm_bindgen_futures::JsFuture;
+
+    let invoke_fn = invoke_fn().ok_or("Tauri invoke not available")?;
+
+    let args = JsObject::new();
+    js_sys::Reflect::set(&args, &JsValue::from_str("url"), &JsValue::from_str(url))
+        .map_err(|e| format!("failed to set url arg: {e:?}"))?;
+    js_sys::Reflect::set(
+        &args,
+        &JsValue::from_str("callbackScheme"),
+        &JsValue::from_str(callback_scheme),
+    )
+    .map_err(|e| format!("failed to set callbackScheme arg: {e:?}"))?;
+
+    let result = invoke_fn
+        .call2(
+            &JsValue::UNDEFINED,
+            &JsValue::from_str("plugin:aswebauth|start_auth"),
+            &args,
+        )
+        .map_err(|e| format!("invoke('start_auth') call failed: {e:?}"))?;
+
+    let promise = result
+        .dyn_into::<js_sys::Promise>()
+        .map_err(|_| "invoke('start_auth') did not return a Promise".to_string())?;
+
+    let value = JsFuture::from(promise)
+        .await
+        .map_err(|e| format!("invoke('start_auth') rejected: {e:?}"))?;
+
+    js_sys::Reflect::get(&value, &JsValue::from_str("url"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .ok_or("missing 'url' field in start_auth response".to_string())
 }
 
 #[component]

--- a/origa_ui/src/pages/login/oauth_buttons.rs
+++ b/origa_ui/src/pages/login/oauth_buttons.rs
@@ -341,9 +341,13 @@ async fn start_aswebauth(url: &str, callback_scheme: &str) -> Result<String, Str
         .dyn_into::<js_sys::Promise>()
         .map_err(|_| "invoke('start_auth') did not return a Promise".to_string())?;
 
-    let value = JsFuture::from(promise)
-        .await
-        .map_err(|e| format!("invoke('start_auth') rejected: {e:?}"))?;
+    let value = JsFuture::from(promise).await.map_err(|e| {
+        // Preserve the raw rejection string (e.g. "cancelled") so the caller
+        // can pattern-match on it. Wrapping in format!("rejected: ...")
+        // would break the Err(e) if e == "cancelled" branch in open_oauth_url.
+        e.as_string()
+            .unwrap_or_else(|| format!("invoke('start_auth') rejected: {e:?}"))
+    })?;
 
     js_sys::Reflect::get(&value, &JsValue::from_str("url"))
         .ok()

--- a/origa_ui/src/pages/login/oauth_listeners.rs
+++ b/origa_ui/src/pages/login/oauth_listeners.rs
@@ -71,7 +71,7 @@ fn extract_url_from_event(event: &JsValue) -> String {
     String::new()
 }
 
-async fn process_oauth_url(
+pub(crate) async fn process_oauth_url(
     url: &str,
     auth_store: &AuthStore,
     i18n: &I18nContext<Locale>,
@@ -100,7 +100,7 @@ async fn process_oauth_url(
         .to_string())
 }
 
-fn handle_oauth_result(result: Result<Option<User>, String>, auth_store: &AuthStore) {
+pub(crate) fn handle_oauth_result(result: Result<Option<User>, String>, auth_store: &AuthStore) {
     match result {
         Ok(Some(user)) => {
             debug!(user_id = %user.id(), "OAuth success — updating user signal");

--- a/tauri-plugin-aswebauth/Cargo.toml
+++ b/tauri-plugin-aswebauth/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tauri-plugin-aswebauth"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+readme.workspace = true
+links = "tauri-plugin-aswebauth"
+
+# ASWebAuthenticationSession is iOS-only. The crate compiles on all targets
+# (it is a workspace member) but the plugin is registered only under
+# `#[cfg(target_os = "ios")]` in tauri/src/lib.rs.
+
+[build-dependencies]
+tauri-plugin.workspace = true
+
+[dependencies]
+tauri.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/tauri-plugin-aswebauth/build.rs
+++ b/tauri-plugin-aswebauth/build.rs
@@ -1,0 +1,8 @@
+// Copyright 2026 yurvon-screamo
+// SPDX-License-Identifier: MIT
+
+const COMMANDS: &[&str] = &["start_auth"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).ios_path("ios").build();
+}

--- a/tauri-plugin-aswebauth/ios/Package.swift
+++ b/tauri-plugin-aswebauth/ios/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.9
+// Copyright 2026 yurvon-screamo
+// SPDX-License-Identifier: MIT
+
+import PackageDescription
+
+let package = Package(
+    name: "tauri-plugin-aswebauth",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "tauri-plugin-aswebauth",
+            type: .static,
+            targets: ["tauri-plugin-aswebauth"]
+        )
+    ],
+    dependencies: [
+        .package(name: "Tauri", path: "../.tauri/tauri-api")
+    ],
+    targets: [
+        .target(
+            name: "tauri-plugin-aswebauth",
+            dependencies: [
+                .byName(name: "Tauri")
+            ],
+            path: "Sources"
+        )
+    ]
+)

--- a/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
+++ b/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
@@ -1,0 +1,101 @@
+// Copyright 2026 yurvon-screamo
+// SPDX-License-Identifier: MIT
+//
+// ASWebAuthenticationSession wrapper for OAuth flows.
+//
+// Replaces the tauri-plugin-opener + desktop-callback.html + custom-scheme
+// flow on iOS. ASWebAuthenticationSession opens Safari in a dedicated auth
+// context, intercepts the `origa://` callback directly, and returns the
+// callback URL via the completion handler — no CFBundleURLTypes needed.
+//
+// `prefersEphemeralWebBrowserSession` is intentionally `false`: Google OAuth
+// rejects ephemeral (incognito-like) browser sessions, blocking login.
+
+import AuthenticationServices
+import SwiftRs
+import Tauri
+import UIKit
+import WebKit
+
+struct StartAuthArgs: Decodable {
+    let url: String
+    let callbackScheme: String
+}
+
+class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding {
+    /// Strong reference to the active session. If this property is nil'd
+    /// (or the plugin is deallocated) the session's completion handler
+    /// will never fire, hanging the OAuth flow indefinitely.
+    private var session: ASWebAuthenticationSession?
+
+    @objc public func startAuth(_ invoke: Invoke) throws {
+        let args = try invoke.parseArgs(StartAuthArgs.self)
+        guard let url = URL(string: args.url) else {
+            invoke.reject("Invalid URL")
+            return
+        }
+
+        let session = ASWebAuthenticationSession(
+            url: url,
+            callbackURLScheme: args.callbackScheme
+        ) { callbackURL, error in
+            // Clear the strong reference so the session can be deallocated.
+            self.session = nil
+
+            if let error = error as? ASWebAuthenticationSessionError,
+               error.code == .canceledLogin {
+                invoke.reject("cancelled")
+            } else if let error = error {
+                invoke.reject("session failed: \(error.localizedDescription)")
+            } else if let callbackURL = callbackURL {
+                invoke.resolve(["url": callbackURL.absoluteString])
+            } else {
+                invoke.reject("no callback URL")
+            }
+        }
+
+        session.presentationContextProvider = self
+        // Google OAuth rejects ephemeral (incognito) sessions. Keep this false
+        // so that Google and Yandex logins both work.
+        session.prefersEphemeralWebBrowserSession = false
+
+        self.session = session
+
+        DispatchQueue.main.async {
+            session.start()
+        }
+    }
+
+    // MARK: - ASWebAuthenticationPresentationContextProviding
+
+    func presentationAnchor(
+        for session: ASWebAuthenticationSession
+    ) -> ASPresentationAnchor {
+        // Return the app's key window so Safari's auth sheet appears on top
+        // of the WebView, not a blank anchor. Uses the foreground active scene
+        // to avoid returning a backgrounded window.
+        let scenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
+
+        for scene in scenes {
+            for window in scene.windows where window.isKeyWindow {
+                return window
+            }
+        }
+
+        // Fallback: first window of the first scene.
+        if let scene = scenes.first, let window = scene.windows.first {
+            return window
+        }
+
+        // Last resort: empty anchor. The auth session may fail to display,
+        // but this should be unreachable in a normal app lifecycle.
+        return ASPresentationAnchor()
+    }
+}
+
+@_cdecl("init_plugin_aswebauth")
+func initPlugin() -> Plugin {
+    return AsWebAuthPlugin()
+}

--- a/tauri-plugin-aswebauth/permissions/autogenerated/commands/start_auth.toml
+++ b/tauri-plugin-aswebauth/permissions/autogenerated/commands/start_auth.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-start-auth"
+description = "Enables the start_auth command without any pre-configured scope."
+commands.allow = ["start_auth"]
+
+[[permission]]
+identifier = "deny-start-auth"
+description = "Denies the start_auth command without any pre-configured scope."
+commands.deny = ["start_auth"]

--- a/tauri-plugin-aswebauth/permissions/autogenerated/reference.md
+++ b/tauri-plugin-aswebauth/permissions/autogenerated/reference.md
@@ -1,0 +1,34 @@
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+<tr>
+<td>
+
+`aswebauth:allow-start-auth`
+
+</td>
+<td>
+
+Enables the start_auth command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`aswebauth:deny-start-auth`
+
+</td>
+<td>
+
+Denies the start_auth command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/tauri-plugin-aswebauth/permissions/schemas/schema.json
+++ b/tauri-plugin-aswebauth/permissions/schemas/schema.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the start_auth command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-start-auth",
+          "markdownDescription": "Enables the start_auth command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_auth command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-start-auth",
+          "markdownDescription": "Denies the start_auth command without any pre-configured scope."
+        }
+      ]
+    }
+  }
+}

--- a/tauri-plugin-aswebauth/src/commands.rs
+++ b/tauri-plugin-aswebauth/src/commands.rs
@@ -1,0 +1,24 @@
+// Copyright 2026 yurvon-screamo
+// SPDX-License-Identifier: MIT
+
+use serde::Serialize;
+
+/// Successful response from `start_auth`.
+///
+/// Serialized to the frontend as `{ "url": "origa://auth/callback?code=..." }`.
+#[derive(Debug, Serialize)]
+pub struct AuthResult {
+    /// The full callback URL intercepted by ASWebAuthenticationSession.
+    pub url: String,
+}
+
+/// Tauri command: start an ASWebAuthenticationSession.
+///
+/// **iOS only.** On non-iOS targets this command is unreachable (the frontend
+/// gates the call behind `tauri::is_ios()`), but it must compile. The Swift
+/// plugin overrides this handler on iOS via `run_mobile_plugin`; the Rust
+/// stub exists solely so `generate_handler!` can resolve the command name.
+#[tauri::command]
+pub async fn start_auth(_url: String, _callback_scheme: String) -> Result<AuthResult, String> {
+    Err("ASWebAuthenticationSession is only available on iOS".to_string())
+}

--- a/tauri-plugin-aswebauth/src/lib.rs
+++ b/tauri-plugin-aswebauth/src/lib.rs
@@ -35,10 +35,11 @@ mod commands;
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     let builder = Builder::<R>::new("aswebauth");
 
+    // Shadow (not mutate) — `ios_plugin_binding` consumes `self` and returns
+    // a new Builder. Using `let builder =` under cfg avoids E0384 on non-iOS
+    // where this line is absent.
     #[cfg(target_os = "ios")]
-    {
-        builder = builder.ios_plugin_binding(init_plugin_aswebauth);
-    }
+    let builder = builder.ios_plugin_binding(init_plugin_aswebauth);
 
     builder
         .invoke_handler(tauri::generate_handler![commands::start_auth])

--- a/tauri-plugin-aswebauth/src/lib.rs
+++ b/tauri-plugin-aswebauth/src/lib.rs
@@ -1,0 +1,46 @@
+// Copyright 2026 yurvon-screamo
+// SPDX-License-Identifier: MIT
+//
+// iOS-only Tauri plugin that wraps ASWebAuthenticationSession for OAuth flows.
+//
+// ASWebAuthenticationSession is Apple's recommended API for browser-based
+// authentication from native apps. Unlike UIApplication.shared.open (which
+// leaves the user stranded in Safari after the OAuth redirect),
+// ASWebAuthenticationSession:
+//
+// 1. Opens Safari in a dedicated authentication context.
+// 2. Intercepts the custom-scheme callback URL directly (no CFBundleURLTypes
+//    registration needed — the tauri-plugin-deep-link build.rs actively
+//    removes CFBundleURLTypes for non-appLink custom schemes on iOS).
+// 3. Returns the callback URL via a completion handler.
+// 4. Closes Safari automatically.
+//
+// Non-iOS targets: the plugin compiles but the Swift code is excluded.
+// `init()` returns a no-op plugin that rejects `start_auth` with an error
+// — unreachable because the frontend only invokes it under `is_ios()`.
+
+use tauri::Runtime;
+use tauri::plugin::{Builder, TauriPlugin};
+
+#[cfg(target_os = "ios")]
+tauri::ios_plugin_binding!(init_plugin_aswebauth);
+
+mod commands;
+
+/// Initializes the plugin.
+///
+/// On iOS, registers the Swift `AsWebAuthPlugin` that wraps
+/// `ASWebAuthenticationSession`. On all other targets the plugin is a no-op
+/// shell whose `start_auth` command always returns an error.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    let builder = Builder::<R>::new("aswebauth");
+
+    #[cfg(target_os = "ios")]
+    {
+        builder = builder.ios_plugin_binding(init_plugin_aswebauth);
+    }
+
+    builder
+        .invoke_handler(tauri::generate_handler![commands::start_auth])
+        .build()
+}

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -67,6 +67,14 @@ base64.workspace = true
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 tauri-plugin-haptics.workspace = true
 
+# iOS-only: ASWebAuthenticationSession plugin for OAuth. Wraps Apple's
+# native auth session API so the browser returns to the app after the OAuth
+# redirect — the tauri-plugin-deep-link build.rs does NOT register
+# CFBundleURLTypes for custom schemes on iOS, so the old opener +
+# desktop-callback.html flow cannot return from Safari.
+[target.'cfg(target_os = "ios")'.dependencies]
+tauri-plugin-aswebauth.workspace = true
+
 # Android-only: rustls-platform-verifier JNI initialization.
 # reqwest (Sentry transport, lindera build) pulls in rustls-platform-verifier
 # on non-WASM targets. On Android it must be initialized with a JNI context

--- a/tauri/capabilities/ios.json
+++ b/tauri/capabilities/ios.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "../gen/schemas/mobile-schema.json",
+	"identifier": "ios",
+	"description": "Capability for iOS-only plugins — ASWebAuthenticationSession for OAuth",
+	"platforms": ["iOS"],
+	"windows": ["main"],
+	"permissions": [
+		"aswebauth:allow-start-auth"
+	]
+}

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -97,6 +97,18 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_haptics::init());
     }
 
+    // iOS-only: ASWebAuthenticationSession for OAuth. The plugin wraps Apple's
+    // native auth session so Safari returns to the app after the OAuth redirect
+    // — the custom-scheme `origa://` is not registered in Info.plist by
+    // tauri-plugin-deep-link (its build.rs removes CFBundleURLTypes for
+    // non-appLink schemes), so ASWebAuthenticationSession intercepts the
+    // callback directly. Android and desktop keep the existing opener +
+    // deep-link listener flow.
+    #[cfg(target_os = "ios")]
+    {
+        builder = builder.plugin(tauri_plugin_aswebauth::init());
+    }
+
     builder = builder
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())


### PR DESCRIPTION
## Problem

OIDC login on iOS does not return to the app after successful authentication in Safari. The `origa://` custom scheme is never registered in Info.plist because `tauri-plugin-deep-link` build.rs actively removes `CFBundleURLTypes` for non-appLink custom schemes on iOS.

## Solution

New `tauri-plugin-aswebauth` — a local Tauri v2 plugin (iOS-only) that wraps Apple's `ASWebAuthenticationSession` API:
- Opens Safari in a dedicated auth context
- Intercepts the `origa://` callback directly (no `CFBundleURLTypes` needed)
- Returns callback URL via completion handler
- Closes Safari automatically

**iOS-only:** `#[cfg(target_os = "ios")]` gating — Android, desktop, and web builds are completely unaffected. Existing opener + deep-link flow remains as fallback.

## Key decisions
- `prefersEphemeralWebBrowserSession = false` — Google OAuth compatibility
- `navigator.platform` primary detection — iPad "Request Desktop Site" workaround
- User cancellation = silent return (no Safari re-open)
- `is_oauth_loading` set before session start for immediate UX feedback

## Files changed
- **New:** `tauri-plugin-aswebauth/` (Cargo.toml, build.rs, lib.rs, commands.rs, Swift plugin)
- **New:** `tauri/capabilities/ios.json` (iOS-only capability)
- **Modified:** workspace Cargo.toml, tauri/Cargo.toml, tauri/src/lib.rs
- **Modified:** origa_ui — is_ios() detection, iOS-branch in open_oauth_url()

## Checklist
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes
- [x] Non-iOS compilation verified (Windows)
- [ ] Tested on physical iPhone (requires mac)