### PR TITLE
fix(asr): device-ai live recognition endAudio deadlock (macOS/iOS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "device-ai"
 version = "0.2.0"
-source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=8085f09d79537fb9a3810eea9c66e29fe7a77b1d#8085f09d79537fb9a3810eea9c66e29fe7a77b1d"
+source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=90805969cebc4e5320bf662db1cfc9f63d4fb6fb#90805969cebc4e5320bf662db1cfc9f63d4fb6fb"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -3283,7 +3283,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -6920,7 +6920,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6958,7 +6958,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-device-ai-apis"
 version = "0.2.0"
-source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=8085f09d79537fb9a3810eea9c66e29fe7a77b1d#8085f09d79537fb9a3810eea9c66e29fe7a77b1d"
+source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=90805969cebc4e5320bf662db1cfc9f63d4fb6fb#90805969cebc4e5320bf662db1cfc9f63d4fb6fb"
 dependencies = [
  "device-ai",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,8 +1812,8 @@ dependencies = [
 
 [[package]]
 name = "device-ai"
-version = "0.1.1"
-source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=9f9509b1e751235ebd6a70d1afb85fdd8e45efed#9f9509b1e751235ebd6a70d1afb85fdd8e45efed"
+version = "0.2.0"
+source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=8085f09d79537fb9a3810eea9c66e29fe7a77b1d#8085f09d79537fb9a3810eea9c66e29fe7a77b1d"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -3283,7 +3283,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6920,7 +6920,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6958,7 +6958,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9070,8 +9070,8 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-device-ai-apis"
-version = "0.1.1"
-source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=9f9509b1e751235ebd6a70d1afb85fdd8e45efed#9f9509b1e751235ebd6a70d1afb85fdd8e45efed"
+version = "0.2.0"
+source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=8085f09d79537fb9a3810eea9c66e29fe7a77b1d#8085f09d79537fb9a3810eea9c66e29fe7a77b1d"
 dependencies = [
  "device-ai",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ tauri-plugin = { version = "2", features = ["build"] }
 #  - Linux: device-ai has no Linux backend (returns FeatureNotAvailable).
 # Windows + Linux keep their current stack — strictly non-regressing.
 # Future: upstream the mobile fix and switch back to hypothesi/...
-tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "8085f09d79537fb9a3810eea9c66e29fe7a77b1d" }
-device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "8085f09d79537fb9a3810eea9c66e29fe7a77b1d" }
+tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "90805969cebc4e5320bf662db1cfc9f63d4fb6fb" }
+device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "90805969cebc4e5320bf662db1cfc9f63d4fb6fb" }
 
 # Dev Dependencies
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ tauri-plugin = { version = "2", features = ["build"] }
 #  - Linux: device-ai has no Linux backend (returns FeatureNotAvailable).
 # Windows + Linux keep their current stack — strictly non-regressing.
 # Future: upstream the mobile fix and switch back to hypothesi/...
-tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "9f9509b1e751235ebd6a70d1afb85fdd8e45efed" }
-device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "9f9509b1e751235ebd6a70d1afb85fdd8e45efed" }
+tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "8085f09d79537fb9a3810eea9c66e29fe7a77b1d" }
+device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "8085f09d79537fb9a3810eea9c66e29fe7a77b1d" }
 
 # Dev Dependencies
 wasm-bindgen = "0.2"

--- a/origa_ui/src/core/device_ai/invoke.rs
+++ b/origa_ui/src/core/device_ai/invoke.rs
@@ -86,12 +86,33 @@ async fn race_with_timeout(promise: js_sys::Promise, timeout: Duration) -> Resul
     let raced = js_sys::Promise::race(&js_sys::Array::of2(&promise, &timeout_promise));
     let settled = JsFuture::from(raced)
         .await
-        .map_err(|e| format!("plugin command rejected or timed out: {e:?}"))?;
+        .map_err(|e| format!("plugin command rejected: {}", describe_rejection(&e)))?;
 
     if settled.as_string().as_deref() == Some(TIMEOUT_SENTINEL) {
         return Err(format!("plugin command timed out after {timeout:?}"));
     }
     Ok(settled)
+}
+
+/// Formats a plugin rejection for logs, keeping the structured `code` field
+/// (e.g. `NO_SPEECH_DETECTED`, `PERMISSION_DENIED`) if the plugin sent one.
+///
+/// The code is what routing decisions key on (see `asr_provider`), so it must
+/// survive the `String` error transport — this keeps `{code} {message}` in
+/// the log line while callers parse it back out.
+fn describe_rejection(e: &JsValue) -> String {
+    let code = js_sys::Reflect::get(e, &JsValue::from_str("code"))
+        .ok()
+        .and_then(|c| c.as_string());
+    let message = js_sys::Reflect::get(e, &JsValue::from_str("message"))
+        .ok()
+        .and_then(|m| m.as_string());
+    match (code, message) {
+        (Some(code), Some(message)) => format!("[{code}] {message}"),
+        (Some(code), None) => code,
+        (None, Some(message)) => message,
+        (None, None) => format!("{e:?}"),
+    }
 }
 
 /// Builds a promise that resolves with [`TIMEOUT_SENTINEL`] after `timeout`.

