### PR TITLE
fix(quiz): error label on wrong yes/no answer + leading punctuation in options wrap

### DIFF
--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -2123,6 +2123,19 @@ rt {
     min-width: 0;
 }
 
+/* Quiz option texts: Chromium's emergency break (word-break: break-word)
+   ignores kinsoku (UAX #14 LB13), letting a wrapped line start with "," ";"
+   "!" "、". The .markdown-no-break span (emitted by glue_trailing_punctuation)
+   glues a word char to its trailing punctuation; the explicit resets are
+   required because the parent's eager breakers are inherited and would
+   re-enable breaking inside the span. Verified: leading-punct cases
+   13 → 0, overflow 0 → 0 (Playwright matrix, widths 100–200px). */
+.markdown-text .markdown-no-break {
+    white-space: nowrap;
+    word-break: normal;
+    overflow-wrap: normal;
+}
+
 .markdown-text h1,
 .markdown-text h2,
 .markdown-text h3,

--- a/origa_ui/src/pages/lesson/quiz_options.rs
+++ b/origa_ui/src/pages/lesson/quiz_options.rs
@@ -62,6 +62,7 @@ pub fn QuizOptions(
                                         content=Signal::derive(move || option_text.clone())
                                         variant=MarkdownVariant::Default
                                         known_kanji=known_kanji.get()
+                                        glue_punctuation=true
                                     />
                                 </Text>
                                 <Show when=move || !show_result.get()>

--- a/origa_ui/src/pages/lesson/quiz_options_multi.rs
+++ b/origa_ui/src/pages/lesson/quiz_options_multi.rs
@@ -146,6 +146,7 @@ fn MultiOptionButton(
                         content=Signal::derive(move || option_text.clone())
                         variant=MarkdownVariant::Default
                         known_kanji=known_kanji.get()
+                        glue_punctuation=true
                     />
                 </Text>
                 <Show when=move || multi_submitted.get() && tag_stored.get_value().is_some()>

--- a/origa_ui/src/pages/lesson/yesno_card_view.rs
+++ b/origa_ui/src/pages/lesson/yesno_card_view.rs
@@ -13,6 +13,7 @@ use super::card_type::CardType;
 use super::lesson_card_header::{CardHeaderAudio, LessonCardTagsQuiz};
 use super::next_card_button::NextCardButton;
 use super::quiz_result::QuizResult;
+use super::quiz_result_display::QuizResultDisplay;
 
 #[derive(Clone, Copy, PartialEq, Default, Debug)]
 pub enum YesNoResult {
@@ -280,32 +281,19 @@ pub fn YesNoCardView(
                 </Show>
 
                 <Show when=move || show_result.get()>
-                    <Show when=move || yesno_result() == YesNoResult::Correct>
-                        <div class="mt-6 text-center">
-                            <Text size=TextSize::Default class="text-[var(--success)] font-bold">
-                                {t!(i18n, lesson.correct)}
-                            </Text>
-                        </div>
-                    </Show>
+                    <QuizResultDisplay quiz_result=QuizResult::from(yesno_result()) />
 
-                    <Show when=move || matches!(yesno_result(), YesNoResult::Incorrect)>
-                        <div class="mt-6 text-center">
-                            <Text size=TextSize::Small variant=TypographyVariant::Muted>
-                                {t!(i18n, lesson.correct_answer)}
-                                <span class="font-semibold">
-                                    {correct_answer_text}
-                                </span>
-                            </Text>
-                        </div>
-                    </Show>
-
-                    <Show when=move || yesno_result() == YesNoResult::DontKnow>
-                        <div class="mt-6 text-center">
-                            <Text size=TextSize::Default class="text-[var(--fg-muted)] font-bold">
-                                {t!(i18n, lesson.dont_know_result)}
-                            </Text>
-                        </div>
-                    </Show>
+                    // Show the correct answer (Да/Нет) on every result —
+                    // as a confirmation when correct and as feedback when
+                    // not, same pattern as the single-quiz card.
+                    <div class="mt-2 text-center">
+                        <Text size=TextSize::Small variant=TypographyVariant::Muted>
+                            {t!(i18n, lesson.correct_answer)}
+                            <span class="font-semibold">
+                                {correct_answer_text}
+                            </span>
+                        </Text>
+                    </div>
                 </Show>
 
                 <Show when=move || {

--- a/origa_ui/src/ui_components/markdown.rs
+++ b/origa_ui/src/ui_components/markdown.rs
@@ -15,6 +15,103 @@ pub enum MarkdownVariant {
     Large,
 }
 
+/// Terminal punctuation that must never start a visual line. Chromium's
+/// emergency word-break ignores kinsoku rules (UAX #14 LB13), so a wrapped
+/// line can start with "," / ";" / "!" / "、" — gluing is required.
+const TRAILING_PUNCT: &str = "、。，．，．；：！？;:,.!?…»」』）)]";
+
+/// Wraps every [word char + trailing punctuation run] cluster in a
+/// `<span class="markdown-no-break">` so the browser treats it as an
+/// unbreakable unit. The class resets the inherited eager breakers
+/// (`word-break`/`overflow-wrap`) inside the span — without that reset the
+/// parent `.markdown-text` styles re-enable breaking inside the span and
+/// the glue is ineffective.
+///
+/// Operates on plain text only: tag interiors and HTML entities are copied
+/// verbatim. Clusters split by a tag boundary (e.g. `<em>bold</em>,`) are
+/// not glued — quiz option strings are plain text, verified against
+/// cdn/dictionary data.
+fn glue_trailing_punctuation(html: &str) -> String {
+    let is_anchor = |c: char| c.is_alphanumeric();
+    let is_trailing = |c: char| TRAILING_PUNCT.contains(c);
+
+    let mut out = String::with_capacity(html.len());
+    let mut chars = html.char_indices().peekable();
+    let mut in_tag = false;
+
+    while let Some((idx, c)) = chars.next() {
+        if c == '<' {
+            // Idempotency: our own glue spans are copied verbatim so a
+            // second pass does not nest spans.
+            if html[idx..].starts_with("<span class=\"markdown-no-break\">") {
+                if let Some(end) = html[idx..].find("</span>") {
+                    let end = idx + end + "</span>".len();
+                    out.push_str(&html[idx..end]);
+                    // Re-sync the iterator past the copied block.
+                    while let Some(&(pos, _)) = chars.peek() {
+                        if pos >= end {
+                            break;
+                        }
+                        chars.next();
+                    }
+                    continue;
+                }
+            }
+            in_tag = true;
+            out.push(c);
+            continue;
+        }
+        if in_tag {
+            if c == '>' {
+                in_tag = false;
+            }
+            out.push(c);
+            continue;
+        }
+        if c == '&' {
+            // Copy HTML entities (&amp; &lt; &#39; …) verbatim: their ';'
+            // is markup, not glueable punctuation.
+            out.push(c);
+            while let Some(&(_, next)) = chars.peek() {
+                if next.is_ascii_alphanumeric() || next == '#' {
+                    out.push(next);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            if let Some(&(_, ';')) = chars.peek() {
+                out.push(';');
+                chars.next();
+            }
+            continue;
+        }
+        if is_anchor(c) {
+            let mut punct_run = String::new();
+            while let Some(&(_, next)) = chars.peek() {
+                if is_trailing(next) {
+                    punct_run.push(next);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            if punct_run.is_empty() {
+                out.push(c);
+            } else {
+                let anchor = &html[idx..idx + c.len_utf8()];
+                out.push_str("<span class=\"markdown-no-break\">");
+                out.push_str(anchor);
+                out.push_str(&punct_run);
+                out.push_str("</span>");
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 fn render_markdown(content: &str) -> String {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
@@ -94,12 +191,18 @@ pub fn MarkdownText(
     #[prop(optional, into)] variant: Signal<MarkdownVariant>,
     #[prop(optional, into)] class: Signal<String>,
     #[prop(optional, default = true)] furigana: bool,
+    #[prop(optional, default = false)] glue_punctuation: bool,
     #[prop(optional, into)] test_id: Signal<String>,
 ) -> impl IntoView {
     let html_content = Memo::new(move |_| {
         let rendered = render_markdown(&content.get());
-        if furigana {
+        let rendered = if furigana {
             add_furigana_to_html(&rendered, &known_kanji)
+        } else {
+            rendered
+        };
+        if glue_punctuation {
+            glue_trailing_punctuation(&rendered)
         } else {
             rendered
         }
@@ -198,6 +301,62 @@ mod tests {
     fn test_empty_input() {
         let output = render_markdown("");
         assert!(output.is_empty());
+    }
+
+    #[test]
+    fn glue_wraps_letter_with_trailing_punctuation() {
+        let out = glue_trailing_punctuation("стремительный, проворный");
+        assert_eq!(
+            out,
+            "стремительны<span class=\"markdown-no-break\">й,</span> проворный"
+        );
+    }
+
+    #[test]
+    fn glue_wraps_punctuation_runs() {
+        let out = glue_trailing_punctuation("проворный; молниеносный");
+        assert!(out.contains("<span class=\"markdown-no-break\">й;</span>"));
+    }
+
+    #[test]
+    fn glue_handles_japanese_punctuation() {
+        let out = glue_trailing_punctuation("はやい、すばやい");
+        assert!(out.contains("<span class=\"markdown-no-break\">い、</span>"));
+    }
+
+    #[test]
+    fn glue_no_change_without_punctuation() {
+        assert_eq!(glue_trailing_punctuation("просто текст"), "просто текст");
+    }
+
+    #[test]
+    fn glue_preserves_tag_interiors() {
+        let out = glue_trailing_punctuation("<p class=\"x\">слово, второе</p>");
+        assert!(out.starts_with("<p class=\"x\">"));
+        assert!(out.ends_with("</p>"));
+        assert!(out.contains("<span class=\"markdown-no-break\">о,</span>"));
+    }
+
+    #[test]
+    fn glue_preserves_html_entities() {
+        // &amp; must not be treated as an anchor+punct cluster
+        let out = glue_trailing_punctuation("rock &amp; roll, друг");
+        assert!(out.contains("&amp;"));
+        assert!(out.contains("<span class=\"markdown-no-break\">l,</span>"));
+    }
+
+    #[test]
+    fn glue_span_is_idempotent() {
+        let once = glue_trailing_punctuation("быстрый, скорый");
+        let twice = glue_trailing_punctuation(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn glue_does_not_touch_punctuation_alone() {
+        // A punctuation run not preceded by a word char (e.g. after a space
+        // or at string start) is not wrapped: there is nothing to glue to.
+        assert_eq!(glue_trailing_punctuation("..."), "...");
     }
 
     #[test]


### PR DESCRIPTION
## Problems

### 1. YesNo quiz: no red label on a wrong answer

On an incorrect answer the YesNo card showed only a muted "Correct answer: Да/Нет" line — no bold red **Неверно**, unlike the single-quiz card (`quiz_result_display.rs` gives green/red/muted labels there). Bad UX: an error reads as neutral info.

**Fix:** YesNo now reuses `QuizResultDisplay` (same green/red/muted labels as the quiz card) and always shows the correct Да/Нет answer as confirmation — same pattern as the single-quiz card (correct answer is always shown).

### 2. Quiz options wrap with leading punctuation

Option texts like "быстрый, стремительный, проворный" wrapped as:

```
стремительный
, проворный
```

**Root cause:** Chromium's emergency word-break (`word-break: break-word`, deprecated value used by `.markdown-text`) ignores kinsoku rules (UAX #14 LB13) — it breaks right before a trailing comma/semicolon/exclamation, pushing the punctuation to the start of the next line.

**Verification (Playwright pixel-measurement matrix, real DM Mono font, widths 100–200px, RU/EN/JP strings incl. ruby):**

| variant | lines starting with `, ; ! 、` | horizontal overflow |
|---|---|---|
| current CSS | **13** | 0 |
| `word-break: normal` | 0 | up to 25px ❌ |
| `hyphens: auto` (lang=ru) | 0 for RU | fails for EN (static `lang="ru"`, no EN hyphenation dict) |
| **glue span (this PR)** | **0** | **0** ✅ |

CSS-only fixes are impossible: any variant that removes the eager breaker either overflows narrow buttons or is language-dependent. Fix at the data level: `glue_trailing_punctuation()` wraps every `[word char + trailing punct run]` cluster in `<span class="markdown-no-break">` whose CSS resets the inherited eager breakers inside the span. Enabled via the new `glue_punctuation` prop on `MarkdownText`, applied to single (`QuizOptions`) and multi (`QuizOptionsMulti`) quiz options.

11.7% of dictionary translations (the source of Meaning-quiz options) contain `,;:` — the case is common, not exotic.

## Tests

- 8 unit tests for `glue_trailing_punctuation` (wrapping, runs, JP punct, tags, entities, idempotency)
- `cargo test -p origa_ui --lib`: 338 passed
- `cargo clippy -p origa_ui --all-targets -- -D warnings`: clean
- `cargo fmt`: applied
