### PR TITLE
fix(ios): use api.register_ios_plugin instead of Builder::ios_plugin_binding

### DIFF
--- a/tauri-plugin-aswebauth/src/commands.rs
+++ b/tauri-plugin-aswebauth/src/commands.rs
@@ -1,7 +1,21 @@
 // Copyright 2026 yurvon-screamo
 // SPDX-License-Identifier: MIT
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for the `start_auth` command.
+///
+/// Serialized from the frontend as `{ "url": "...", "callbackScheme": "origa" }`.
+/// Only constructed on iOS (passed to `run_mobile_plugin`).
+#[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(not(target_os = "ios"), expect(dead_code))]
+pub struct StartAuthArgs {
+    /// Full OAuth provider URL (PKCE challenge included).
+    pub url: String,
+    /// Custom URL scheme to intercept (e.g. "origa").
+    #[serde(rename = "callbackScheme")]
+    pub callback_scheme: String,
+}
 
 /// Successful response from `start_auth`.
 ///
@@ -12,13 +26,44 @@ pub struct AuthResult {
     pub url: String,
 }
 
-/// Tauri command: start an ASWebAuthenticationSession.
-///
-/// **iOS only.** On non-iOS targets this command is unreachable (the frontend
-/// gates the call behind `tauri::is_ios()`), but it must compile. The Swift
-/// plugin overrides this handler on iOS via `run_mobile_plugin`; the Rust
-/// stub exists solely so `generate_handler!` can resolve the command name.
+/// iOS: delegates to the Swift `AsWebAuthPlugin.startAuth` via
+/// `PluginHandle::run_mobile_plugin`. The Swift completion handler resolves
+/// with `{ "url": "origa://auth/callback?code=..." }`.
+#[cfg(target_os = "ios")]
+#[tauri::command]
+pub async fn start_auth<R: Runtime>(
+    app: tauri::AppHandle<R>,
+    url: String,
+    callback_scheme: String,
+) -> Result<AuthResult, String> {
+    use crate::AsWebAuthState;
+    use tauri::Runtime;
+
+    let state = app
+        .try_state::<AsWebAuthState<R>>()
+        .ok_or("aswebauth plugin not initialized")?;
+
+    let result: AuthResult = state
+        .handle
+        .run_mobile_plugin(
+            "startAuth",
+            StartAuthArgs {
+                url,
+                callback_scheme,
+            },
+        )
+        .map_err(|e| e.to_string())?;
+
+    Ok(result)
+}
+
+/// Non-iOS stub — always returns an error. Unreachable because the frontend
+/// gates the call behind `tauri::is_ios()`.
+#[cfg(not(target_os = "ios"))]
 #[tauri::command]
 pub async fn start_auth(_url: String, _callback_scheme: String) -> Result<AuthResult, String> {
     Err("ASWebAuthenticationSession is only available on iOS".to_string())
 }
+
+#[cfg(target_os = "ios")]
+use tauri::Runtime;

--- a/tauri-plugin-aswebauth/src/lib.rs
+++ b/tauri-plugin-aswebauth/src/lib.rs
@@ -15,31 +15,59 @@
 // 3. Returns the callback URL via a completion handler.
 // 4. Closes Safari automatically.
 //
-// Non-iOS targets: the plugin compiles but the Swift code is excluded.
-// `init()` returns a no-op plugin that rejects `start_auth` with an error
-// — unreachable because the frontend only invokes it under `is_ios()`.
+// Non-iOS targets: the plugin compiles but registers no mobile handle.
+// `start_auth` returns an error — unreachable because the frontend only
+// invokes it under `is_ios()`.
 
 use tauri::Runtime;
 use tauri::plugin::{Builder, TauriPlugin};
+
+#[cfg(target_os = "ios")]
+use tauri::{Manager, plugin::PluginHandle};
 
 #[cfg(target_os = "ios")]
 tauri::ios_plugin_binding!(init_plugin_aswebauth);
 
 mod commands;
 
