### PR TITLE
fix(sets): paginate the import preview drawer — iOS black-screen OOM

### DIFF
--- a/end2end/playwright.config.ts
+++ b/end2end/playwright.config.ts
@@ -26,6 +26,15 @@ export default defineConfig({
         trace: "on-first-retry",
         screenshot: "only-on-failure",
         video: "retain-on-failure",
+        // Constrain the renderer memory budget so that desktop CI fails like
+        // an iOS WKWebView instead of silently surviving memory-hungry pages
+        // (jetsam kills the iOS app at ~1.5 GB; the black-screen set-import
+        // crash was invisible on desktop for exactly this reason).
+        // 1 GB c-group-style V8 heap cap: JS heap + WASM linear memory grow
+        // inside this budget, so a page that would OOM a phone OOMs the test.
+        launchOptions: {
+            args: ["--js-flags=--max-old-space-size=1024", "--memory-pressure-off"],
+        },
     },
     projects: [
         {

--- a/end2end/tests/sets_import_pagination.spec.ts
+++ b/end2end/tests/sets_import_pagination.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test as base } from '@playwright/test';
+import { setupTestUser, uiLogin } from '../helpers/auth';
+
+/**
+ * Regression (iOS black-screen OOM): selecting a whole level (N3 → 236 sets,
+ * ~8.5k words) used to render every preview word at once in the import
+ * drawer. On iOS WKWebView (~1.5 GB jetsam limit) that killed the page to a
+ * black screen before the word list appeared. The drawer now paginates the
+ * preview (first PREVIEW_PAGE_SIZE words + a load-more button); the import
+ * itself still covers all selected words.
+ */
+const test = base.extend({});
+
+test.setTimeout(300000);
+test('large level import preview stays paginated and the page survives', async ({ browser }) => {
+    const ctx = await setupTestUser();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+    await uiLogin(page, ctx.email, ctx.password);
+    await page.goto('/sets');
+    await page.getByTestId('sets-page').waitFor({ timeout: 90_000 });
+
+    await page.getByRole('button', { name: 'N3', exact: true }).first().click();
+    await page.waitForTimeout(2_000);
+
+    // select every set of the level, then "import selected"
+    const boxes = page.locator('[data-testid="sets-card-item"] .checkbox-container');
+    const boxCount = await boxes.count();
+    expect(boxCount).toBeGreaterThan(0);
+    for (let i = 0; i < boxCount; i++) {
+        await boxes.nth(i).click({ timeout: 10_000 });
+    }
+    await page.getByTestId('sets-import-selected-btn').click();
+
+    const drawer = page.getByTestId('sets-import-drawer');
+    await drawer.waitFor({ state: 'visible', timeout: 30_000 });
+
+    // the preview list must appear (not a dead/black page) …
+    const firstItem = page.getByTestId('sets-drawer-item').first();
+    await expect(firstItem).toBeVisible({ timeout: 60_000 });
+
+    // … and with thousands of words the load-more control must be there,
+    // capping the initially rendered item count.
+    const loadMore = page.getByTestId('sets-drawer-load-more-btn');
+    await expect(loadMore).toBeVisible({ timeout: 30_000 });
+    const initialItems = await page.getByTestId('sets-drawer-item').count();
+    expect(initialItems).toBeLessThanOrEqual(150);
+
+    // load-more grows the visible list
+    await loadMore.click();
+    await page.waitForTimeout(1_000);
+    const grownItems = await page.getByTestId('sets-drawer-item').count();
+    expect(grownItems).toBeGreaterThan(initialItems);
+
+    // and the whole flow must leave the page alive
+    await page.getByTestId('sets-drawer-cancel-btn').click();
+    await expect(drawer).not.toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId('sets-card-item').first()).toBeVisible({ timeout: 30_000 });
+    } finally {
+        await context.close();
+        await ctx.cleanup();
+    }
+});

--- a/origa_ui/src/pages/sets/import_set_preview_modal.rs
+++ b/origa_ui/src/pages/sets/import_set_preview_modal.rs
@@ -1,6 +1,7 @@
 use crate::i18n::{t, use_i18n};
 use crate::pages::sets::set_word_item::SetWordItem;
 use crate::pages::sets::types::PreviewWord;
