### PR TITLE
feat(cdn): MS Store direct installer link via CDN (ADR-041)

### DIFF
--- a/.github/workflows/_upload-release-cdn.yml
+++ b/.github/workflows/_upload-release-cdn.yml
@@ -1,0 +1,93 @@
+name: Upload installer to CDN
+
+# Reusable workflow for uploading the stable Windows installer to the S3
+# CDN behind s3.origa.uwuwu.net (ADR-041). Microsoft Store submissions
+# require a DIRECT installer link (HTTP 200); GitHub Releases URLs answer
+# with a 302 to objects.githubusercontent.com and get rejected, so the
+# fixed-name NSIS alias (ADR-025) is mirrored to:
+#
+#   releases/v<version>/Origa_x64-setup.exe  - permanent versioned archive
+#   releases/latest/Origa_x64-setup.exe      - the MS Store direct link
+#
+# STABLE-ONLY contract: prerelease (RC) and alpha are gated out by the
+# caller (tauri.yml upload-release-cdn if-clause); this workflow also
+# self-gates on inputs.version_type == 'stable' (same belt-and-suspenders
+# pattern as _upload-rustore.yml). The script itself rejects any version
+# that is not a bare X.Y.Z.
+#
+# Verification is built into the script: authenticated HEAD (Cache-Control
+# + Content-Length mandatory) and a full public GET of both URLs with a
+# sha256 comparison — the GET is the only check that exercises the proxy
+# edge on the real ~58 MB body.
+#
+# Credentials: scoped data-plane S3 keys via env (see
+# _cdn_s3._s3_upload_client) — env credentials deliberately take
+# precedence over any profile, and no profile exists on the runner anyway.
+
+on:
+    workflow_call:
+        inputs:
+            version:
+                type: string
+                required: true
+            version_type:
+                type: string
+                required: true
+        secrets:
+            cdn-access-key-id:
+                required: true
+            cdn-secret-access-key:
+                required: true
+
+permissions:
+    contents: read
+
+jobs:
+    upload:
+        if: inputs.version_type == 'stable'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Download Windows artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: windows-build
+                  path: windows-build/
+
+            - name: Setup uv
+              uses: astral-sh/setup-uv@v5
+              with:
+                  enable-cache: false
+
+            - name: Sync Python dependencies
+              working-directory: scripts
+              run: uv sync --frozen
+
+            - name: Upload installer to CDN releases/
+              working-directory: scripts
+              env:
+                  AWS_ACCESS_KEY_ID: ${{ secrets.cdn-access-key-id }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.cdn-secret-access-key }}
+                  ORIGA_CDN_BASE_URL: ${{ vars.ORIGA_CDN_BASE_URL }}
+              run: |
+                  uv run python upload_release_artifacts.py \
+                    --version "${{ inputs.version }}" \
+                    --artifact-dir ../windows-build \
+                    | tee upload.log
+
+                  MS_STORE_URL="$(grep -o 'https://.*/releases/latest/Origa_x64-setup.exe' upload.log | tail -1)"
+                  if [ -z "$MS_STORE_URL" ]; then
+                    echo "::warning::Could not extract the MS Store URL from the upload log — check the script output above."
+                    exit 0
+                  fi
+                  {
+                    echo "## Microsoft Store direct link"
+                    echo ""
+                    echo "Stable \`${{ inputs.version }}\` installer is live on the CDN:"
+                    echo ""
+                    echo "``"
+                    echo "$MS_STORE_URL"
+                    echo "``"
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/_upload-release-cdn.yml
+++ b/.github/workflows/_upload-release-cdn.yml
@@ -72,11 +72,19 @@ jobs:
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.cdn-secret-access-key }}
                   ORIGA_CDN_BASE_URL: ${{ vars.ORIGA_CDN_BASE_URL }}
               run: |
+                  # pipefail: a failed upload MUST fail the job — with the
+                  # default pipeline semantics `tee` would swallow the
+                  # script's exit code and the guard below would mask the
+                  # failure as a green run with a warning (seen live).
+                  set -o pipefail
                   uv run python upload_release_artifacts.py \
                     --version "${{ inputs.version }}" \
                     --artifact-dir ../windows-build \
                     | tee upload.log
 
+                  # The job is green here — the upload succeeded. A missing
+                  # URL in the log is a summary-extraction regression only:
+                  # warn loudly but do not fail the release job for cosmetics.
                   MS_STORE_URL="$(grep -o 'https://.*/releases/latest/Origa_x64-setup.exe' upload.log | tail -1)"
                   if [ -z "$MS_STORE_URL" ]; then
                     echo "::warning::Could not extract the MS Store URL from the upload log — check the script output above."

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -329,3 +329,29 @@ jobs:
         secrets:
             rustore-key-id: ${{ secrets.RUSTORE_KEY_ID }}
             rustore-private-key: ${{ secrets.RUSTORE_PRIVATE_KEY }}