+/// Plugin state holding the mobile plugin handle (iOS only).
+///
+/// On iOS, `setup` stores the `PluginHandle` returned by
+/// `register_ios_plugin` so that `start_auth` can delegate to the Swift
+/// `AsWebAuthPlugin` via `run_mobile_plugin`.
+//
+// On non-iOS targets this type is not used — `start_auth` returns an error
+// without touching plugin state.
+#[cfg(target_os = "ios")]
+pub struct AsWebAuthState<R: Runtime> {
+    pub(crate) handle: PluginHandle<R>,
+}
+
 /// Initializes the plugin.
 ///
-/// On iOS, registers the Swift `AsWebAuthPlugin` that wraps
-/// `ASWebAuthenticationSession` via `api.register_ios_plugin()` inside
-/// `.setup()`. On all other targets the plugin is a no-op shell whose
-/// `start_auth` command always returns an error.
+/// On iOS, registers the Swift `AsWebAuthPlugin` via
+/// `api.register_ios_plugin()` and stores the handle in plugin state.
+/// The `start_auth` command retrieves the handle and calls
+/// `run_mobile_plugin("startAuth", ...)` to invoke the Swift
+/// `ASWebAuthenticationSession` wrapper.
+///
+/// On non-iOS targets the plugin is a no-op — `start_auth` returns an
+/// error because the frontend only invokes it under `is_ios()`.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::<R>::new("aswebauth")
-        .setup(|_app, _api| {
+        .setup(|app, api| {
             #[cfg(target_os = "ios")]
             {
-                let _handle = _api.register_ios_plugin(init_plugin_aswebauth)?;
+                let handle = api.register_ios_plugin(init_plugin_aswebauth)?;
+                app.manage(AsWebAuthState::<R> { handle });
             }
+
+            // Non-iOS: no mobile handle to register. start_auth is a stub.
+            #[cfg(not(target_os = "ios"))]
+            {
+                let _ = (app, api);
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![commands::start_auth])

--- a/tauri-plugin-aswebauth/src/lib.rs
+++ b/tauri-plugin-aswebauth/src/lib.rs
@@ -30,18 +30,18 @@ mod commands;
 /// Initializes the plugin.
 ///
 /// On iOS, registers the Swift `AsWebAuthPlugin` that wraps
-/// `ASWebAuthenticationSession`. On all other targets the plugin is a no-op
-/// shell whose `start_auth` command always returns an error.
+/// `ASWebAuthenticationSession` via `api.register_ios_plugin()` inside
+/// `.setup()`. On all other targets the plugin is a no-op shell whose
+/// `start_auth` command always returns an error.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    let builder = Builder::<R>::new("aswebauth");
-
-    // Shadow (not mutate) — `ios_plugin_binding` consumes `self` and returns
-    // a new Builder. Using `let builder =` under cfg avoids E0384 on non-iOS
-    // where this line is absent.
-    #[cfg(target_os = "ios")]
-    let builder = builder.ios_plugin_binding(init_plugin_aswebauth);
-
-    builder
+    Builder::<R>::new("aswebauth")
+        .setup(|_app, _api| {
+            #[cfg(target_os = "ios")]
+            {
+                let _handle = _api.register_ios_plugin(init_plugin_aswebauth)?;
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![commands::start_auth])
         .build()
 }


### PR DESCRIPTION
## Problem

The iOS release build (v0.5.1-rc2) failed with:
```
error[E0599]: no method named `ios_plugin_binding` found for struct `tauri::plugin::Builder<R, C>`
```

## Root Cause

`Builder::ios_plugin_binding()` does not exist in the Tauri v2 plugin API. The correct pattern (matching tauri-plugin-opener reference) is:
1. `ios_plugin_binding!` macro creates the FFI function
2. `.setup(|_app, api|)` closure calls `api.register_ios_plugin()`

## Fix

Rewrite plugin init to use `.setup()` + `api.register_ios_plugin()` instead of the non-existent `Builder::ios_plugin_binding()`.

Fixes iOS release build failure on aarch64-apple-ios.