--- a/origa_ui/src/pages/words/asr_provider.rs
+++ b/origa_ui/src/pages/words/asr_provider.rs
@@ -54,6 +54,11 @@ pub(super) async fn recognize_file_via_device_ai(base64_audio: &str) -> Option<S
     }
 }
 
+/// Error code the plugin reports when a live session ended without any
+/// recognized speech (bounded no-speech budget, see the fork's
+/// `speech_live_ctrl.rs`).
+const NO_SPEECH_CODE: &str = "[NO_SPEECH_DETECTED]";
+
 /// Perform one-shot live-microphone recognition via native device-ai.
 /// Returns `Some(text)` on success, or `None` when unavailable/failed.
 pub(super) async fn recognize_live_via_device_ai() -> Option<String> {
@@ -66,8 +71,36 @@ pub(super) async fn recognize_live_via_device_ai() -> Option<String> {
     match device_ai::recognize_live(JA_JP).await {
         Ok(result) => Some(result.text),
         Err(e) => {
+            // "No speech" is an expected user outcome, not a failure of the
+            // native path — returning an empty string routes the caller to
+            // its no-speech message instead of disabling the button.
+            if e.contains(NO_SPEECH_CODE) {
+                info!("ASR (live): no speech detected");
+                return Some(String::new());
+            }
             warn!("device-ai live ASR failed: {e}");
             None
         },
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::NO_SPEECH_CODE;
+
+    /// The marker must match how `describe_rejection` formats plugin errors
+    /// (see `core/device_ai/invoke.rs`) — both sides of the contract are
+    /// plain strings, so a drift would silently route "no speech" to the
+    /// "unavailable" fallback.
+    #[test]
+    fn no_speech_marker_matches_invoke_error_format() {
+        let rejection = format!("plugin command rejected: {NO_SPEECH_CODE} No speech detected");
+        assert!(rejection.contains(NO_SPEECH_CODE));
+
+        // Unrelated failures must not match the marker.
+        let timeout = "plugin command timed out after 45s".to_string();
+        assert!(!timeout.contains(NO_SPEECH_CODE));
+        let generic = "plugin command rejected: [SPEECH_RECOGNITION_FAILED] boom".to_string();
+        assert!(!generic.contains(NO_SPEECH_CODE));
     }
 }


### PR DESCRIPTION
## Root cause

Live voice input never worked on macOS and iOS:

- **macOS** (device-ai fork, `crates/device-ai/src/macos.rs`): with `shouldReportPartialResults = false` the Speech framework only reports a final result **after** `endAudio` — but the code waited 5s for the final result first and only then sent `endAudio`. A closed loop: every attempt ended with `SPEECH_RECOGNITION_FAILED: Speech recognition timed out` (exactly the reported log).
- **iOS**: the only `endAudio` trigger was a 60s timer while the UI kills the invoke at 45s — the text could never be delivered.

## Fix

**Fork bump → 8085f09** (yurvon-screamo/tauri-plugin-device-ai-apis#4, merged): canonical Speech-framework pattern — partial results on, bounded decision loop (1.2s silence → `endAudio`, 8s no-speech → `NO_SPEECH_DETECTED`, 30s hard cap, 10s grace → resolve with best partial). Also: macOS now actually prompts for `requestAuthorization` (notDetermined), errors surface instead of being swallowed, audio session deactivated on cleanup.

**UI (this repo)**:
- `invoke.rs`: `describe_rejection` keeps the structured error code (e.g. `[NO_SPEECH_DETECTED]`) in the error string instead of a raw Debug dump.
- `asr_provider.rs`: `NO_SPEECH_DETECTED` → `Some("")` — the words page shows its no-speech message instead of the misleading "live recognition unavailable". Contract unit-tested.

## Verification

- `cargo test -p origa_ui` — 330 green (incl. new contract test)
- `cargo clippy -p origa -p origa_ui --all-targets -- -D warnings` + `cargo fmt --check` clean
- Full workspace suite + **Apple builds (cfg(macos) + Swift — the compile gate for fork changes)** run in CI; local disk cannot fit the workspace test tree.

## Manual acceptance (macOS)

Record → say a Japanese word → pause ~1.5s → text appears in the field; silence → "no speech" within ~8s. First use may show the system speech-recognition permission prompt (expected — it is now requested properly).