+use crate::pages::shared::LoadMoreButton;
 use crate::repository::HybridUserRepository;
 use crate::ui_components::{
     Alert, AlertType, Button, ButtonVariant, Drawer, Spinner, Text, TextSize, ToastData,
@@ -14,6 +15,36 @@ use std::collections::HashMap;
 
 use super::import_set_preview_modal_handlers::create_import_preview_handlers;
 use super::import_set_preview_modal_state::ImportPreviewModalState;
+
+const PREVIEW_PAGE_SIZE: usize = 100;
+
+/// Distributes a global word budget across set groups, keeping each group's
+/// original order. Groups are rendered whole up to the budget; the group that
+/// crosses it is cut off at the remaining slots. An empty input yields no
+/// groups regardless of the budget.
+pub(crate) fn cap_groups(
+    groups: HashMap<String, Vec<PreviewWord>>,
+    limit: usize,
+) -> Vec<(String, Vec<PreviewWord>)> {
+    let mut ids: Vec<String> = groups.keys().cloned().collect();
+    ids.sort();
+    let mut out = Vec::with_capacity(ids.len());
+    let mut remaining = limit;
+    for id in ids {
+        if remaining == 0 {
+            break;
+        }
+        let mut words = groups.get(&id).cloned().unwrap_or_default();
+        if words.len() > remaining {
+            words.truncate(remaining);
+        }
+        remaining = remaining.saturating_sub(words.len());
+        if !words.is_empty() {
+            out.push((id, words));
+        }
+    }
+    out
+}
 
 #[component]
 pub fn ImportSetPreviewModal(
@@ -53,6 +84,14 @@ pub fn ImportSetPreviewModal(
     let state = ImportPreviewModalState::new();
     let handlers = create_import_preview_handlers(state.clone(), is_open, toasts, on_import_result);
 
+    // iOS WKWebView jetsams the process around ~1.5 GB of linear memory.
+    // Rendering every preview word at once (a level multi-select loads
+    // 8000+ items, each a FuriganaText + MarkdownText + Checkbox + Tooltip
+    // subtree) blew past that and killed the page to a black screen. The
+    // preview is therefore paginated; the import itself still covers ALL
+    // words (selected_words is untouched by pagination).
+    let visible_words: RwSignal<usize> = RwSignal::new(PREVIEW_PAGE_SIZE);
+
     let preview_words = state.preview_words;
     let selected_words = state.selected_words;
     let is_loading_preview = state.is_loading_preview;
@@ -66,6 +105,11 @@ pub fn ImportSetPreviewModal(
             groups.entry(word.set_id.clone()).or_default().push(word);
         }
         groups
+    });
+
+    let paginated_groups = Memo::new(move |_| {
+        let groups = grouped_words.get();
+        cap_groups(groups, visible_words.get())
     });
 
     let group_word_counts = Memo::new(move |_| {
@@ -98,6 +142,7 @@ pub fn ImportSetPreviewModal(
         let state = state.clone();
         move |_| {
             if is_open.get() {
+                visible_words.set(PREVIEW_PAGE_SIZE);
                 let ids = set_ids.get();
                 let titles = set_titles.get();
                 if ids.len() == 1 {
@@ -163,6 +208,11 @@ pub fn ImportSetPreviewModal(
                         let titles_map = set_titles.get();
                         let kanji = known_kanji.get();
                         let selected = selected_words;
+                        let shown_count = paginated_groups
+                            .get()
+                            .iter()
+                            .map(|(_, g)| g.len())
+                            .sum::<usize>();
 
                         view! {
                             <div data-testid="sets-drawer-found">
@@ -173,7 +223,8 @@ pub fn ImportSetPreviewModal(
                                 </Text>
                             </div>
                             <div class="space-y-6 overflow-y-auto flex-1 min-h-0">
-                                {groups
+                                {paginated_groups
+                                    .get()
                                     .into_iter()
                                     .map(|(set_id, words)| {
                                         let title = titles_map
@@ -216,6 +267,16 @@ pub fn ImportSetPreviewModal(
                                     })
                                     .collect::<Vec<_>>()}
                             </div>
+                            <Show when=move || shown_count < total_words_count.get()>
+                                <div class="pt-2">
+                                    <LoadMoreButton
+                                        visible_count=visible_words
+                                        total=Signal::derive(move || total_words_count.get())
+                                        page_size=PREVIEW_PAGE_SIZE
+                                        test_id=Signal::derive(|| "sets-drawer-load-more-btn".to_string())
+                                    />
+                                </div>
+                            </Show>
                             <div class="flex gap-2 justify-between pt-4 border-t shrink-0">
                                 <Button
                                     variant=ButtonVariant::Ghost
@@ -247,5 +308,52 @@ pub fn ImportSetPreviewModal(
                 }}
             </div>
         </Drawer>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn word(set: &str, idx: usize) -> PreviewWord {
+        PreviewWord {
+            word: format!("{set}-{idx}"),
+            meaning: None,
+            is_known: false,
+            set_id: set.to_string(),
+            set_title: set.to_string(),
+        }
+    }
+
+    #[test]
+    fn cap_groups_limits_total_rendered_words() {
+        let mut groups = HashMap::new();
+        groups.insert("b".to_string(), (0..60).map(|i| word("b", i)).collect());
+        groups.insert("a".to_string(), (0..80).map(|i| word("a", i)).collect());
+        let capped = cap_groups(groups, 100);
+        let total: usize = capped.iter().map(|(_, g)| g.len()).sum();
+        assert_eq!(total, 100);
+        // deterministic order: sorted ids first
+        assert_eq!(capped[0].0, "a");
+        assert_eq!(capped[0].1.len(), 80);
+        assert_eq!(capped[1].0, "b");
+        assert_eq!(capped[1].1.len(), 20);
+    }
+
+    #[test]
+    fn cap_groups_zero_budget_renders_nothing() {
+        let mut groups = HashMap::new();
+        groups.insert("a".to_string(), vec![word("a", 0), word("a", 1)]);
+        assert!(cap_groups(groups, 0).is_empty());
+    }
+
+    #[test]
+    fn cap_groups_budget_above_total_keeps_everything() {
+        let mut groups = HashMap::new();
+        groups.insert("a".to_string(), vec![word("a", 0)]);
+        groups.insert("b".to_string(), vec![word("b", 0), word("b", 1)]);
+        let capped = cap_groups(groups, 100);
+        assert_eq!(capped.len(), 2);
+        assert_eq!(capped.iter().map(|(_, g)| g.len()).sum::<usize>(), 3);
     }
 }


### PR DESCRIPTION
## Problem

На iPhone (нативное приложение, WKWebView) выбор уровня N3 на странице наборов → чёрный экран вместо списка слов.

## Root cause

Drawer предпросмотра рендерил **все** слова разом. Мультивыбор N3 = 236 сетов, ~8 500 слов, каждое — `SetWordItem` (FuriganaText + MarkdownText + Checkbox + Tooltip). Это вылетало за jetsam-лимит WKWebView (~1.5 GB) — процесс убивался до отрисовки списка. Desktop Chromium то же самое переживает — потому CI был слеп к этому классу регрессий (проверено: импорт всех сетов N2/N3 зелёный на десктопе даже без фикса furigana из #408).

## Fix

- **Пагинация превью**: первые 100 слов + `LoadMoreButton` (+100). Бюджет детерминированно распределяется по группам сетов (`cap_groups`, 3 юнит-теста). Импорт по-прежнему покрывает **все** выбранные слова — пагинация только про рендер.
- **E2E-регрессия** (`sets_import_pagination.spec.ts`): выбрать все N3-сеты → drawer открывается → items видны → начальный count ≤ 150 → load-more растит список → cancel → страница жива.
- **Memory-cap в CI** (идея Юры): `launchOptions --js-flags=--max-old-space-size=1024 --memory-pressure-off` — теперь десктопный e2e умирает как телефон, а не молча поглощает прожорливые страницы.

## Verification

- `cargo test -p origa_ui --lib`: 344/344 (включая 3 новых `cap_groups`)
- clippy `-D warnings`: чист; fmt: чист
- E2E на локальном стенде: pagination-тест GREEN, существующие grammar/kanji тесты с memory-cap — GREEN