### PR TITLE
chore: device-ai fork pin → 8b5765f (cross-platform CI in the fork)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "device-ai"
 version = "0.2.0"
-source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=017bf58fac4b4c303fd5f9c9d1d3a812133213c1#017bf58fac4b4c303fd5f9c9d1d3a812133213c1"
+source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=8b5765fa068123a40060345549fd6028ee80c624#8b5765fa068123a40060345549fd6028ee80c624"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -3283,7 +3283,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -6920,7 +6920,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6958,7 +6958,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-device-ai-apis"
 version = "0.2.0"
-source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=017bf58fac4b4c303fd5f9c9d1d3a812133213c1#017bf58fac4b4c303fd5f9c9d1d3a812133213c1"
+source = "git+https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis?rev=8b5765fa068123a40060345549fd6028ee80c624#8b5765fa068123a40060345549fd6028ee80c624"
 dependencies = [
  "device-ai",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ tauri-plugin = { version = "2", features = ["build"] }
 #  - Linux: device-ai has no Linux backend (returns FeatureNotAvailable).
 # Windows + Linux keep their current stack — strictly non-regressing.
 # Future: upstream the mobile fix and switch back to hypothesi/...
-tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "017bf58fac4b4c303fd5f9c9d1d3a812133213c1" }
-device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "017bf58fac4b4c303fd5f9c9d1d3a812133213c1" }
+tauri-plugin-device-ai-apis = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "8b5765fa068123a40060345549fd6028ee80c624" }
+device-ai = { git = "https://github.com/yurvon-screamo/tauri-plugin-device-ai-apis", rev = "8b5765fa068123a40060345549fd6028ee80c624" }
 
 # Dev Dependencies
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Fork PR #7 adds `build-platforms.yml` — cross-platform compile gates that would have caught the PR #5 (Kotlin) and PR #6 (macOS) breakages before merge:

- rust-desktop: cargo check on ubuntu/windows/macos (macos compiles cfg(macos) objc/Speech)
- rust-mobile-check: cargo check aarch64-linux-android
- android-example: example APK build — compiles DeviceAiPlugin.kt
- ios-example: example simulator build — compiles DeviceAiPlugin.swift

Fixes found along the way (all fork-side): SPM manifest swift-tools 5.5 + .iOS(.v15) (barcode symbologies), example app bundle id / tauri version alignment / package-lock sync.

No Origa runtime changes: the Swift source compiles inside Origa's own Xcode project (green Apple builds on v0.5.7-rc2 prove it). This pin bump just keeps fork main == pin so CI gating applies to the code Origa actually builds.