### PR TITLE
fix(asr): device-ai fork bump — macOS live-speech compile fix (017bf58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "device-ai"
 version = "0.2.0"
-source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=90805969cebc4e5320bf662db1cfc9f63d4fb6fb#90805969cebc4e5320bf662db1cfc9f63d4fb6fb"
+source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=017bf58fac4b4c303fd5f9c9d1d3a812133213c1#017bf58fac4b4c303fd5f9c9d1d3a812133213c1"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -3283,7 +3283,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6920,7 +6920,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6958,7 +6958,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-device-ai-apis"
 version = "0.2.0"
-source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=90805969cebc4e5320bf662db1cfc9f63d4fb6fb#90805969cebc4e5320bf662db1cfc9f63d4fb6fb"
+source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=017bf58fac4b4c303fd5f9c9d1d3a812133213c1#017bf58fac4b4c303fd5f9c9d1d3a812133213c1"
 dependencies = [
  "device-ai",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ tauri-plugin = { version = "2", features = ["build"] }
 #  - Linux: device-ai has no Linux backend (returns FeatureNotAvailable).
 # Windows + Linux keep their current stack — strictly non-regressing.
 # Future: upstream the mobile fix and switch back to hypothesi/...
-tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "90805969cebc4e5320bf662db1cfc9f63d4fb6fb" }
-device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "90805969cebc4e5320bf662db1cfc9f63d4fb6fb" }
+tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "017bf58fac4b4c303fd5f9c9d1d3a812133213c1" }
+device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "017bf58fac4b4c303fd5f9c9d1d3a812133213c1" }
 
 # Dev Dependencies
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Follow-up to #401. The first Apple CI build (v0.5.7-rc1 tag) exposed two compile errors in the fork's macOS live-recognition rewrite: a function-scoped `speech_live_ctrl` import (E0433) and an invalid `.copied()` on `MutexGuard<Option<isize>>` (E0599). Fixed in fork PR #6; this re-points the pins.

After merge I will tag v0.5.7-rc2 — Apple builds (macOS universal + iOS) are the compile gate.