### PR TITLE
fix(ui): remove nested lesson scroll container — page scroll only

### DIFF
--- a/origa_ui/src/pages/lesson/content.rs
+++ b/origa_ui/src/pages/lesson/content.rs
@@ -277,7 +277,10 @@ pub fn LessonContent() -> impl IntoView {
         </Show>
 
         <Show when=move || !is_loading.get() && !is_completed.get() && error_message.get().is_none()>
-            <div data-testid="lesson-content" class="relative flex-1 min-h-0 overflow-y-scroll overflow-x-hidden block px-0.5 sm:px-1 py-1 sm:py-2 overscroll-contain" style="-webkit-overflow-scrolling: touch;">
+            // No nested scroll container here — the whole page scrolls.
+            // A separate scroll layer over the lesson zone used to fight the
+            // page scroll on mobile (jitter + snap-back) and was removed.
+            <div data-testid="lesson-content" class="relative px-0.5 sm:px-1 py-1 sm:py-2">
                 <Show when=move || is_syncing_cards.get()>
                     <div data-testid="lesson-sync-indicator" class="absolute top-0 right-0 flex items-center gap-1 text-sm text-muted-foreground p-2">
                         <Spinner test_id="lesson-sync-spinner" class=Signal::derive(|| "".to_string()) size=Signal::derive(|| "sm".to_string()) />


### PR DESCRIPTION
## Root cause (finally confirmed on desktop)

The lesson zone (card + tags header + space below card) had its own `overflow-y` scroll layer separate from the main page scroll. Two competing scroll containers caused:

- **Mobile**: jittery scroll with position snap-back (the nested layer recaptured touch gestures)
- **Desktop**: the inner scrollbar appeared and didn't work

## Fix

Removed the nested scroll entirely (`content.rs`): the lesson content div is now a plain block — the whole page scrolls via the global scroll, same as every other screen.

- `min-h-[60svh]` on the card keeps its height
- `grow` on the card becomes inert (no flex parent) — harmless

## Tests
- `cargo clippy -p origa_ui --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test -p origa_ui` — 329 passed, 0 failed ✅