### PR TITLE
fix(ui): batch mobile layout/UX fixes for 13 bugs

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1228,6 +1228,51 @@ input[type="submit"],
     background: transparent;
 }
 
+/* Scrollable Tabs variant: horizontal scroll for narrow viewports where
+   all tabs don't fit (e.g. 4 input-mode tabs in Add Words on a 360px phone).
+   hide-scrollbar keeps the visual clean while remaining swipeable. */
+.tabs--scrollable {
+    display: flex;
+    border-bottom: 1px solid var(--border-dark);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+
+.tabs--scrollable::-webkit-scrollbar {
+    display: none;
+}
+
+.tabs--scrollable .tab {
+    font-family: var(--font-mono);
+    font-size: var(--text-label-sm, 11px);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 10px 14px;
+    color: var(--fg-muted);
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+    white-space: nowrap;
+    background: transparent;
+    flex-shrink: 0;
+}
+
+.tabs--scrollable .tab:hover {
+    color: var(--fg-black);
+}
+
+.tabs--scrollable .tab.active {
+    color: var(--fg-black);
+    border-bottom-color: var(--fg-black);
+    background: transparent;
+}
+
+/* Suppress the base .tab::after underline inside scrollable variant —
+   it conflicts with the border-bottom indicator above. */
+.tabs--scrollable .tab::after {
+    display: none;
+}
+
 .tooltip-container {
     position: relative;
     display: inline-block;
@@ -1235,7 +1280,9 @@ input[type="submit"],
 
 .tooltip {
     position: absolute;
-    left: 50%;
+    /* Default center; overridden by --tooltip-shift-x (px) from JS when the
+       tooltip would overflow the viewport left/right edge. */
+    left: calc(50% + var(--tooltip-shift-x, 0px));
     transform: translateX(-50%);
     background: var(--fg-black);
     color: var(--bg-paper);
@@ -1244,13 +1291,13 @@ input[type="submit"],
     font-size: var(--text-label);
     letter-spacing: 0.05em;
     white-space: normal;
-    max-width: 250px;
+    max-width: min(250px, calc(100vw - 16px));
     word-wrap: break-word;
     text-align: center;
     opacity: 0;
     visibility: hidden;
     transition: opacity var(--anima-duration-normal) var(--anima-ease-paper), visibility var(--anima-duration-normal) var(--anima-ease-paper);
-    z-index: 50;
+    z-index: 100;
     /* Prevent invisible tooltip from intercepting pointer events */
     pointer-events: none;
 }
@@ -1259,11 +1306,13 @@ input[type="submit"],
     bottom: calc(100% + 8px);
 }
 
+/* Arrow follows the trigger center, shifted along with the tooltip body via
+   --tooltip-shift-x so it stays visually connected. */
 .tooltip--top::after {
     content: "";
     position: absolute;
     top: 100%;
-    left: 50%;
+    left: calc(50% - var(--tooltip-shift-x, 0px));
     transform: translateX(-50%);
     border: 6px solid transparent;
     border-top-color: var(--fg-black);
@@ -1277,7 +1326,7 @@ input[type="submit"],
     content: "";
     position: absolute;
     bottom: 100%;
-    left: 50%;
+    left: calc(50% - var(--tooltip-shift-x, 0px));
     transform: translateX(-50%);
     border: 6px solid transparent;
     border-bottom-color: var(--fg-black);
@@ -1557,12 +1606,13 @@ input[type="submit"],
     bottom: 0;
     left: 0;
     right: 0;
-    /* Full height INCLUDING the safe-area inset so the bar fills the space
-       above the home indicator on notched iPhones (viewport-fit=cover).
-       Previously height was a flat 72px and padding-bottom ate into it,
-       leaving icons crushed and a gap below the bar. */
+    /* Full height INCLUDING the safe-area inset so the bar background fills
+       the space above the home indicator on notched iPhones. Rather than
+       padding the entire safe-area away (which left a huge empty gap below
+       the icons), we use a fraction of it — buttons extend into the lower
+       zone, leaving just enough room for the home indicator line. */
     height: calc(72px + env(safe-area-inset-bottom, 0px));
-    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-bottom: calc(env(safe-area-inset-bottom, 0px) * 0.35);
     background: var(--bg-cream);
     border-top: 1px solid var(--border-dark);
     display: flex;
@@ -1835,7 +1885,9 @@ rt {
 
 .kanji-popup {
     position: absolute;
-    left: 0;
+    /* Center under the kanji char instead of left:0 so it doesn't
+       systematically overflow the right viewport edge on mobile. */
+    left: 50%;
     top: 100%;
     min-width: 120px;
     max-width: min(240px, calc(100vw - 32px));
@@ -1843,7 +1895,8 @@ rt {
     margin-top: 4px;
     background: var(--bg-paper);
     border: 1px solid var(--border-dark);
-    z-index: 50;
+    z-index: 100;
+    transform: translateX(-50%);
 }
 
 .kanji-popup::after {
@@ -4776,6 +4829,23 @@ rt {
     border: 1px solid var(--border-dark);
     padding: 24px;
     position: relative;
+}
+
+/* On mobile the section cards are already inside the lesson card (which has
+   its own border + shadow). The nested border + ::after shadow create
+   visually heavy double-framing that eats horizontal space on a narrow
+   phone. Strip the frame down to just a title-divider so content gets
+   maximum useful width. */
+@media (max-width: 639px) {
+    .grammar-detail-section-card {
+        border: none;
+        padding: 0 2px;
+        background: transparent;
+    }
+
+    .grammar-detail-section-card::after {
+        display: none;
+    }
 }
 
 .grammar-detail-section-card::after {

--- a/origa_ui/src/pages/home/welcome_card.rs
+++ b/origa_ui/src/pages/home/welcome_card.rs
@@ -70,7 +70,7 @@ pub fn WelcomeCard(
     });
 
     view! {
-        <div class="py-6 sm:py-8" data-testid=test_id_val>
+        <div class="py-4 sm:py-6" data-testid=test_id_val>
             <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                 <div class="font-serif text-2xl sm:text-3xl text-[var(--fg-black)]">
                     {move || greeting.get()} ", "
@@ -81,7 +81,7 @@ pub fn WelcomeCard(
                 <div class="shrink-0">
                     <A href="/lesson">
                         <button
-                            class="btn btn-olive flex items-center justify-center gap-2 w-full sm:w-auto sm:min-w-[280px] px-6 py-1 sm:px-10 sm:py-1.5"
+                            class="btn btn-olive flex items-center justify-center gap-2 w-full sm:w-auto sm:min-w-[280px] px-6 py-3 sm:px-10 sm:py-2.5"
                             data-testid=move || Some(lesson_test_id.get())
                         >
                             <Icon icon=icondata::LuBookOpen width="16" height="16" />

--- a/origa_ui/src/pages/lesson/content.rs
+++ b/origa_ui/src/pages/lesson/content.rs
@@ -277,7 +277,7 @@ pub fn LessonContent() -> impl IntoView {
         </Show>
 
         <Show when=move || !is_loading.get() && !is_completed.get() && error_message.get().is_none()>
-            <div data-testid="lesson-content" class="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col p-4 sm:p-6">
+            <div data-testid="lesson-content" class="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col px-1 sm:px-2 py-1 sm:py-2">
                 <Show when=move || is_syncing_cards.get()>
                     <div data-testid="lesson-sync-indicator" class="absolute top-0 right-0 flex items-center gap-1 text-sm text-muted-foreground p-2">
                         <Spinner test_id="lesson-sync-spinner" class=Signal::derive(|| "".to_string()) size=Signal::derive(|| "sm".to_string()) />

--- a/origa_ui/src/pages/lesson/lesson_card.rs
+++ b/origa_ui/src/pages/lesson/lesson_card.rs
@@ -17,7 +17,7 @@ use super::answer_display::extract_card_answer;
 use super::card_type::CardType;
 use super::kanji_card_details::RadicalDisplay;
 use super::lesson_card_answer::LessonCardAnswer;
-use super::lesson_card_header::LessonCardHeader;
+use super::lesson_card_header::{LessonCardAudio, LessonCardTags};
 use super::lesson_card_question::LessonCardQuestion;
 use super::lesson_state::LessonContext;
 use crate::repository::cdn_provider::prefetch_blob_url;
@@ -276,52 +276,58 @@ pub fn LessonCard(
     });
 
     view! {
-        <Card class=Signal::derive(|| super::LESSON_CARD_CLASS.to_string()) shadow=true test_id="lesson-card-root">
-            <LessonCardHeader
+        <div class="flex flex-col">
+            <LessonCardTags
                 card_type=card_type
-                question_text=if is_reversed { answer.get_value() } else { display_question.get_value() }
                 grammar_info=grammar_info.clone()
                 show_answer=show_answer
                 card=card.clone()
-                audio_path=audio_path
             />
+            <Card class=Signal::derive(|| super::LESSON_CARD_CLASS.to_string()) shadow=true test_id="lesson-card-root">
+                <LessonCardAudio
+                    card_type=card_type
+                    question_text=if is_reversed { answer.get_value() } else { display_question.get_value() }
+                    is_reversed=is_reversed
+                    audio_path=audio_path
+                />
 
-            <div class="flex-1 flex flex-col justify-center">
-                <Show when=move || !show_answer.get()>
-                    <LessonCardQuestion
-                        question_text=card_question_text.get_value()
-                        kanji=kanji_stored.get_value()
-                        is_reversed=is_reversed
-                        on_show_answer=on_show_answer
-                        known_kanji=known_kanji
-                        native_language=native_language
-                    />
-                </Show>
+                <div class="flex-1 flex flex-col justify-center">
+                    <Show when=move || !show_answer.get()>
+                        <LessonCardQuestion
+                            question_text=card_question_text.get_value()
+                            kanji=kanji_stored.get_value()
+                            is_reversed=is_reversed
+                            on_show_answer=on_show_answer
+                            known_kanji=known_kanji
+                            native_language=native_language
+                        />
+                    </Show>
 
-                <Show when=move || show_answer.get()>
-                    <LessonCardAnswer
-                        question_text=answer_heading.get_value()
-                        answer_text=if is_reversed { question.get_value() } else { answer.get_value() }
-                        answer_translations=answer_translations_stored.get_value()
-                        answer_description=answer_description_stored.get_value()
-                        is_expanded=is_expanded
-                        needs_collapse=needs_collapse
-                        content_ref=content_ref
-                        on_toggle=on_toggle
-                        is_kanji=card_type == CardType::Kanji
-                        is_phrase
-                        is_reversed=is_reversed
-                        on_readings=on_readings_stored.get_value()
-                        kun_readings=kun_readings_stored.get_value()
-                        radicals=radicals_stored.get_value()
-                        example_words=examples_stored.get_value()
-                        grammar_info=grammar_info.clone()
-                        known_kanji=known_kanji
-                        native_language=native_language
-                    />
-                </Show>
-            </div>
-        </Card>
+                    <Show when=move || show_answer.get()>
+                        <LessonCardAnswer
+                            question_text=answer_heading.get_value()
+                            answer_text=if is_reversed { question.get_value() } else { answer.get_value() }
+                            answer_translations=answer_translations_stored.get_value()
+                            answer_description=answer_description_stored.get_value()
+                            is_expanded=is_expanded
+                            needs_collapse=needs_collapse
+                            content_ref=content_ref
+                            on_toggle=on_toggle
+                            is_kanji=card_type == CardType::Kanji
+                            is_phrase
+                            is_reversed=is_reversed
+                            on_readings=on_readings_stored.get_value()
+                            kun_readings=kun_readings_stored.get_value()
+                            radicals=radicals_stored.get_value()
+                            example_words=examples_stored.get_value()
+                            grammar_info=grammar_info.clone()
+                            known_kanji=known_kanji
+                            native_language=native_language
+                        />
+                    </Show>
+                </div>
+            </Card>
+        </div>
     }
 }
 

--- a/origa_ui/src/pages/lesson/lesson_card_answer.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_answer.rs
@@ -87,7 +87,7 @@ pub fn LessonCardAnswer(
 
             <div
                 node_ref=content_ref
-                class=move || if is_expanded.get() { "border-t border-[var(--border-light)] pt-4 mt-4" } else { "border-t border-[var(--border-light)] pt-4 mt-4 line-clamp-3" }
+                class=move || if is_expanded.get() { "border-t border-[var(--border-light)] pt-4 mt-4" } else { "border-t border-[var(--border-light)] pt-4 mt-4 line-clamp-6" }
             >
                 <div class="max-w-max mx-auto space-y-4">
                     <Show
@@ -119,9 +119,9 @@ pub fn LessonCardAnswer(
                         when=move || is_kanji
                         fallback=move || {
                             view! {
-                                <div class="flex gap-4 items-baseline text-left">
-                                    <div class="w-16 shrink-0">
-                                        <Text size=TextSize::Default variant=TypographyVariant::Muted>
+                                <div class="flex flex-col gap-1 text-left">
+                                    <div class="text-[var(--text-label-sm)] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
+                                        <Text size=TextSize::Small variant=TypographyVariant::Muted>
                                             {t!(i18n, lesson.answer)}
                                         </Text>
                                     </div>
@@ -168,6 +168,17 @@ pub fn LessonCardAnswer(
                 </div>
             </div>
 
+            <Show when=move || needs_collapse.get()>
+                <div class="mt-2">
+                    <Button
+                        variant=ButtonVariant::Ghost
+                        on_click=Callback::new(move |_: MouseEvent| on_toggle.run(()))
+                    >
+                        {move || if is_expanded.get() { t!(i18n, common.collapse).into_any() } else { t!(i18n, common.expand).into_any() }}
+                    </Button>
+                </div>
+            </Show>
+
             <Show
                 when=move || grammar_info_stored
                     .get_value()
@@ -190,17 +201,6 @@ pub fn LessonCardAnswer(
                             }
                         })
                 }}
-            </Show>
-
-            <Show when=move || needs_collapse.get()>
-                <div class="mt-2">
-                    <Button
-                        variant=ButtonVariant::Ghost
-                        on_click=Callback::new(move |_: MouseEvent| on_toggle.run(()))
-                    >
-                        {move || if is_expanded.get() { t!(i18n, common.collapse).into_any() } else { t!(i18n, common.expand).into_any() }}
-                    </Button>
-                </div>
             </Show>
         </div>
     }

--- a/origa_ui/src/pages/lesson/lesson_card_header.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_header.rs
@@ -7,14 +7,15 @@ use super::card_type::CardType;
 use super::grammar_info_badge::GrammarInfoBadge;
 use super::pos_label::part_of_speech_label;
 
+/// Tags row rendered ABOVE the card (card type, POS, grammar badge).
+/// Separated from the audio button so tags never compete with it for
+/// horizontal space inside the card.
 #[component]
-pub fn LessonCardHeader(
+pub fn LessonCardTags(
     card_type: CardType,
-    question_text: String,
     grammar_info: Option<GrammarInfo>,
     show_answer: Signal<bool>,
     card: Card,
-    #[prop(into)] audio_path: Option<String>,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let grammar_info = StoredValue::new(grammar_info);
@@ -23,44 +24,63 @@ pub fn LessonCardHeader(
             .map(|p| part_of_speech_label(p, &i18n)),
     );
     view! {
-        <div class="flex items-center justify-between mb-4 gap-2">
-            <div class="flex items-center gap-2 flex-wrap min-w-0">
-                <Tag variant=Signal::derive(move || card_type.tag_variant())>
-                    {card_type.label(&i18n)}
-                </Tag>
-                <Show when=move || pos_label.get_value().is_some()>
-                    {move || {
-                        pos_label
-                            .get_value()
-                            .map(|label| {
-                                view! {
-                                    // POS is secondary metadata (a sub-classification of the
-                                    // Vocabulary card), not a primary category. DESIGN.md
-                                    // assigns the muted Tertiary tier to secondary metadata
-                                    // and reserves coloured Tag variants for distinguishing
-                                    // card TYPES — keep Default here.
-                                    <Tag>
-                                        {label}
-                                    </Tag>
-                                }
-                            })
-                    }}
-                </Show>
-                <Show when=move || show_answer.get() && grammar_info.get_value().is_some()>
-                    {move || {
-                        grammar_info
-                            .get_value()
-                            .map(|info| {
-                                view! {
-                                    <GrammarInfoBadge title=info.title().to_string() />
-                                }
-                            })
-                    }}
-                </Show>
-            </div>
-            <Show when=move || card_type != CardType::Kanji>
-                <AudioButtons text=question_text.clone() audio_path=audio_path.clone() class=Signal::derive(|| "shrink-0".to_string())/>
+        <div class="flex items-center gap-2 flex-wrap min-w-0 mb-2 px-1">
+            <Tag variant=Signal::derive(move || card_type.tag_variant())>
+                {card_type.label(&i18n)}
+            </Tag>
+            <Show when=move || pos_label.get_value().is_some()>
+                {move || {
+                    pos_label
+                        .get_value()
+                        .map(|label| {
+                            view! {
+                                // POS is secondary metadata (a sub-classification of the
+                                // Vocabulary card), not a primary category. DESIGN.md
+                                // assigns the muted Tertiary tier to secondary metadata
+                                // and reserves coloured Tag variants for distinguishing
+                                // card TYPES — keep Default here.
+                                <Tag>
+                                    {label}
+                                </Tag>
+                            }
+                        })
+                }}
+            </Show>
+            <Show when=move || show_answer.get() && grammar_info.get_value().is_some()>
+                {move || {
+                    grammar_info
+                        .get_value()
+                        .map(|info| {
+                            view! {
+                                <GrammarInfoBadge title=info.title().to_string() />
+                            }
+                        })
+                }}
             </Show>
         </div>
+    }
+}
+
+/// Audio button rendered inside the card. Hidden on reversed cards
+/// (playing audio would reveal the answer) and on kanji cards.
+#[component]
+pub fn LessonCardAudio(
+    card_type: CardType,
+    question_text: String,
+    is_reversed: bool,
+    #[prop(into)] audio_path: Option<String>,
+) -> impl IntoView {
+    let text = StoredValue::new(question_text);
+    let path = StoredValue::new(audio_path);
+    view! {
+        <Show when=move || card_type != CardType::Kanji && !is_reversed>
+            <div class="flex justify-center mb-2">
+                <AudioButtons
+                    text=text.get_value()
+                    audio_path=path.get_value()
+                    class=Signal::derive(|| "shrink-0".to_string())
+                />
+            </div>
+        </Show>
     }
 }

--- a/origa_ui/src/pages/lesson/lesson_card_question.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_question.rs
@@ -23,7 +23,17 @@ pub fn LessonCardQuestion(
     view! {
         <div class="text-center">
             <Show when=move || kanji_stored.get_value().is_none()>
-                <div class="mb-2 sm:mb-4 lesson-question">
+                <div class=move || {
+                    if is_reversed {
+                        // Reversed cards show a translation as the prompt —
+                        // often a long phrase. Use the default markdown size
+                        // (no .lesson-question wrapper) so it doesn't get the
+                        // heading-h2 clamp meant for short Japanese words.
+                        "mb-2 sm:mb-4".to_string()
+                    } else {
+                        "mb-2 sm:mb-4 lesson-question".to_string()
+                    }
+                }>
                     <Heading level=HeadingLevel::H2>
                         <Show
                             when=move || is_reversed

--- a/origa_ui/src/pages/words/add_words_preview_modal.rs
+++ b/origa_ui/src/pages/words/add_words_preview_modal.rs
@@ -144,7 +144,7 @@ pub fn AddWordsPreviewModal(
                     match stage {
                         AnalysisStage::Analyzing => view! {
                             <div class="space-y-4">
-                                <Tabs tabs=tabs active=active_tab test_id=Signal::derive(|| "words-add-tabs".to_string()) />
+                                <Tabs tabs=tabs active=active_tab test_id=Signal::derive(|| "words-add-tabs".to_string()) class="tabs--scrollable".to_string() />
                                 <div class="flex items-center justify-center py-8">
                                     <Text size=TextSize::Default variant=TypographyVariant::Muted>
                                         {t!(i18n, words.analyzing)}
@@ -179,7 +179,7 @@ pub fn AddWordsPreviewModal(
                                         None
                                     }
                                 }}
-                                <Tabs tabs=tabs active=active_tab test_id=Signal::derive(|| "words-add-tabs".to_string()) />
+                                <Tabs tabs=tabs active=active_tab test_id=Signal::derive(|| "words-add-tabs".to_string()) class="tabs--scrollable".to_string() />
                                 {move || {
                                     let mode = input_mode.get();
                                     match mode {

--- a/origa_ui/src/pages/words/analyzed_word_item.rs
+++ b/origa_ui/src/pages/words/analyzed_word_item.rs
@@ -1,6 +1,8 @@
 use crate::i18n::{td_string, use_i18n};
 use crate::pages::icons::{CHECK_CIRCLE_ICON, ICON_CLASS_KNOWN, ICON_CLASS_NEW, PLUS_CIRCLE_ICON};
-use crate::ui_components::{Checkbox, FuriganaText, MarkdownText, MarkdownVariant, Tooltip};
+use crate::ui_components::{
+    Checkbox, FuriganaText, MarkdownText, MarkdownVariant, Tooltip, TooltipPlacementMode,
+};
 use leptos::prelude::*;
 use origa::use_cases::AnalyzedWord;
 use std::collections::HashSet;
@@ -52,7 +54,7 @@ pub fn AnalyzedWordItem(
                         />
                     </div>
 
-                        <Tooltip text=Signal::derive(tooltip_text)>
+                        <Tooltip text=Signal::derive(tooltip_text) placement_mode=TooltipPlacementMode::ForceBottom>
                         <span class=format!("{} opacity-60 group-hover:opacity-100 transition-opacity", icon_class)
                               inner_html=status_icon
                         />

--- a/origa_ui/src/ui_components/mod.rs
+++ b/origa_ui/src/ui_components/mod.rs
@@ -118,7 +118,7 @@ pub use text_to_speech::{
     speak_tts_text_with_callback, stop_speech,
 };
 pub use toast::{ToastContainer, ToastData, ToastType};
-pub use tooltip::Tooltip;
+pub use tooltip::{Tooltip, TooltipPlacementMode};
 pub use typography::{DisplayText, Heading, HeadingLevel, Text, TextSize, TypographyVariant};
 pub use update_drawer::UpdateDrawer;
 pub use word_audio::{register_audio, speak_word, speak_word_with_callback, stop_current_audio};

--- a/origa_ui/src/ui_components/multi_line_chart.rs
+++ b/origa_ui/src/ui_components/multi_line_chart.rs
@@ -366,7 +366,7 @@ pub fn MultiLineChart(
             </Show>
 
             // Legend below SVG
-            <div class="flex justify-center gap-5 mt-4">
+            <div class="flex justify-center gap-2 sm:gap-5 mt-4 flex-wrap">
                 <For
                     each=move || legend_items()
                     key=|(key, _, _)| key.clone()
@@ -377,7 +377,7 @@ pub fn MultiLineChart(
                                     class="inline-block"
                                     style=format!("width:12px;height:2px;background-color:{}", color)
                                 ></span>
-                                <span class="font-mono text-[12px] uppercase tracking-[0.1em]" style="color:var(--fg-muted)">
+                                <span class="font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.08em] sm:tracking-[0.1em]" style="color:var(--fg-muted)">
                                     {label}
                                 </span>
                             </div>

--- a/origa_ui/src/ui_components/tooltip.rs
+++ b/origa_ui/src/ui_components/tooltip.rs
@@ -1,5 +1,6 @@
 use leptos::html::Div;
 use leptos::prelude::*;
+use leptos::wasm_bindgen::JsCast;
 
 const VIEWPORT_MARGIN: f64 = 8.0;
 
@@ -8,6 +9,16 @@ pub enum TooltipPlacement {
     #[default]
     Top,
     Bottom,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum TooltipPlacementMode {
+    /// Automatically choose Top/Bottom based on available viewport space.
+    #[default]
+    Auto,
+    /// Force Bottom (e.g. when the trigger is at the top of a list and Top
+    /// would overlap the element above).
+    ForceBottom,
 }
 
 /// Pure placement decision. Prefers Top when there is enough room above
@@ -34,10 +45,46 @@ pub(crate) fn decide_placement(
     }
 }
 
+/// Calculate the horizontal shift (in px) needed so the tooltip body stays
+/// within the viewport. Returns a positive value (shift right) when the
+/// tooltip overflows the left edge, a negative value (shift left) when it
+/// overflows the right edge, or 0 when it fits.
+///
+/// `trigger_left` / `trigger_right` — trigger element viewport coordinates.
+/// `tooltip_width` — measured tooltip width.
+/// `viewport_width` — inner width of the window.
+/// `margin` — minimum pixel gap to keep between tooltip and viewport edge.
+pub(crate) fn decide_shift_x(
+    trigger_left: f64,
+    trigger_right: f64,
+    tooltip_width: f64,
+    viewport_width: f64,
+    margin: f64,
+) -> f64 {
+    // The tooltip is centered above/below the trigger by default
+    // (left: 50%; transform: translateX(-50%)).
+    let trigger_center = (trigger_left + trigger_right) / 2.0;
+    let tooltip_half = tooltip_width / 2.0;
+
+    let tooltip_left = trigger_center - tooltip_half;
+    let tooltip_right = trigger_center + tooltip_half;
+
+    if tooltip_left < margin {
+        // Overflows left edge → shift right
+        margin - tooltip_left
+    } else if tooltip_right > viewport_width - margin {
+        // Overflows right edge → shift left
+        (viewport_width - margin) - tooltip_right
+    } else {
+        0.0
+    }
+}
+
 #[component]
 pub fn Tooltip(
     #[prop(optional, into)] text: Signal<String>,
     #[prop(optional, into)] test_id: Signal<String>,
+    #[prop(optional)] placement_mode: TooltipPlacementMode,
     children: Children,
 ) -> impl IntoView {
     let placement = RwSignal::new(TooltipPlacement::default());
@@ -59,21 +106,56 @@ pub fn Tooltip(
             return;
         };
         let trigger_rect = container.get_bounding_client_rect();
-        let tooltip_height = tooltip_ref
-            .get()
+        let tooltip_el = tooltip_ref.get();
+
+        let tooltip_height = tooltip_el
+            .as_ref()
             .map(|el| el.get_bounding_client_rect().height())
             .unwrap_or(40.0);
+        let tooltip_width = tooltip_el
+            .as_ref()
+            .map(|el| el.get_bounding_client_rect().width())
+            .unwrap_or(120.0);
+
         let viewport_height = window()
             .inner_height()
             .ok()
             .and_then(|v| v.as_f64())
             .unwrap_or(800.0);
-        placement.set(decide_placement(
-            trigger_rect.top(),
-            viewport_height,
-            tooltip_height,
+        let viewport_width = window()
+            .inner_width()
+            .ok()
+            .and_then(|v| v.as_f64())
+            .unwrap_or(400.0);
+
+        // Y-axis: Top vs Bottom
+        let resolved_placement = match placement_mode {
+            TooltipPlacementMode::Auto => decide_placement(
+                trigger_rect.top(),
+                viewport_height,
+                tooltip_height,
+                VIEWPORT_MARGIN,
+            ),
+            TooltipPlacementMode::ForceBottom => TooltipPlacement::Bottom,
+        };
+        placement.set(resolved_placement);
+
+        // X-axis: keep tooltip within viewport horizontally
+        let shift_x = decide_shift_x(
+            trigger_rect.left(),
+            trigger_rect.right(),
+            tooltip_width,
+            viewport_width,
             VIEWPORT_MARGIN,
-        ));
+        );
+
+        // Apply shift via CSS variable consumed by .tooltip / .tooltip::after
+        if let Some(el) = &tooltip_el {
+            let html_el: &web_sys::HtmlElement = el.unchecked_ref();
+            let _ = html_el
+                .style()
+                .set_property("--tooltip-shift-x", &format!("{shift_x}px"));
+        }
     };
 
     view! {
@@ -135,5 +217,37 @@ mod tests {
             decide_placement(10.0, 60.0, 100.0, 8.0),
             TooltipPlacement::Bottom,
         );
+    }
+
+    // --- decide_shift_x tests ---
+
+    #[test]
+    fn shift_x_centered_trigger_returns_zero() {
+        // Trigger centered in 400px viewport, tooltip 120px → fits easily
+        assert_eq!(decide_shift_x(170.0, 230.0, 120.0, 400.0, 8.0), 0.0);
+    }
+
+    #[test]
+    fn shift_x_trigger_near_left_edge_shifts_right() {
+        // Trigger at left edge (left=0, right=40, center=20).
+        // Tooltip half=60, tooltip_left = 20-60 = -40 → overflow.
+        // shift = margin - tooltip_left = 8 - (-40) = 48
+        assert_eq!(decide_shift_x(0.0, 40.0, 120.0, 400.0, 8.0), 48.0);
+    }
+
+    #[test]
+    fn shift_x_trigger_near_right_edge_shifts_left() {
+        // Trigger at right edge (left=360, right=400, center=380).
+        // Tooltip half=60, tooltip_right = 380+60 = 440 → overflow.
+        // shift = (400-8) - 440 = -48
+        assert_eq!(decide_shift_x(360.0, 400.0, 120.0, 400.0, 8.0), -48.0);
+    }
+
+    #[test]
+    fn shift_x_trigger_in_corner_shifts_correctly() {
+        // Trigger in top-left corner: left=2, right=30, center=16
+        // Tooltip 200px wide: tooltip_left = 16-100 = -84
+        // shift = 8 - (-84) = 92
+        assert_eq!(decide_shift_x(2.0, 30.0, 200.0, 400.0, 8.0), 92.0);
     }
 }


### PR DESCRIPTION
## Summary

Batch fix for 13 mobile UI bugs reported on vertical phone screens (iPhone/Android).

## Changes

### Layout & Spacing
- **Lesson card X-padding**: reduced from `p-4 sm:p-6` to `px-1 sm:px-2 py-1 sm:py-2` — card uses maximum horizontal width
- **Bottom tab bar**: safe-area padding reduced from 100% to 35% — buttons fill the gap above home indicator instead of leaving empty space
- **Welcome card**: lesson button height increased (`py-3`), spacing reduced (`py-4`)

### Tooltip & Popover
- **Viewport-aware positioning**: new `decide_shift_x()` function calculates horizontal shift to keep tooltip within viewport; arrow follows via `--tooltip-shift-x` CSS variable
- **ForceBottom placement**: new `TooltipPlacementMode` prop (used in AnalyzedWordItem to avoid overlap with 'Found N words' header)
- **Z-index**: 50→100 for tooltip and kanji-popup
- **Kanji popup**: centered under char (`left: 50%`) instead of `left: 0`; viewport-clamped max-width

### Lesson Card
- **Tags moved above card**: `LessonCardHeader` split into `LessonCardTags` (rendered above Card) + `LessonCardAudio` (inside Card)
- **Audio hidden on reversed cards**: prevents answer hint
- **Reversed card font**: removed `.lesson-question` wrapper for reversed cards — translation text uses default markdown size instead of heading-h2 clamp (36px→18px)
- **Answer label**: `flex gap-4 items-baseline` → `flex-col` (label above content, full width)
- **Line clamp**: 3→6 lines before collapse trigger
- **Grammar mutated card**: reordered — Expand button first, Grammar details second

### Other
- **Add Words tabs**: scrollable variant (`.tabs--scrollable`) for 4 input-mode tabs
- **Activity chart legend**: `gap-5` → `gap-2 sm:gap-5` + `flex-wrap`
- **Grammar detail section**: inner border/shadow stripped on mobile (`@media max-width:639px`)

## Tests
- `cargo clippy -p origa_ui --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test -p origa_ui` — 329 passed, 0 failed ✅
- 4 new unit tests for `decide_shift_x()` edge cases

## Review notes
- Kanji popup uses CSS-only centering (no JS shift). For full viewport-aware logic like tooltip, a follow-up with JS measurement in `furigana_hover.rs` would be needed.
- Tooltip repositioning on scroll is not implemented (low priority — tooltips are short-lived on hover/tap).