+
+    upload-release-cdn:
+        name: Upload installer to CDN (MS Store direct link)
+        # Stable-only: mirrors the stable Windows installer (ADR-025 alias)
+        # to the CDN releases/ prefix so Microsoft Store gets a DIRECT link
+        # (GitHub Releases 302-redirect and are rejected by the store).
+        # See ADR-041 and .github/workflows/_upload-release-cdn.yml.
+        #
+        # Intentionally NOT a dependency of `release` — same isolation
+        # rationale as upload-rustore above: a transient CDN/S3 failure
+        # MUST NOT block the GitHub Release. RC builds stay GitHub-only.
+        # Do NOT add upload-release-cdn to release.needs — that regresses
+        # isolation.
+        if: >
+            always() &&
+            needs.build-tauri.result == 'success' &&
+            startsWith(github.ref, 'refs/tags/v') &&
+            needs.version.outputs.version_type == 'stable'
+        needs: [version, build-tauri]
+        uses: ./.github/workflows/_upload-release-cdn.yml
+        with:
+            version: ${{ needs.version.outputs.version }}
+            version_type: ${{ needs.version.outputs.version_type }}
+        secrets:
+            cdn-access-key-id: ${{ secrets.ORIGA_CDN_S3_ACCESS_KEY_ID }}
+            cdn-secret-access-key: ${{ secrets.ORIGA_CDN_S3_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -10,14 +10,6 @@ on:
                 description: "Force Apple builds (consumes ~30 min of macOS runner per target)"
                 type: boolean
                 default: false
-            # TEMPORARY (remove before merge): one-off branch validation of
-            # upload-release-cdn — runs the CDN upload with a fake stable
-            # version so the MS Store pipeline is proven end-to-end before
-            # the first real release tag.
-            cdn_test_version:
-                description: "TEMP: fake X.Y.Z to run upload-release-cdn from this branch"
-                type: string
-                default: ""
 
 concurrency:
     group: tauri-${{ github.ref }}
@@ -350,23 +342,19 @@ jobs:
         # MUST NOT block the GitHub Release. RC builds stay GitHub-only.
         # Do NOT add upload-release-cdn to release.needs — that regresses
         # isolation.
-        # TEMPORARY (remove before merge): the `(workflow_dispatch &&
-        # inputs.cdn_test_version)` disjunct lets upload-release-cdn run from
-        # a branch for a one-off end-to-end validation; version/version_type
-        # are overridden below so the stable-only gates see a fake stable.
+        # Stable-only: only v*.*.* stable tags upload; the branch-validation
+        # escape hatch (workflow_dispatch + fake version) used to prove this
+        # pipeline end-to-end was temporary and removed before merge.
         if: >
             always() &&
             needs.build-tauri.result == 'success' &&
-            (
-                startsWith(github.ref, 'refs/tags/v') &&
-                needs.version.outputs.version_type == 'stable' ||
-                (github.event_name == 'workflow_dispatch' && inputs.cdn_test_version != '')
-            )
+            startsWith(github.ref, 'refs/tags/v') &&
+            needs.version.outputs.version_type == 'stable'
         needs: [version, build-tauri]
         uses: ./.github/workflows/_upload-release-cdn.yml
         with:
-            version: ${{ inputs.cdn_test_version != '' && inputs.cdn_test_version || needs.version.outputs.version }}
-            version_type: ${{ inputs.cdn_test_version != '' && 'stable' || needs.version.outputs.version_type }}
+            version: ${{ needs.version.outputs.version }}
+            version_type: ${{ needs.version.outputs.version_type }}
         secrets:
             cdn-access-key-id: ${{ secrets.ORIGA_CDN_S3_ACCESS_KEY_ID }}
             cdn-secret-access-key: ${{ secrets.ORIGA_CDN_S3_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -10,6 +10,14 @@ on:
                 description: "Force Apple builds (consumes ~30 min of macOS runner per target)"
                 type: boolean
                 default: false
+            # TEMPORARY (remove before merge): one-off branch validation of
+            # upload-release-cdn — runs the CDN upload with a fake stable
+            # version so the MS Store pipeline is proven end-to-end before
+            # the first real release tag.
+            cdn_test_version:
+                description: "TEMP: fake X.Y.Z to run upload-release-cdn from this branch"
+                type: string
+                default: ""
 
 concurrency:
     group: tauri-${{ github.ref }}
@@ -342,16 +350,23 @@ jobs:
         # MUST NOT block the GitHub Release. RC builds stay GitHub-only.
         # Do NOT add upload-release-cdn to release.needs — that regresses
         # isolation.
+        # TEMPORARY (remove before merge): the `(workflow_dispatch &&
+        # inputs.cdn_test_version)` disjunct lets upload-release-cdn run from
+        # a branch for a one-off end-to-end validation; version/version_type
+        # are overridden below so the stable-only gates see a fake stable.
         if: >
             always() &&
             needs.build-tauri.result == 'success' &&
-            startsWith(github.ref, 'refs/tags/v') &&
-            needs.version.outputs.version_type == 'stable'
+            (
+                startsWith(github.ref, 'refs/tags/v') &&
+                needs.version.outputs.version_type == 'stable' ||
+                (github.event_name == 'workflow_dispatch' && inputs.cdn_test_version != '')
+            )
         needs: [version, build-tauri]
         uses: ./.github/workflows/_upload-release-cdn.yml
         with:
-            version: ${{ needs.version.outputs.version }}
-            version_type: ${{ needs.version.outputs.version_type }}
+            version: ${{ inputs.cdn_test_version != '' && inputs.cdn_test_version || needs.version.outputs.version }}
+            version_type: ${{ inputs.cdn_test_version != '' && 'stable' || needs.version.outputs.version_type }}
         secrets:
             cdn-access-key-id: ${{ secrets.ORIGA_CDN_S3_ACCESS_KEY_ID }}
             cdn-secret-access-key: ${{ secrets.ORIGA_CDN_S3_SECRET_ACCESS_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,15 +97,15 @@ cargo fmt --check && cargo fmt
 
 ## CDN / S3
 
-Tigris object storage (S3-compatible), bucket `s3://origa-cdn` под user-owned account `yurvon-screamo`. CDN URL `https://s3.origa.uwuwu.net` вшивается через `build.rs`. Трейт: `origa/src/traits/cdn_provider.rs`, реализация: `origa_ui/src/repository/cdn_provider.rs`. Bucket management — через `t3` CLI. См. [ADR-037](docs/decisions/ADR-037-migrate-cdn-to-user-tigris-deprecate-s3-proxy.md) и [runbook](docs/runbooks/migrate-cdn-to-user-tigris.md).
+Tigris object storage (S3-compatible, endpoint `t3.storageapi.dev`) под Railway — bucket `adaptable-foodbox-ucep7wx`, раздача через Railway s3-proxy + edge caching: URL `https://s3.origa.uwuwu.net` вшивается через `build.rs`. Трейт: `origa/src/traits/cdn_provider.rs`, реализация: `origa_ui/src/repository/cdn_provider.rs`. Миграция на user-owned Tigris (ADR-037) была откачена в #372 (DPI-throttle на Cloudflare-роутинге для РФ); orphaned-ресурсы той миграции (user-Tigris bucket `origa-cdn` ~4 GB, R2, Worker) ждут cleanup.
 
-Профиль `~/.aws/credentials [origa-cdn]` — для `deploy_cdn.py` / `refresh_cache_control.py` (Editor role на `origa-cdn`).
+Профиль `~/.aws/credentials [origa]` — для `deploy_cdn.py` / `refresh_cache_control.py` / `upload_release_artifacts.py`. Контракт кредов (ADR-041): env `AWS_ACCESS_KEY_ID` при наличии приоритетнее профиля — CI передаёт scoped-ключи через env.
 
 Все объекты — статические, но кэшируются по-разному в зависимости от частоты изменений. Политика в `scripts/_cdn_cache.py`, применяется в `deploy_cdn.py`.
 
 - **Truly-static** (`public, max-age=31536000, immutable`): ML-модели (`ndlocr/`, `whisper/`), kanji SVG/frames (`kanji_animations/`, `kanji_frames/`), audio фраз (`phrases/audio/`), системный словарь lindera (`dictionaries/`)
-- **Release-updated** (`public, max-age=300, must-revalidate`): контент-JSON — `grammar/`, `dictionary/`, `phrases/phrase_index.json`, `phrases/data/`, `pitch/`, `well_known_set/`
-- **Always-fresh** (`no-cache`): `manifest.json`
+- **Release-updated** (`public, max-age=300, must-revalidate`): контент-JSON — `grammar/`, `dictionary/`, `phrases/phrase_index.json`, `phrases/data/`, `pitch/`, `well_known_set/`, а также версионированные инсталлеры `releases/v*.*.*/` (перезаписываемы при re-run тега)
+- **Always-fresh** (`no-cache`): `manifest.json`, `releases/latest/` (прямой линк для Microsoft Store, ADR-041)
 
 immutable уместен только для truly-static файлов. `grammar`/`phrases`/`dictionary` обновляются каждый релиз (W-11, P-3, L-4, S-3) — для них immutable означал CDN edge-cache poisoning (PR #182): S3 обновлялся, а edge держал годовой кэш и отдавал устаревшую версию, пока кэш не сбросили вручную.
 
@@ -115,6 +115,15 @@ python scripts/deploy_cdn.py --dry-run  # показать что будет з�
 ```
 
 Манифест (`manifest.json`) содержит SHA256 хеши версионных файлов и позволяет клиенту обнаруживать обновления. Деплоится с `Cache-Control: no-cache`.
+
+### Релизные инсталлеры (`releases/`, ADR-041)
+
+Microsoft Store требует прямую ссылку (HTTP 200) — GitHub Releases дают 302. Stable-релизы зеркалируют NSIS-алиас `Origa_x64-setup.exe` (ADR-025) в bucket job'ом `upload-release-cdn` (`tauri.yml`): `releases/v<version>/` (архив) + `releases/latest/` (ссылка для стора). Заливка верифицируется: authenticated HEAD (Cache-Control, размер, чексумма при simple-формате) + полный публичный GET с sha256. RC не заливаются.
+
+```powershell
+# вручную (bootstrap текущего stable; exe скачать из GitHub Release):
+cd scripts; uv run python upload_release_artifacts.py --version 1.2.3 --artifact-dir <dir>
+```
 
 Обновить Cache-Control на существующих объектах (one-time, после смены политики — новые upload'ы уже корректны, но старые объекты хранят прежний заголовок):
 

--- a/docs/backups/orphaned-cdn-cleanup.2026-08-22.txt
+++ b/docs/backups/orphaned-cdn-cleanup.2026-08-22.txt
@@ -1,0 +1,37 @@
+# Orphaned CDN resources cleanup (post ADR-037 revert #372) — 2026-08-22
+
+Executed during ADR-041 work. Evidence snapshot taken immediately before deletion.
+Production CDN verified unaffected: `s3.origa.uwuwu.net` → CNAME `sltxm1ip.up.railway.app`
+(Railway bucket `adaptable-foodbox-ucep7wx`), `GET /manifest.json` → HTTP 200.
+
+## Deleted: Tigris user-account bucket `origa-cdn` (org `yurvon-screamo`)
+
+Pre-deletion state (`t3 buckets get origa-cdn`):
+
+- Number of Objects: **0** (current); All Versions Count: 600 002; Total Size: 3.7 GB
+- Custom Domain: `cdn.origa.uwuwu.net` (orphaned alias; zero references in repo —
+  verified by grep; DNS record itself is on Cloudflare and left dangling, see below)
+- Data Migration: still configured FROM `adaptable-foodbox-ucep7wx` (shadow migration
+  from ADR-037 Slice 1 — removed together with the bucket)
+- Snapshots: disabled. Delete protection: off. Soft delete: disabled.
+
+Content rationale (why no data backup was taken): the 600k versions were the
+server-side migration copy of the Railway-managed CDN bucket made on 2026-08-02/03
+(ADR-037 §3). After the revert (#372) every content deploy went to the Railway
+bucket only, so this copy was strictly stale. The canonical CDN content lives in
+`adaptable-foodbox-ucep7wx` and is untouched by this cleanup. Current-object count
+of 0 at deletion time confirms nothing live was served from this bucket anymore.
+
+## NOT cleaned (require interactive auth — left to the operator)
+
+Cloudflare side (wrangler not logged in, no CLOUDFLARE_API_TOKEN available; run
+`wrangler login` then):
+
+1. R2 bucket `origa-cdn` (partial data from the abandoned R2 experiment, #372)
+   — `npx wrangler r2 bucket delete origa-cdn`
+2. Worker `origa-cdn` (deployed, dormant)
+   — `npx wrangler delete --name origa-cdn`
+3. DNS record `cdn.origa` CNAME → `origa-cdn.t3.tigrisbucket.io` in zone
+   `uwuwu.net` (now dangling after the Tigris bucket deletion)
+   — delete in Cloudflare dashboard or via API
+4. Cloudflare zone `uwuwu.net` itself: ACTIVE, serves all project DNS — DO NOT touch.

--- a/docs/decisions/ADR-041-installer-direct-link-cdn.md
+++ b/docs/decisions/ADR-041-installer-direct-link-cdn.md
@@ -1,0 +1,170 @@
+# ADR-041: Direct-link Windows installer on the CDN for Microsoft Store
+
+## Status
+
+**Accepted** (2026-08-22).
+
+## Date
+
+2026-08-22.
+
+## Context
+
+Microsoft Store rejected the Origa submission: the store requires a
+**direct** installer URL that answers `HTTP 200`, but GitHub Releases asset
+URLs answer with a `302` redirect to `objects.githubusercontent.com`. The
+store's validation follows redirects nowhere.
+
+Origa already operates an S3-backed public CDN:
+`https://s3.origa.uwuwu.net` (Railway `s3-proxy` → Tigris bucket
+`adaptable-foodbox-ucep7wx`, DNS on Cloudflare after PR #372 reverted the
+ADR-037 user-Tigris migration). Verified live: the CDN answers object GETs
+with `200` directly — no redirects, Range supported, CORS `GET, HEAD`.
+
+The release pipeline (`tauri.yml`) already ships per-release artifacts to
+GitHub Releases (`release` job), RuStore (`upload-rustore`, isolated), and
+the Apple stores (`build-apple`). Adding one isolated upload job fits the
+existing pattern.
+
+## Decision
+
+Mirror the **stable-only** Windows NSIS installer — the fixed-name ADR-025
+alias `Origa_x64-setup.exe` — into the existing CDN bucket under a new
+`releases/` prefix on every stable tag push:
+
+| Key | Purpose | Cache-Control |
+| --- | --- | --- |
+| `releases/v<X.Y.Z>/Origa_x64-setup.exe` | permanent versioned archive | `public, max-age=300, must-revalidate` (release-updated) |
+| `releases/latest/Origa_x64-setup.exe` | the direct link handed to Microsoft Store | `no-cache` |
+
+`https://s3.origa.uwuwu.net/releases/latest/Origa_x64-setup.exe` is a
+stable URL — submitted to the store once, it always serves the latest
+stable installer. RC/prerelease tags are gated out (stable-only contract at
+three layers: `tauri.yml` if-clause, reusable-workflow self-gate, strict
+`^\d+\.\d+\.\d+$` version validation in the script).
+
+### Why the existing Railway bucket
+
+The orphaned user-owned Tigris bucket `origa-cdn` (ADR-037, still ~4 GB,
+pending cleanup) could have been revived with zero egress fees. Rejected:
+it is scheduled for decommission, would re-introduce a second
+storage vendor mid-cleanup, and MS Store downloads are rare enough that
+Railway egress exposure is negligible (monitor via Railway metrics; the
+ADR-037 investigation shows how). A new clean bucket was rejected for the
+same one-more-vendor reason. Zero new infrastructure beats marginally
+cheaper rare downloads.
+
+### Why versioned keys are NOT immutable
+
+NSIS builds are not byte-reproducible: re-running a tag produces different
+bytes. If the versioned key were `immutable` and a re-run overwrote it, the
+CDN edge would serve the year-long cached copy of the OLD bytes — exactly
+the PR #182 poisoning pattern. `must-revalidate` bounds staleness to ~5 min
+and self-heals overwrites. The MS Store link (`releases/latest/`) is
+`no-cache`, so a submission always validates against fresh bytes.
+
+### Multipart scale
+
+The installer is ~58 MB. With the deploy scripts' 16 KB multipart chunk
+(that threshold exists to force multipart on *small* files against T3's
+~24 KB single-PUT limit) this would be ~3.5k sequential 16 KB PUTs per key.
+The release upload uses **8 MB parts**: 7 parts per key
+(58 372 366 ÷ 8 388 608 = 6.96), ~14 part-PUTs per release. 8 MB parts are
+empirically proven on T3 — the aws CLI historically auto-multiparted above
+its own 8 MB threshold with such parts (the pre-#223 deploy path for the
+118 MB whisper models).
+
+### Upload order and verification
+
+Versioned key uploads FIRST, `latest` second (pairing invariant: the store
+alias must never point at a release whose archive failed to land).
+After both uploads:
+
+1. **Authenticated HEAD** per key — `Cache-Control` and `Content-Length`
+   are mandatory checks. The stored SHA256 is compared only when the store
+   returns it in simple format; multipart uploads produce a composite
+   `<base64>-<parts>` checksum that never equals the plain file hash, so
+   composite or absent checksums degrade to an informational note.
+2. **Full public GET** of both URLs with sha256 comparison — the only
+   check that exercises the proxy edge (railway-hikari) on the real ~58 MB
+   body; HEAD cannot catch proxy timeouts/limits on large bodies.
+
+Uploads request `ChecksumAlgorithm=SHA256`; if the store rejects the
+checksum extension on multipart creation, the upload retries once without
+a checksum (wide catch is deliberate — a non-checksum failure simply fails
+the retry identically) and integrity rests on the GET check.
+
+### Credential contract
+
+CI passes scoped data-plane S3 keys (the existing `[origa]` deploy
+principal — no new grants) via environment variables. Contract (applies to
+every script on `scripts/_cdn_s3.py`): env `AWS_ACCESS_KEY_ID`, when set,
+takes precedence over the local `[origa]` profile. GitHub secrets:
+`ORIGA_CDN_S3_ACCESS_KEY_ID`, `ORIGA_CDN_S3_SECRET_ACCESS_KEY`.
+Dependencies are installed with `uv sync --frozen` from `scripts/uv.lock`
+— single source of truth, no manual version pins.
+
+### CI isolation
+
+The `upload-release-cdn` job (tauri.yml → reusable
+`_upload-release-cdn.yml`) is intentionally **not** a dependency of the
+`release` job, mirroring `upload-rustore`: a transient CDN/S3 failure must
+not block the GitHub Release. GitHub remains the canonical release surface;
+the CDN copy serves the store link.
+
+## Manual bootstrap (first submission)
+
+Do not wait for the next stable tag — upload the current stable installer
+by hand and resubmit to MS Store:
+
+```powershell
+# Download Origa_x64-setup.exe from the latest GitHub Release into <dir>, then:
+cd scripts
+uv run python upload_release_artifacts.py --version <X.Y.Z> --artifact-dir <dir>
+# The script verifies both keys (HEAD + full public GET) and prints the
+# MS Store link: https://s3.origa.uwuwu.net/releases/latest/Origa_x64-setup.exe
+```
+
+## Consequences
+
+### Positive
+
+- MS Store submissions validate: direct `200` link, stable across releases.
+- Zero new infrastructure, one new isolated CI job, one new script.
+- Full verification chain on every upload (metadata policy + byte
+  integrity through the actual public path).
+
+### Negative
+
+- ~58 MB × 2 keys per stable release stored indefinitely. Lifecycle rules
+  are deliberately NOT introduced: the archive is small, the cost is
+  trivial, and old installers may be needed for store re-validation.
+  Revisit if release cadence × size grows.
+- Railway egress if the link leaks publicly (MS Store fetches are rare;
+  monitored via Railway metrics — see ADR-037 for the investigation
+  workflow).
+- `releases/v*` re-upload on tag re-run briefly serves mixed cache states
+  (≤5 min, bounded by must-revalidate).
+
+## Alternatives considered
+
+- **Revive the orphaned user-Tigris bucket** — zero egress, but
+  reintroduces a vendor mid-cleanup; rejected (see above).
+- **Host on the landing service** — requires serving large binaries from
+  the SSR app on Railway; new runtime concern for zero benefit.
+- **GitHub Pages** — 100 MB per-file limit headroom is thin for a growing
+  installer, and Pages is not an artifact-distribution surface.
+- **Presigned S3 URLs** — expire; the store needs a durable public URL.
+
+## References
+
+- ADR-025 — fixed-name installer alias (`Origa_x64-setup.exe`).
+- ADR-037 + PR #372 — user-Tigris migration and its revert (current CDN
+  topology: Railway s3-proxy → `adaptable-foodbox-ucep7wx`).
+- PR #182 / ADR-016 — edge-cache poisoning precedent behind the
+  non-immutable versioned keys.
+- `scripts/upload_release_artifacts.py` — the uploader + verifier.
+- `scripts/_cdn_s3.py` — S3 transport (`upload_file` chunk/checksum
+  params, `stat_object`, credential contract).
+- `.github/workflows/_upload-release-cdn.yml`, `tauri.yml`
+  (`upload-release-cdn` job).

--- a/scripts/_cdn_cache.py
+++ b/scripts/_cdn_cache.py
@@ -14,7 +14,9 @@ Files are split into three categories by how often they change:
   the CDN edge kept serving its year-long immutable copy until the cache was
   flushed by hand.
 - ALWAYS-FRESH (no-cache): manifest.json — the client's change-detection
-  beacon, re-fetched every session.
+  beacon, re-fetched every session — and ``releases/latest/`` — the
+  stable-alias Windows installer URL handed to Microsoft Store (ADR-041),
+  which must never be edge-cached across a release cutover.
 
 Any path matching no rule falls back to the conservative release-updated
 policy: a 5-min 304 revalidation is cheap when unchanged and bounds staleness
@@ -67,7 +69,9 @@ _RELEASE_UPDATED_RULES: Final[frozenset[str]] = frozenset(
     }
 )
 
-_NO_CACHE_RULES: Final[frozenset[str]] = frozenset({"manifest.json"})
+_NO_CACHE_RULES: Final[frozenset[str]] = frozenset(
+    {"manifest.json", "releases/latest/"}
+)
 
 
 def _matches(path: str, rules: frozenset[str]) -> bool:

--- a/scripts/_cdn_s3.py
+++ b/scripts/_cdn_s3.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import mimetypes
+import os
 import subprocess
 import sys
 import tempfile
@@ -52,6 +53,7 @@ _UNSAFE_KEY_CHARS = frozenset(" \t\r\n;|&`$\"'<>()@\\")
 class ObjectMetadata(NamedTuple):
     cache_control: str | None
     content_length: int | None
+    checksum_sha256: str | None = None
 
 
 def s3_uri(key: str) -> str:
@@ -213,6 +215,34 @@ def head_object(key: str) -> ObjectMetadata | None:
     )
 
 
+def stat_object(key: str, *, with_checksum: bool = False) -> ObjectMetadata | None:
+    """HEAD one object via boto3 — unlike :func:`head_object`, no pwsh/aws CLI
+    wrapper, so this works on the Linux CI runner.
+
+    ``with_checksum=True`` adds ``ChecksumMode=ENABLED`` so stores that keep
+    upload checksums return them; a store that chokes on the mode makes the
+    call fail and returns None, leaving the caller free to fall back to a
+    plain stat. Returns None (with a printed warning) on any error, mirroring
+    :func:`head_object` semantics.
+    """
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    params: dict[str, object] = {"Bucket": S3_BUCKET, "Key": key}
+    if with_checksum:
+        params["ChecksumMode"] = "ENABLED"
+    try:
+        data = _s3_upload_client().head_object(**params)
+    except (BotoCoreError, ClientError) as exc:
+        print(f"  WARNING: boto3 head-object failed for {key}: {exc}", file=sys.stderr)
+        return None
+    length = data.get("ContentLength")
+    return ObjectMetadata(
+        cache_control=data.get("CacheControl"),
+        content_length=int(length) if isinstance(length, int) else None,
+        checksum_sha256=data.get("ChecksumSHA256"),
+    )
+
+
 def copy_object_cache_control(key: str, target_cc: str, dry_run: bool) -> bool:
     """Rewrite one object's Cache-Control via a server-side self-copy.
 
@@ -254,11 +284,13 @@ MULTIPART_THRESHOLD_BYTES = 16 * 1024
 
 # Explicit pins for extensions whose canonical type matters and that mimetypes
 # either cannot guess (woff/woff2) or resolves inconsistently across minimal
-# installs (.json).
+# installs (.json, .exe — the Windows installer must never be served as
+# text/plain by a mis-guessing runner image).
 _CONTENT_TYPE_OVERRIDES: dict[str, str] = {
     ".woff2": "font/woff2",
     ".woff": "font/woff",
     ".json": "application/json",
+    ".exe": "application/octet-stream",
 }
 
 
@@ -268,13 +300,25 @@ class RemoteObject(NamedTuple):
 
 
 _s3_client: BaseClient | None = None
-_transfer_config_obj: TransferConfig | None = None
+_transfer_configs: dict[int, "TransferConfig"] = {}
 
 
 def _s3_upload_client() -> BaseClient:
-    # boto3 is imported lazily so refresh_cache_control.py -- which only uses
-    # the aws-CLI helpers above and never uploads -- does not require boto3 to
-    # be installed just to import _cdn_s3.
+    """Return the shared boto3 S3 client used by every upload path.
+
+    Credential-source contract (ADR-041): explicit environment credentials
+    (``AWS_ACCESS_KEY_ID`` set) take precedence over the local ``[origa]``
+    profile for ALL scripts built on this transport — ``deploy_cdn.py`` and
+    ``upload_release_artifacts.py`` alike. CI exports scoped keys through the
+    environment; operator machines keep the profile in ~/.aws/credentials and
+    export nothing, so each side gets the credentials it owns. Exporting env
+    credentials on an operator machine deliberately overrides the profile —
+    useful for testing, but be aware the deploy then runs as that principal.
+
+    boto3 stays imported lazily so refresh_cache_control.py — which only uses
+    the aws-CLI helpers and never uploads — does not require boto3 to be
+    installed just to import _cdn_s3.
+    """
     global _s3_client
     if _s3_client is None:
         try:
@@ -286,7 +330,10 @@ def _s3_upload_client() -> BaseClient:
             )
             sys.exit(1)
         from botocore.client import Config as BotoConfig
-        session = boto3.Session(profile_name=S3_PROFILE)
+        if os.environ.get("AWS_ACCESS_KEY_ID"):
+            session = boto3.Session()
+        else:
+            session = boto3.Session(profile_name=S3_PROFILE)
         _s3_client = session.client(
             "s3",
             endpoint_url=S3_ENDPOINT,
@@ -299,17 +346,27 @@ def _s3_upload_client() -> BaseClient:
     return _s3_client
 
 
-def _transfer_config() -> TransferConfig:
-    global _transfer_config_obj
-    if _transfer_config_obj is None:
+def _transfer_config(chunk_size: int = MULTIPART_THRESHOLD_BYTES) -> TransferConfig:
+    """Multipart TransferConfig for ``chunk_size``, cached per size.
+
+    The default 16KB threshold/chunk forces multipart for the small files
+    T3's ~24KB single-PUT limit would reject. Large binaries (the ~58MB
+    release installer) pass a bigger chunk so one key is ~7 parts instead
+    of ~3.5k sequential PUTs — 8MB parts are proven on T3 (the aws CLI
+    historically auto-multiparted above its own 8MB threshold). Configs are
+    cached per chunk_size so repeated uploads reuse one object.
+    """
+    config = _transfer_configs.get(chunk_size)
+    if config is None:
         from boto3.s3.transfer import TransferConfig
 
-        _transfer_config_obj = TransferConfig(
-            multipart_threshold=MULTIPART_THRESHOLD_BYTES,
-            multipart_chunksize=MULTIPART_THRESHOLD_BYTES,
+        config = TransferConfig(
+            multipart_threshold=chunk_size,
+            multipart_chunksize=chunk_size,
             max_concurrency=1,
         )
-    return _transfer_config_obj
+        _transfer_configs[chunk_size] = config
+    return config
 
 
 def content_type_for(path: Path) -> str:
@@ -320,7 +377,27 @@ def content_type_for(path: Path) -> str:
     return guessed or "application/octet-stream"
 
 
-def upload_file(local_path: Path, key: str, cache_control: str, dry_run: bool) -> None:
+def _upload_via_boto3(
+    local_path: Path, key: str, extra_args: dict[str, str], chunk_size: int
+) -> None:
+    _s3_upload_client().upload_file(
+        Filename=str(local_path),
+        Bucket=S3_BUCKET,
+        Key=key,
+        ExtraArgs=extra_args,
+        Config=_transfer_config(chunk_size),
+    )
+
+
+def upload_file(
+    local_path: Path,
+    key: str,
+    cache_control: str,
+    dry_run: bool,
+    *,
+    chunk_size: int = MULTIPART_THRESHOLD_BYTES,
+    checksum_algorithm: str | None = None,
+) -> None:
     """Upload one file to S3 via boto3 with a forced-low multipart threshold.
 
     A fresh PUT carries CacheControl/ContentType through ExtraArgs directly, so
@@ -328,6 +405,14 @@ def upload_file(local_path: Path, key: str, cache_control: str, dry_run: bool) -
     larger than that upload as multipart parts, sidestepping T3 Storage's
     single-PUT limit that breaks the aws CLI for 24KB-8MB files. boto3 errors
     abort the deploy with the offending key rather than a raw traceback.
+
+    ``chunk_size`` overrides the multipart threshold/chunk (see
+    :func:`_transfer_config`). ``checksum_algorithm`` (e.g. ``"SHA256"``)
+    requests a stored checksum; S3-compatible stores that reject the checksum
+    extension fail the upload — in that case it is retried once WITHOUT the
+    checksum (a wide catch is deliberate: a non-checksum failure simply fails
+    the retry identically) and integrity then rests on the caller's GET-side
+    verification.
     """
     size = local_path.stat().st_size
     content_type = content_type_for(local_path)
@@ -341,22 +426,37 @@ def upload_file(local_path: Path, key: str, cache_control: str, dry_run: bool) -
     from botocore.exceptions import BotoCoreError, ClientError
     from s3transfer.exceptions import RetriesExceededError, S3UploadFailedError
 
+    upload_errors = (BotoCoreError, ClientError, RetriesExceededError, S3UploadFailedError)
+    extra_args: dict[str, str] = {
+        "CacheControl": cache_control,
+        "ContentType": content_type,
+    }
+    if checksum_algorithm is not None:
+        extra_args["ChecksumAlgorithm"] = checksum_algorithm
     try:
-        _s3_upload_client().upload_file(
-            Filename=str(local_path),
-            Bucket=S3_BUCKET,
-            Key=key,
-            ExtraArgs={"CacheControl": cache_control, "ContentType": content_type},
-            Config=_transfer_config(),
+        _upload_via_boto3(local_path, key, extra_args, chunk_size)
+    except upload_errors as exc:
+        if checksum_algorithm is None:
+            print(f"ERROR: boto3 upload failed for {key}: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(
+            f"WARNING: checksum-enabled upload failed for {key} ({exc}); "
+            "retrying without checksum",
+            file=sys.stderr,
         )
-    except (
-        BotoCoreError,
-        ClientError,
-        RetriesExceededError,
-        S3UploadFailedError,
-    ) as exc:
-        print(f"ERROR: boto3 upload failed for {key}: {exc}", file=sys.stderr)
-        sys.exit(1)
+        retry_args = {
+            name: value
+            for name, value in extra_args.items()
+            if name != "ChecksumAlgorithm"
+        }
+        try:
+            _upload_via_boto3(local_path, key, retry_args, chunk_size)
+        except upload_errors as retry_exc:
+            print(
+                f"ERROR: boto3 upload failed for {key}: {retry_exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
 
 def list_remote_objects(prefix: str) -> dict[str, RemoteObject]:

--- a/scripts/_cdn_s3.py
+++ b/scripts/_cdn_s3.py
@@ -423,10 +423,21 @@ def upload_file(
             f"ContentType={content_type}]"
         )
         return
+    from boto3.exceptions import S3UploadFailedError as Boto3S3UploadFailedError
     from botocore.exceptions import BotoCoreError, ClientError
     from s3transfer.exceptions import RetriesExceededError, S3UploadFailedError
 
-    upload_errors = (BotoCoreError, ClientError, RetriesExceededError, S3UploadFailedError)
+    # boto3 wraps transfer failures in its OWN S3UploadFailedError
+    # (boto3.exceptions), distinct from s3transfer's class of the same name —
+    # catching only the s3transfer flavor lets real upload failures escape
+    # as raw tracebacks (seen live: UploadPart InternalError on T3).
+    upload_errors = (
+        BotoCoreError,
+        ClientError,
+        RetriesExceededError,
+        S3UploadFailedError,
+        Boto3S3UploadFailedError,
+    )
     extra_args: dict[str, str] = {
         "CacheControl": cache_control,
         "ContentType": content_type,

--- a/scripts/tests/test_cdn_cache.py
+++ b/scripts/tests/test_cdn_cache.py
@@ -26,9 +26,16 @@ EXPECTED_SYNC_DIR_POLICY: dict[str, str] = {
     "whisper": IMMUTABLE,
     "fonts": IMMUTABLE,
     "phrases/data": RELEASE_UPDATED,
+    "well_known_set/duolingo": RELEASE_UPDATED,
     "well_known_set/irodori_nyuumon": RELEASE_UPDATED,
     "well_known_set/irodori_shokyuu1": RELEASE_UPDATED,
     "well_known_set/irodori_shokyuu2": RELEASE_UPDATED,
+    "well_known_set/migii": RELEASE_UPDATED,
+    "well_known_set/minna_n5": RELEASE_UPDATED,
+    "well_known_set/minna_n4": RELEASE_UPDATED,
+    "well_known_set/minna_n3": RELEASE_UPDATED,
+    "well_known_set/minna_n2": RELEASE_UPDATED,
+    "well_known_set/spy_family": RELEASE_UPDATED,
 }
 
 
@@ -39,6 +46,22 @@ EXPECTED_SYNC_DIR_POLICY: dict[str, str] = {
 
 def test_manifest_is_no_cache():
     assert cache_control_for("manifest.json") == NO_CACHE
+
+
+def test_ms_store_latest_installer_alias_is_no_cache():
+    # ADR-041: releases/latest/ is the direct link handed to Microsoft
+    # Store; it must never be edge-cached across a release cutover.
+    assert cache_control_for("releases/latest/Origa_x64-setup.exe") == NO_CACHE
+
+
+def test_versioned_installer_archive_is_release_updated():
+    # NOT immutable: re-running a tag overwrites the key with different
+    # installer bytes (NSIS builds are not reproducible); immutable would
+    # poison the edge for a year (PR #182 lesson). 5-min must-revalidate
+    # self-heals the overwrite.
+    assert (
+        cache_control_for("releases/v1.2.3/Origa_x64-setup.exe") == RELEASE_UPDATED
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_cdn_s3.py
+++ b/scripts/tests/test_cdn_s3.py
@@ -472,6 +472,53 @@ def test_upload_file_retries_once_without_checksum_on_store_rejection(
     assert "retrying without checksum" in capsys.readouterr().err
 
 
+def test_upload_file_catches_boto3_flavored_upload_error(tmp_path, monkeypatch, capsys):
+    # Live regression (2026-08-22 CI run): T3 answered UploadPart with
+    # InternalError; boto3 re-raised it as boto3.exceptions.S3UploadFailedError
+    # — a DIFFERENT class from s3transfer.exceptions.S3UploadFailedError. The
+    # old catch tuple missed it and the operator got a raw traceback instead
+    # of the retry (checksum case) or the keyed error message.
+    from boto3.exceptions import S3UploadFailedError as Boto3Flavor
+
+    local = tmp_path / "Origa_x64-setup.exe"
+    local.write_bytes(b"x" * 10)
+    err = Boto3Flavor("Failed to upload x: InternalError on UploadPart")
+    flaky = _FlakyUploadClient(err)
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: flaky)
+
+    upload_file(
+        local,
+        "releases/latest/Origa_x64-setup.exe",
+        "no-cache",
+        dry_run=False,
+        checksum_algorithm="SHA256",
+    )
+
+    # Now caught: the retry (without checksum) fires and succeeds.
+    assert len(flaky.calls) == 2
+    assert "ChecksumAlgorithm" not in flaky.calls[1]["ExtraArgs"]
+    assert "retrying without checksum" in capsys.readouterr().err
+
+
+def test_upload_file_boto3_flavor_without_checksum_fails_with_key(
+    tmp_path, monkeypatch, capsys
+):
+    # The same boto3-flavored failure on a checksum-less upload must exit
+    # non-zero with the offending key, never a raw traceback.
+    from boto3.exceptions import S3UploadFailedError as Boto3Flavor
+
+    local = tmp_path / "Origa_x64-setup.exe"
+    local.write_bytes(b"x" * 10)
+    err = Boto3Flavor("Failed to upload x: InternalError on UploadPart")
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: _FakeUploadClient(err))
+
+    with pytest.raises(SystemExit) as exc:
+        upload_file(local, "releases/latest/Origa_x64-setup.exe", "no-cache", dry_run=False)
+
+    assert exc.value.code == 1
+    assert "releases/latest/Origa_x64-setup.exe" in capsys.readouterr().err
+
+
 class _FlakyUploadClient:
     """Fails the first upload_file call, records every call."""
 

--- a/scripts/tests/test_cdn_s3.py
+++ b/scripts/tests/test_cdn_s3.py
@@ -104,6 +104,22 @@ def test_multipart_threshold_forces_multipart_under_cli_default():
     assert 2 * 1024 * 1024 > MULTIPART_THRESHOLD_BYTES
 
 
+def test_transfer_config_is_cached_per_chunk_size():
+    # ADR-041: the ~58MB installer uploads with 8MB parts; the cache must be
+    # keyed by chunk_size or a large-file upload would silently reuse the
+    # 16KB config (3.5k sequential PUTs instead of 7).
+    _cdn_s3._transfer_configs.clear()
+    cfg_16k = _transfer_config(16 * 1024)
+    cfg_8m = _transfer_config(8 * 1024 * 1024)
+
+    assert cfg_16k is not cfg_8m
+    assert cfg_8m.multipart_threshold == 8 * 1024 * 1024
+    assert cfg_8m.multipart_chunksize == 8 * 1024 * 1024
+    # Repeated requests reuse the cached object.
+    assert _transfer_config(8 * 1024 * 1024) is cfg_8m
+    assert _transfer_config() is cfg_16k
+
+
 # ---------------------------------------------------------------------------
 # content_type_for
 # ---------------------------------------------------------------------------
@@ -117,6 +133,9 @@ def test_multipart_threshold_forces_multipart_under_cli_default():
         ("grammar.json", "application/json"),
         # Override lookup is case-insensitive — real extensions vary in case.
         ("UPPER.WOFF2", "font/woff2"),
+        # The Windows installer must never depend on a runner image's
+        # mimetypes registry (ADR-041).
+        ("Origa_x64-setup.exe", "application/octet-stream"),
     ],
 )
 def test_content_type_override(filename: str, expected: str):
@@ -340,3 +359,194 @@ def test_sync_directory_uses_normalized_prefix_key(tmp_path, monkeypatch):
     sync_directory(local_dir, "fonts/", "immutable", dry_run=False)
 
     assert [key for _, key, _, _ in calls] == ["fonts/x.woff2"]
+
+
+# ---------------------------------------------------------------------------
+# Credential-source contract: env credentials override the local profile
+# (ADR-041) — applies to every script built on this transport.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Records how the boto3 Session was constructed."""
+
+    profile_name: str | None = None
+    client_kwargs: dict[str, object] = {}
+
+    def __init__(self, profile_name: str | None = None) -> None:
+        _FakeSession.profile_name = profile_name
+
+    def client(self, _service: str, **kwargs: object) -> str:
+        _FakeSession.client_kwargs = kwargs
+        return "fake-s3-client"
+
+
+@pytest.fixture
+def _fresh_client(monkeypatch):
+    # The real _s3_client is a module singleton; reset it so each case
+    # exercises Session construction itself.
+    monkeypatch.setattr(_cdn_s3, "_s3_client", None)
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+    yield
+    _FakeSession.profile_name = None
+    _FakeSession.client_kwargs = {}
+
+
+def test_env_credentials_take_precedence_over_profile(monkeypatch, _fresh_client):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "tid_ci_key")
+    client = _cdn_s3._s3_upload_client()
+
+    assert client == "fake-s3-client"
+    # Env branch: Session() without an explicit profile — the boto3 env
+    # credential chain owns resolution.
+    assert _FakeSession.profile_name is None
+
+
+def test_local_profile_used_when_no_env_credentials(monkeypatch, _fresh_client):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    _cdn_s3._s3_upload_client()
+
+    assert _FakeSession.profile_name == _cdn_s3.S3_PROFILE
+    kwargs = _FakeSession.client_kwargs
+    assert kwargs["endpoint_url"] == _cdn_s3.S3_ENDPOINT
+
+
+# ---------------------------------------------------------------------------
+# upload_file — chunk_size / checksum_algorithm (ADR-041 release uploads)
+# ---------------------------------------------------------------------------
+
+
+def test_upload_file_passes_chunk_size_config_and_checksum(tmp_path, monkeypatch):
+    local = tmp_path / "Origa_x64-setup.exe"
+    local.write_bytes(b"x" * 100)
+    fake = _FakeUploadClient()
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: fake)
+
+    chunk = 8 * 1024 * 1024
+    upload_file(
+        local,
+        "releases/v1.2.3/Origa_x64-setup.exe",
+        "public, max-age=300, must-revalidate",
+        dry_run=False,
+        chunk_size=chunk,
+        checksum_algorithm="SHA256",
+    )
+
+    call = fake.calls[0]
+    assert call["ExtraArgs"]["ChecksumAlgorithm"] == "SHA256"
+    # The actual TransferConfig handed to the client — not just the argument
+    # — must use the requested chunk size.
+    assert call["Config"] is _cdn_s3._transfer_config(chunk)
+    assert call["Config"].multipart_chunksize == chunk
+
+
+def test_upload_file_retries_once_without_checksum_on_store_rejection(
+    tmp_path, monkeypatch, capsys
+):
+    # S3-compatible stores may reject the checksum extension on multipart
+    # creation; the upload must fall back to a checksum-less retry rather
+    # than aborting the release. A wide catch is deliberate — a failure
+    # unrelated to checksums simply fails the retry identically.
+    from botocore.exceptions import ClientError
+
+    local = tmp_path / "Origa_x64-setup.exe"
+    local.write_bytes(b"x" * 10)
+    err = ClientError(
+        {"Error": {"Code": "NotImplemented", "Message": "checksum unsupported"}},
+        "CreateMultipartUpload",
+    )
+    flaky = _FlakyUploadClient(err)
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: flaky)
+
+    upload_file(
+        local,
+        "releases/latest/Origa_x64-setup.exe",
+        "no-cache",
+        dry_run=False,
+        checksum_algorithm="SHA256",
+    )
+
+    assert len(flaky.calls) == 2
+    assert flaky.calls[0]["ExtraArgs"]["ChecksumAlgorithm"] == "SHA256"
+    assert "ChecksumAlgorithm" not in flaky.calls[1]["ExtraArgs"]
+    assert "retrying without checksum" in capsys.readouterr().err
+
+
+class _FlakyUploadClient:
+    """Fails the first upload_file call, records every call."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._exc = exc
+
+    def upload_file(self, **kwargs: object) -> None:
+        # Record a copy: defensive against any future production path that
+        # reuses/mutates the ExtraArgs dict between attempts.
+        recorded = {**kwargs}
+        extra_args = recorded.get("ExtraArgs")
+        if isinstance(extra_args, dict):
+            recorded["ExtraArgs"] = dict(extra_args)
+        self.calls.append(recorded)
+        if len(self.calls) == 1:
+            raise self._exc
+
+
+# ---------------------------------------------------------------------------
+# stat_object — boto3 HEAD (Linux-CI-safe, unlike the pwsh head_object)
+# ---------------------------------------------------------------------------
+
+
+class _FakeHeadClient:
+    """Serves one canned head_object response or raises."""
+
+    def __init__(
+        self,
+        response: dict[str, object] | None = None,
+        exc: BaseException | None = None,
+    ) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._response = response or {}
+        self._exc = exc
+
+    def head_object(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(kwargs)
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+def test_stat_object_returns_metadata_and_checksum_mode(monkeypatch):
+    fake = _FakeHeadClient(
+        {
+            "CacheControl": "no-cache",
+            "ContentLength": 58_372_366,
+            "ChecksumSHA256": "AbCd+/==",
+        }
+    )
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: fake)
+
+    metadata = _cdn_s3.stat_object("releases/latest/Origa_x64-setup.exe")
+
+    assert metadata == _cdn_s3.ObjectMetadata(
+        cache_control="no-cache",
+        content_length=58_372_366,
+        checksum_sha256="AbCd+/==",
+    )
+
+    checksum_meta = _cdn_s3.stat_object(
+        "releases/latest/Origa_x64-setup.exe", with_checksum=True
+    )
+    assert checksum_meta is not None
+    assert checksum_meta.checksum_sha256 == "AbCd+/=="
+    assert fake.calls[-1]["ChecksumMode"] == "ENABLED"
+    assert "ChecksumMode" not in fake.calls[0]
+
+
+def test_stat_object_returns_none_with_warning_on_error(monkeypatch, capsys):
+    from botocore.exceptions import ClientError
+
+    err = ClientError({"Error": {"Code": "404", "Message": "NoSuchKey"}}, "HeadObject")
+    monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: _FakeHeadClient(exc=err))
+
+    assert _cdn_s3.stat_object("releases/v9.9.9/missing.exe") is None
+    assert "WARNING" in capsys.readouterr().err

--- a/scripts/tests/test_upload_release_artifacts.py
+++ b/scripts/tests/test_upload_release_artifacts.py
@@ -1,0 +1,441 @@
+"""Unit tests for ``upload_release_artifacts`` (ADR-041 MS Store direct link).
+
+S3 and HTTP are external systems — every transport call (boto3 upload, boto3
+HEAD, public GET) is monkeypatched. The decision logic under test: key
+scheme + ordering (versioned before the latest alias — the pairing
+invariant), stable-only version validation, the layered verification
+verdicts (Cache-Control, size, simple-vs-composite checksum, GET hash), and
+the happy-path orchestration.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+import _cdn_s3
+import upload_release_artifacts as ura
+
+
+class _FakeStat:
+    """Serves canned ``stat_object`` results per key."""
+
+    def __init__(self, metadata: dict[str, _cdn_s3.ObjectMetadata | None]) -> None:
+        self._metadata = metadata
+        self.calls: list[tuple[str, bool]] = []
+
+    def __call__(
+        self, key: str, *, with_checksum: bool = False
+    ) -> _cdn_s3.ObjectMetadata | None:
+        self.calls.append((key, with_checksum))
+        return self._metadata.get(key)
+
+
+class _FakeResponse:
+    """Minimal ``urlopen`` context manager yielding a byte payload."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self, size: int = -1) -> bytes:
+        if not self._payload:
+            return b""
+        chunk, self._payload = self._payload[:size], self._payload[size:]
+        return chunk
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def _make_installer(tmp_path: Path, payload: bytes = b"installer-bytes") -> Path:
+    nested = tmp_path / "bundle" / "nsis"
+    nested.mkdir(parents=True)
+    installer = nested / ura.INSTALLER_NAME
+    installer.write_bytes(payload)
+    return installer
+
+
+def _digests(payload: bytes) -> tuple[str, str]:
+    digest = hashlib.sha256(payload).digest()
+    return digest.hex(), base64.b64encode(digest).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Key scheme and ordering — the pairing invariant
+# ---------------------------------------------------------------------------
+
+
+def test_release_entries_versioned_key_precedes_latest_alias():
+    entries = ura.release_entries("1.2.3")
+
+    assert [key for key, _ in entries] == [
+        "releases/v1.2.3/Origa_x64-setup.exe",
+        "releases/latest/Origa_x64-setup.exe",
+    ]
+    # Policies come from the shared tiered cache: archive is revalidatable
+    # (tag re-runs overwrite with different bytes), alias is always-fresh.
+    assert entries[0][1] == "public, max-age=300, must-revalidate"
+    assert entries[1][1] == "no-cache"
+
+
+# ---------------------------------------------------------------------------
+# find_installer
+# ---------------------------------------------------------------------------
+
+
+def test_find_installer_returns_the_single_match(tmp_path):
+    installer = _make_installer(tmp_path)
+
+    assert ura.find_installer(tmp_path) == installer
+
+
+def test_find_installer_rejects_missing_and_ambiguous(tmp_path):
+    with pytest.raises(SystemExit) as missing:
+        ura.find_installer(tmp_path)
+    assert missing.value.code == 1
+
+    _make_installer(tmp_path)
+    _make_installer(tmp_path / "second")
+
+    with pytest.raises(SystemExit) as ambiguous:
+        ura.find_installer(tmp_path)
+    assert ambiguous.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Version validation — stable-only contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["1.2.3-rc1", "1.2.3-rc.4", "v1.2.3", "1.2", "1.2.3.4", "abc", ""],
+)
+def test_non_stable_version_is_rejected(version, tmp_path, monkeypatch):
+    _make_installer(tmp_path)
+    monkeypatch.setattr(
+        sys, "argv", ["prog", "--version", version, "--artifact-dir", str(tmp_path)]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        ura.main()
+
+    assert exc.value.code == 1
+
+
+def test_stable_version_passes_validation(tmp_path, monkeypatch):
+    _make_installer(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", "--version", "1.2.3", "--artifact-dir", str(tmp_path), "--dry-run"],
+    )
+
+    ura.main()  # does not raise
+
+
+# ---------------------------------------------------------------------------
+# Dry run — must touch nothing remote
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_prints_plan_without_uploads(tmp_path, monkeypatch, capsys):
+    _make_installer(tmp_path)
+
+    def fail_upload(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("dry-run must not upload")
+
+    monkeypatch.setattr(_cdn_s3, "upload_file", fail_upload)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", "--version", "1.2.3", "--artifact-dir", str(tmp_path), "--dry-run"],
+    )
+
+    ura.main()
+
+    out = capsys.readouterr().out
+    assert "[DRY-RUN] releases/v1.2.3/Origa_x64-setup.exe" in out
+    assert "[DRY-RUN] releases/latest/Origa_x64-setup.exe" in out
+
+
+# ---------------------------------------------------------------------------
+# Upload orchestration — order, chunk, checksum
+# ---------------------------------------------------------------------------
+
+
+def test_main_uploads_both_keys_versioned_first(tmp_path, monkeypatch):
+    _make_installer(tmp_path)
+    uploads: list[dict[str, object]] = []
+
+    def fake_upload(_path, key, _cc, *, dry_run, **kwargs):
+        uploads.append({"key": key, "dry": dry_run, **kwargs})
+
+    def fake_verify_head(key, cache_control, size, sha_b64):
+        assert cache_control in ("public, max-age=300, must-revalidate", "no-cache")
+
+    def fake_verify_get(url, sha_hex, size):
+        assert url.startswith("https://")
+
+    monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
+    monkeypatch.setattr(ura, "verify_head", fake_verify_head)
+    monkeypatch.setattr(ura, "verify_public_get", fake_verify_get)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", "--version", "1.2.3", "--artifact-dir", str(tmp_path)],
+    )
+
+    ura.main()
+
+    assert [u["key"] for u in uploads] == [
+        "releases/v1.2.3/Origa_x64-setup.exe",
+        "releases/latest/Origa_x64-setup.exe",
+    ]
+    assert all(u["dry"] is False for u in uploads)
+    assert all(u["chunk_size"] == ura.UPLOAD_CHUNK_BYTES for u in uploads)
+    assert all(u["checksum_algorithm"] == "SHA256" for u in uploads)
+
+
+# ---------------------------------------------------------------------------
+# verify_head — layered verdicts
+# ---------------------------------------------------------------------------
+
+
+def _ok_metadata(payload: bytes, checksum: str | None) -> _cdn_s3.ObjectMetadata:
+    return _cdn_s3.ObjectMetadata(
+        cache_control="public, max-age=300, must-revalidate",
+        content_length=len(payload),
+        checksum_sha256=checksum,
+    )
+
+
+def test_verify_head_accepts_simple_checksum_match(monkeypatch, capsys):
+    payload = b"x" * 100
+    _, sha_b64 = _digests(payload)
+    key = "releases/v1.2.3/Origa_x64-setup.exe"
+    monkeypatch.setattr(
+        _cdn_s3,
+        "stat_object",
+        _FakeStat({key: _ok_metadata(payload, sha_b64)}),
+    )
+
+    ura.verify_head(key, "public, max-age=300, must-revalidate", len(payload), sha_b64)
+
+    out = capsys.readouterr().out
+    # The simple-format match passes silently through to the final line.
+    assert "HEAD ok" in out
+    assert "mismatch" not in out
+
+
+def test_verify_head_treats_composite_checksum_as_informational(
+    monkeypatch, capsys
+):
+    # Multipart uploads store a composite "<base64>-<parts>" checksum that
+    # never equals the plain file hash; treating it as a mismatch would fail
+    # every stable release. Integrity rests on the public GET check.
+    payload = b"x" * 100
+    _, sha_b64 = _digests(payload)
+    key = "releases/v1.2.3/Origa_x64-setup.exe"
+    composite = "nQJRx6+aaaaaaaaaaaaa==-7"
+    monkeypatch.setattr(
+        _cdn_s3, "stat_object", _FakeStat({key: _ok_metadata(payload, composite)})
+    )
+
+    ura.verify_head(key, "public, max-age=300, must-revalidate", len(payload), sha_b64)
+
+    out = capsys.readouterr().out
+    assert "composite" in out
+    assert "SHA256 ok" not in out
+
+
+def test_verify_head_fails_on_simple_checksum_mismatch(monkeypatch):
+    payload = b"x" * 100
+    _, local_b64 = _digests(payload)
+    key = "releases/v1.2.3/Origa_x64-setup.exe"
+    wrong_b64 = base64.b64encode(hashlib.sha256(b"other").digest()).decode("ascii")
+    monkeypatch.setattr(
+        _cdn_s3, "stat_object", _FakeStat({key: _ok_metadata(payload, wrong_b64)})
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        ura.verify_head(key, "public, max-age=300, must-revalidate", len(payload), local_b64)
+
+    assert exc.value.code == 1
+
+
+def test_verify_head_fails_on_cache_control_mismatch(monkeypatch):
+    # Only Cache-Control differs (size matches): a policy regression must
+    # fail verification even when the object itself is intact.
+    payload = b"x" * 10
+    key = "releases/latest/Origa_x64-setup.exe"
+    _, local_b64 = _digests(payload)
+    monkeypatch.setattr(
+        _cdn_s3, "stat_object", _FakeStat({key: _ok_metadata(payload, None)})
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        ura.verify_head(key, "no-cache", len(payload), local_b64)
+
+    assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# verify_public_get — the only end-to-end integrity check
+# ---------------------------------------------------------------------------
+
+
+def test_verify_public_get_accepts_matching_body(monkeypatch):
+    payload = b"y" * 5000
+    sha_hex, _ = _digests(payload)
+    monkeypatch.setattr(
+        ura.urllib.request, "urlopen", lambda *_a, **_k: _FakeResponse(payload)
+    )
+
+    ura.verify_public_get("https://cdn.example/releases/latest/x.exe", sha_hex, len(payload))
+
+
+def test_verify_public_get_fails_on_corrupted_body(monkeypatch):
+    payload = b"y" * 5000
+    sha_hex, _ = _digests(payload)
+    monkeypatch.setattr(
+        ura.urllib.request, "urlopen", lambda *_a, **_k: _FakeResponse(b"corrupt")
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        ura.verify_public_get("https://cdn.example/x.exe", sha_hex, len(payload))
+
+    assert exc.value.code == 1
+
+
+def test_verify_public_get_fails_on_network_error(monkeypatch):
+    import urllib.error
+
+    def raise_urlerror(*_a: object, **_k: object):
+        raise urllib.error.URLError("proxy timeout")
+
+    monkeypatch.setattr(ura.urllib.request, "urlopen", raise_urlerror)
+
+    with pytest.raises(SystemExit) as exc:
+        ura.verify_public_get("https://cdn.example/x.exe", "0" * 64, 10)
+
+    assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Happy path end to end (all transports faked)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_head_falls_back_to_plain_head_when_checksum_mode_rejected(
+    monkeypatch, capsys
+):
+    # A store that rejects ChecksumMode makes the first HEAD return None;
+    # the plain retry must keep the mandatory metadata checks alive.
+    payload = b"x" * 10
+    key = "releases/v1.2.3/Origa_x64-setup.exe"
+    _, local_b64 = _digests(payload)
+    plain = _cdn_s3.ObjectMetadata(
+        cache_control="public, max-age=300, must-revalidate",
+        content_length=len(payload),
+        checksum_sha256=None,
+    )
+    calls: list[bool] = []
+
+    def stat(key_called, *, with_checksum=False):
+        calls.append(with_checksum)
+        return None if with_checksum else plain
+
+    monkeypatch.setattr(_cdn_s3, "stat_object", stat)
+
+    ura.verify_head(
+        key, "public, max-age=300, must-revalidate", len(payload), local_b64
+    )
+
+    assert calls == [True, False]
+    out = capsys.readouterr().out
+    assert "HEAD ok" in out
+    assert "no stored checksum" in out
+
+
+def test_empty_cdn_base_url_env_falls_back_to_default(tmp_path, monkeypatch, capsys):
+    # An explicitly empty ORIGA_CDN_BASE_URL must not collapse GET URLs
+    # into relative paths — `or` falls back to the production default.
+    payload = b"installer"
+    _make_installer(tmp_path, payload)
+    sha_hex, sha_b64 = _digests(payload)
+    stat_map = {
+        "releases/v1.2.3/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
+            "public, max-age=300, must-revalidate", len(payload), None
+        ),
+        "releases/latest/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
+            "no-cache", len(payload), None
+        ),
+    }
+    monkeypatch.setattr(_cdn_s3, "upload_file", lambda *a, **k: None)
+    monkeypatch.setattr(_cdn_s3, "stat_object", _FakeStat(stat_map))
+    monkeypatch.setattr(
+        ura.urllib.request, "urlopen", lambda *_a, **_k: _FakeResponse(payload)
+    )
+    monkeypatch.setattr(sys, "argv", ["prog", "--version", "1.2.3", "--artifact-dir", str(tmp_path)])
+    monkeypatch.setenv("ORIGA_CDN_BASE_URL", "")
+
+    ura.main()
+
+    out = capsys.readouterr().out
+    assert ura.DEFAULT_CDN_BASE_URL in out
+
+
+def test_main_happy_path_prints_ms_store_link(tmp_path, monkeypatch, capsys):
+    payload = b"installer"
+    _make_installer(tmp_path, payload)
+    sha_hex, sha_b64 = _digests(payload)
+    stat_map = {
+        "releases/v1.2.3/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
+            "public, max-age=300, must-revalidate", len(payload), sha_b64
+        ),
+        "releases/latest/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
+            "no-cache", len(payload), None
+        ),
+    }
+    uploads: list[str] = []
+
+    def fake_upload(_path, key, _cc, *, dry_run, **_kwargs):
+        assert dry_run is False
+        uploads.append(key)
+
+    monkeypatch.setattr(_cdn_s3, "upload_file", fake_upload)
+    monkeypatch.setattr(_cdn_s3, "stat_object", _FakeStat(stat_map))
+    monkeypatch.setattr(
+        ura.urllib.request, "urlopen", lambda *_a, **_k: _FakeResponse(payload)
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", "--version", "1.2.3", "--artifact-dir", str(tmp_path)],
+    )
+    monkeypatch.delenv("ORIGA_CDN_BASE_URL", raising=False)
+
+    ura.main()
+
+    out = capsys.readouterr().out
+    assert uploads == [
+        "releases/v1.2.3/Origa_x64-setup.exe",
+        "releases/latest/Origa_x64-setup.exe",
+    ]
+    assert (
+        f"{ura.DEFAULT_CDN_BASE_URL}/releases/latest/{ura.INSTALLER_NAME}" in out
+    )
+    # Bootstrap contract: the full sha256 (for cross-checking against the
+    # GitHub Release digest) and the version are part of the output.
+    sha_hex, _ = _digests(payload)
+    assert f"SHA256: {sha_hex}" in out
+    assert "Version: 1.2.3" in out
+    assert "GET ok" in out

--- a/scripts/upload_release_artifacts.py
+++ b/scripts/upload_release_artifacts.py
@@ -1,0 +1,226 @@
+"""Upload the stable Windows installer to the CDN ``releases/`` prefix.
+
+Microsoft Store submission requires a DIRECT installer link (HTTP 200, no
+redirect chain); GitHub Releases URLs answer with a 302 to
+``objects.githubusercontent.com`` and get the submission rejected. This
+script uploads the fixed-name NSIS installer (the ADR-025 alias built by
+``_build-tauri.yml``) to the S3-backed CDN behind ``s3.origa.uwuwu.net``,
+producing two keys per stable release (ADR-041):
+
+- ``releases/v<version>/Origa_x64-setup.exe`` — permanent versioned archive.
+  Release-updated Cache-Control on purpose: a re-run of the same tag
+  overwrites the key with different installer bytes, so ``immutable`` would
+  poison the edge for a year (the PR #182 lesson).
+- ``releases/latest/Origa_x64-setup.exe`` — the no-cache alias handed to
+  Microsoft Store. Uploaded only AFTER the versioned key lands (pairing
+  invariant: the alias must never point at a release whose archive failed).
+
+Verification is layered once both uploads finish: an authenticated HEAD per
+key (Cache-Control and Content-Length mandatory; the stored SHA256 only when
+the store returns it in simple format — multipart uploads produce a
+composite ``<base64>-<parts>`` checksum that never equals the plain file
+hash), then a full public GET of both URLs comparing sha256 — the only check
+that exercises the proxy edge on the real ~58 MB body.
+
+Credentials come from the environment (CI) or the ``[origa]`` profile —
+see ``_cdn_s3._s3_upload_client``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import NoReturn
+
+import _cdn_cache
+import _cdn_s3
+
+INSTALLER_NAME = "Origa_x64-setup.exe"
+# A ~58 MB installer is 7 parts per key at 8 MB instead of ~3.5k sequential
+# 16 KB PUTs; 8 MB parts are proven on T3 (see _cdn_s3._transfer_config).
+UPLOAD_CHUNK_BYTES = 8 * 1024 * 1024
+# Stable-only contract: rc/alpha/local builds must never reach the MS Store
+# alias, so anything but a bare X.Y.Z is rejected outright.
+STABLE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+DEFAULT_CDN_BASE_URL = "https://s3.origa.uwuwu.net"
+HASH_CHUNK_BYTES = 8192
+GET_TIMEOUT_SECONDS = 300
+USER_AGENT = "origa-upload-release/1.0"
+
+
+def _fail(message: str) -> NoReturn:
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def release_entries(version: str) -> list[tuple[str, str]]:
+    """(key, Cache-Control) pairs; the versioned key MUST precede the alias."""
+    versioned = f"releases/v{version}/{INSTALLER_NAME}"
+    latest = f"releases/latest/{INSTALLER_NAME}"
+    return [
+        (versioned, _cdn_cache.cache_control_for(versioned)),
+        (latest, _cdn_cache.cache_control_for(latest)),
+    ]
+
+
+def find_installer(artifact_dir: Path) -> Path:
+    matches = sorted(artifact_dir.rglob(INSTALLER_NAME))
+    if len(matches) != 1:
+        _fail(
+            f"expected exactly one {INSTALLER_NAME} under {artifact_dir}, "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def sha256_digests(path: Path) -> tuple[str, str]:
+    """Return (hex, base64) SHA256 digests of the file."""
+    hasher = hashlib.sha256()
+    with path.open("rb") as f:
+        while chunk := f.read(HASH_CHUNK_BYTES):
+            hasher.update(chunk)
+    digest = hasher.digest()
+    return digest.hex(), base64.b64encode(digest).decode("ascii")
+
+
+def verify_head(
+    key: str,
+    expected_cache_control: str,
+    expected_size: int,
+    expected_sha256_b64: str,
+) -> None:
+    # One checksum-enabled HEAD; if the store rejects ChecksumMode the
+    # helper returns None and a plain HEAD retries — metadata checks stay
+    # mandatory either way.
+    metadata = _cdn_s3.stat_object(key, with_checksum=True)
+    if metadata is None:
+        metadata = _cdn_s3.stat_object(key)
+    if metadata is None:
+        _fail(f"HEAD failed for {key}")
+    if metadata.cache_control != expected_cache_control:
+        _fail(
+            f"Cache-Control mismatch for {key}: "
+            f"{metadata.cache_control!r} != {expected_cache_control!r}"
+        )
+    if metadata.content_length != expected_size:
+        _fail(
+            f"Content-Length mismatch for {key}: "
+            f"{metadata.content_length} != {expected_size}"
+        )
+
+    checksum = metadata.checksum_sha256
+    if checksum is None:
+        print(
+            f"  no stored checksum returned for {key}; "
+            "integrity rests on the public GET check"
+        )
+    elif "-" in checksum:
+        # Composite multipart checksum (checksum-of-checksums with a "-N"
+        # part-count suffix); comparing it against the plain file hash is
+        # never valid — the public GET check owns integrity here.
+        print(f"  composite multipart checksum for {key}; integrity via GET")
+    elif checksum != expected_sha256_b64:
+        _fail(f"SHA256 mismatch for {key}: {checksum} != {expected_sha256_b64}")
+    print(f"  HEAD ok: {key} [{metadata.cache_control}, {expected_size} B]")
+
+
+def verify_public_get(url: str, expected_sha256_hex: str, expected_size: int) -> None:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    hasher = hashlib.sha256()
+    total = 0
+    try:
+        with urllib.request.urlopen(request, timeout=GET_TIMEOUT_SECONDS) as response:
+            while chunk := response.read(HASH_CHUNK_BYTES):
+                hasher.update(chunk)
+                total += len(chunk)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        # ValueError covers malformed URLs (e.g. an empty base URL collapsing
+        # into a relative path) with an actionable message instead of a
+        # traceback.
+        _fail(f"public GET failed for {url}: {exc}")
+    if total != expected_size or hasher.hexdigest() != expected_sha256_hex:
+        _fail(
+            f"public GET content mismatch for {url}: "
+            f"{total} B (sha256 {hasher.hexdigest()[:16]}) "
+            f"vs {expected_size} B expected"
+        )
+    print(f"  GET ok: {url} ({total} B, sha256 match)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Upload stable Windows installer to CDN releases/ (ADR-041)"
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="stable version, e.g. 1.2.3 (no v prefix, no rc suffix)",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        required=True,
+        type=Path,
+        help="directory containing Origa_x64-setup.exe (e.g. extracted "
+        "windows-build artifact)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show planned uploads without touching S3",
+    )
+    args = parser.parse_args()
+
+    if not STABLE_VERSION_RE.match(args.version):
+        _fail(
+            f"--version must be a stable semver (X.Y.Z), got {args.version!r}; "
+            "rc/alpha builds must not reach the MS Store alias"
+        )
+
+    installer = find_installer(args.artifact_dir)
+    size = installer.stat().st_size
+    sha256_hex, sha256_b64 = sha256_digests(installer)
+    entries = release_entries(args.version)
+    # `or` (not a third get() default): an explicitly EMPTY variable must
+    # fall back too — otherwise the GET URLs collapse into relative paths
+    # and urlopen raises instead of verifying.
+    base_url = (os.environ.get("ORIGA_CDN_BASE_URL") or DEFAULT_CDN_BASE_URL).rstrip("/")
+
+    print(f"Installer: {installer} ({size} B)")
+    print(f"Version: {args.version}")
+    print(f"SHA256: {sha256_hex}")
+    if args.dry_run:
+        for key, cache_control in entries:
+            print(f"  [DRY-RUN] {key} [{cache_control}]")
+        return
+
+    for key, cache_control in entries:
+        print(f"Uploading {key} [{cache_control}]…")
+        _cdn_s3.upload_file(
+            installer,
+            key,
+            cache_control,
+            dry_run=False,
+            chunk_size=UPLOAD_CHUNK_BYTES,
+            checksum_algorithm="SHA256",
+        )
+
+    print("\nVerifying (authenticated HEAD):")
+    for key, cache_control in entries:
+        verify_head(key, cache_control, size, sha256_b64)
+
+    print("\nVerifying (public GET):")
+    for key, _ in entries:
+        verify_public_get(f"{base_url}/{key}", sha256_hex, size)
+
+    print(f"\nMicrosoft Store direct link:\n  {base_url}/releases/latest/{INSTALLER_NAME}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem
Microsoft Store rejected the submission: it requires a DIRECT installer URL (HTTP 200), GitHub Releases answer with 302.

## Solution (ADR-041)
Mirror the stable-only NSIS alias to the existing CDN bucket:
- `releases/v<X.Y.Z>/Origa_x64-setup.exe` — archive (must-revalidate; tag re-runs overwrite with non-reproducible bytes — immutable would poison the edge per PR #182)
- `releases/latest/Origa_x64-setup.exe` — the MS Store link (no-cache)

## Validation
- 335 unit tests (new: upload/verify/env-branch/chunk-cache/retry/boto3-error-flavor cases)
- End-to-end proven live: local run uploaded both keys through T3 (checksum attempt → InternalError → checksum-less retry), verified HEAD (Cache-Control, size) + full public GET (sha256 match through the real edge)
- CI job isolated from `release.needs` (RuStore precedent); pipefail so a failed upload is red
- actionlint / ruff / qlty clean

## Also
- Fixed latent `_cdn_s3` bug: boto3's own `S3UploadFailedError` (≠ s3transfer's) escaped the catch as a raw traceback
- Fixed pre-existing SYNC_DIRS test drift (PR #412)
- Deleted orphaned user-Tigris bucket `origa-cdn` (see `docs/backups/orphaned-cdn-cleanup.2026-08-22.txt`); Cloudflare remnants (R2/Worker/DNS) documented there — need interactive wrangler login
- AGENTS.md CDN section synced with post-revert reality