### PR TITLE
fix: stop auto-opening DevTools on release + gate full CI to tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
     pull_request:
         branches: [master]
     push:
-        branches: [master]
-        paths-ignore: ["docs/**", "*.md", "scripts/**", "cdn/**"]
+        tags:
+            - "v*.*.*"
     workflow_dispatch:
 
 concurrency:

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -191,12 +191,12 @@ pub fn run() {
 
             tracing::info!("[deep-link] setup complete");
 
+            // release-devtools feature enables the DevTools panel (F12 /
+            // right-click → Inspect) but does NOT auto-open it. Opening the
+            // panel at startup was annoying users on every launch.
             #[cfg(feature = "release-devtools")]
             {
-                if let Some(window) = app.get_webview_window("main") {
-                    window.open_devtools();
-                    tracing::info!("[devtools] DevTools opened (release-devtools feature enabled)");
-                }
+                tracing::info!("[devtools] DevTools available (F12 / right-click → Inspect)");
             }
 
             Ok(())


### PR DESCRIPTION
## Summary

Two fixes:

### 1. DevTools auto-open on release builds
The `release-devtools` feature (in `default`) enabled `tauri/devtools` **and** auto-opened the DevTools window via `window.open_devtools()` on every startup. Users on release builds saw the inspector panel pop up on each launch.

**Fix:** The feature now enables the DevTools panel (F12 / right-click → Inspect) without auto-opening it.

### 2. Full CI on every master push
Full CI (lint + test + e2e + docker + tauri build) was running on every push to `master`, consuming runner minutes on routine merges.

**Fix:** Changed the `push` trigger from `branches: [master]` to `tags: [v*.*.*]`. Full pipeline now fires only on release and RC tags. PRs to master still run full CI as a pre-merge gate.

## Test Plan
- [x] `cargo check -p origa-app` passes
- [x] `cargo clippy -p origa-app --all-targets -- -D warnings` passes
- [x] `cargo fmt --check --all` passes