### PR TITLE
fix(cdn): versioned store URL without 'v' prefix (MS Store validation)

### DIFF
--- a/.github/workflows/_upload-release-cdn.yml
+++ b/.github/workflows/_upload-release-cdn.yml
@@ -6,7 +6,7 @@ name: Upload installer to CDN
 # with a 302 to objects.githubusercontent.com and get rejected, so the
 # fixed-name NSIS alias (ADR-025) is mirrored to:
 #
-#   releases/v<version>/Origa_x64-setup.exe  - permanent versioned archive
+#   releases/<version>/Origa_x64-setup.exe  - permanent versioned archive (no "v" prefix: MS Store parses the version from the URL path)
 #   releases/latest/Origa_x64-setup.exe      - the MS Store direct link
 #
 # STABLE-ONLY contract: prerelease (RC) and alpha are gated out by the
@@ -82,10 +82,10 @@ jobs:
                     --artifact-dir ../windows-build \
                     | tee upload.log
 
-                  # The job is green here — the upload succeeded. A missing
-                  # URL in the log is a summary-extraction regression only:
-                  # warn loudly but do not fail the release job for cosmetics.
-                  MS_STORE_URL="$(grep -o 'https://.*/releases/latest/Origa_x64-setup.exe' upload.log | tail -1)"
+                  # The store submission URL is the VERSIONED key (MS Store
+                  # parses X.Y.Z out of the path; "v" prefixes fail its
+                  # validation). The latest/ alias is for humans only.
+                  MS_STORE_URL="$(grep -o 'https://.*/releases/[0-9][0-9.]*[0-9]/Origa_x64-setup.exe' upload.log | tail -1)"
                   if [ -z "$MS_STORE_URL" ]; then
                     echo "::warning::Could not extract the MS Store URL from the upload log — check the script output above."
                     exit 0
@@ -93,7 +93,7 @@ jobs:
                   {
                     echo "## Microsoft Store direct link"
                     echo ""
-                    echo "Stable \`${{ inputs.version }}\` installer is live on the CDN:"
+                    echo "Stable \`${{ inputs.version }}\` installer is live on the CDN"
                     echo ""
                     echo "``"
                     echo "$MS_STORE_URL"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,8 @@ Tigris object storage (S3-compatible, endpoint `t3.storageapi.dev`) под Railw
 Все объекты — статические, но кэшируются по-разному в зависимости от частоты изменений. Политика в `scripts/_cdn_cache.py`, применяется в `deploy_cdn.py`.
 
 - **Truly-static** (`public, max-age=31536000, immutable`): ML-модели (`ndlocr/`, `whisper/`), kanji SVG/frames (`kanji_animations/`, `kanji_frames/`), audio фраз (`phrases/audio/`), системный словарь lindera (`dictionaries/`)
-- **Release-updated** (`public, max-age=300, must-revalidate`): контент-JSON — `grammar/`, `dictionary/`, `phrases/phrase_index.json`, `phrases/data/`, `pitch/`, `well_known_set/`, а также версионированные инсталлеры `releases/v*.*.*/` (перезаписываемы при re-run тега)
-- **Always-fresh** (`no-cache`): `manifest.json`, `releases/latest/` (прямой линк для Microsoft Store, ADR-041)
+- **Release-updated** (`public, max-age=300, must-revalidate`): контент-JSON — `grammar/`, `dictionary/`, `phrases/phrase_index.json`, `phrases/data/`, `pitch/`, `well_known_set/`, а также версионированные инсталлеры `releases/<X.Y.Z>/` (перезаписываемы при re-run тега; без префикса `v` — MS Store парсит версию из URL)
+- **Always-fresh** (`no-cache`): `manifest.json`, `releases/latest/` (человекочитаемый алиас последнего stable; в MS Store сабмитится версионируемый `releases/<X.Y.Z>/`, ADR-041)
 
 immutable уместен только для truly-static файлов. `grammar`/`phrases`/`dictionary` обновляются каждый релиз (W-11, P-3, L-4, S-3) — для них immutable означал CDN edge-cache poisoning (PR #182): S3 обновлялся, а edge держал годовой кэш и отдавал устаревшую версию, пока кэш не сбросили вручную.
 
@@ -118,7 +118,7 @@ python scripts/deploy_cdn.py --dry-run  # показать что будет з�
 
 ### Релизные инсталлеры (`releases/`, ADR-041)
 
-Microsoft Store требует прямую ссылку (HTTP 200) — GitHub Releases дают 302. Stable-релизы зеркалируют NSIS-алиас `Origa_x64-setup.exe` (ADR-025) в bucket job'ом `upload-release-cdn` (`tauri.yml`): `releases/v<version>/` (архив) + `releases/latest/` (ссылка для стора). Заливка верифицируется: authenticated HEAD (Cache-Control, размер, чексумма при simple-формате) + полный публичный GET с sha256. RC не заливаются.
+Microsoft Store требует прямую версионируемую ссылку (HTTP 200 + версия в пути без префикса `v`, напр. `.../releases/0.6.4/setup.exe`) — GitHub Releases дают 302. Stable-релизы зеркалируют NSIS-алиас `Origa_x64-setup.exe` (ADR-025) в bucket job'ом `upload-release-cdn` (`tauri.yml`): `releases/<version>/` (архив — именно его сабмитят в стор) + `releases/latest/` (алиас для людей). Заливка верифицируется: authenticated HEAD (Cache-Control, размер, чексумма при simple-формате) + полный публичный GET с sha256. RC не заливаются.
 
 ```powershell
 # вручную (bootstrap текущего stable; exe скачать из GitHub Release):

--- a/docs/decisions/ADR-041-installer-direct-link-cdn.md
+++ b/docs/decisions/ADR-041-installer-direct-link-cdn.md
@@ -34,14 +34,24 @@ alias `Origa_x64-setup.exe` — into the existing CDN bucket under a new
 
 | Key | Purpose | Cache-Control |
 | --- | --- | --- |
-| `releases/v<X.Y.Z>/Origa_x64-setup.exe` | permanent versioned archive | `public, max-age=300, must-revalidate` (release-updated) |
-| `releases/latest/Origa_x64-setup.exe` | the direct link handed to Microsoft Store | `no-cache` |
+| `releases/<X.Y.Z>/Origa_x64-setup.exe` | permanent versioned archive — **the URL submitted to the store** | `public, max-age=300, must-revalidate` (release-updated) |
+| `releases/latest/Origa_x64-setup.exe` | convenience alias (landing page, manual testing) | `no-cache` |
 
-`https://s3.origa.uwuwu.net/releases/latest/Origa_x64-setup.exe` is a
-stable URL — submitted to the store once, it always serves the latest
-stable installer. RC/prerelease tags are gated out (stable-only contract at
-three layers: `tauri.yml` if-clause, reusable-workflow self-gate, strict
-`^\d+\.\d+\.\d+$` version validation in the script).
+**Submission contract learned from the store's validation (2026-08-23):**
+the store REQUIRES the submitted URL to be versioned — it parses a version
+out of the path (its example is `.../downloads/1.1/setup.exe`) and rejects
+anything it cannot parse as `X.Y.Z`. Two consequences: (1) the version
+segment carries NO `v` prefix — `releases/v0.6.4/` fails validation with
+the generic "must point to a versioned package" error while
+`releases/0.6.4/` passes; (2) the submitted URL is the VERSIONED key per
+release (each app update = new URL + resubmission), so the `latest` alias
+is NOT what goes into the store form — it exists for humans, not for the
+store bot.
+
+`https://s3.origa.uwuwu.net/releases/<X.Y.Z>/Origa_x64-setup.exe` is the
+per-release store URL. RC/prerelease tags are gated out (stable-only
+contract at three layers: `tauri.yml` if-clause, reusable-workflow
+self-gate, strict `^\d+\.\d+\.\d+$` version validation in the script).
 
 ### Why the existing Railway bucket
 
@@ -143,7 +153,7 @@ uv run python upload_release_artifacts.py --version <X.Y.Z> --artifact-dir <dir>
 - Railway egress if the link leaks publicly (MS Store fetches are rare;
   monitored via Railway metrics — see ADR-037 for the investigation
   workflow).
-- `releases/v*` re-upload on tag re-run briefly serves mixed cache states
+- `releases/<X.Y.Z>*` re-upload on tag re-run briefly serves mixed cache states
   (≤5 min, bounded by must-revalidate).
 
 ## Alternatives considered

--- a/scripts/_cdn_cache.py
+++ b/scripts/_cdn_cache.py
@@ -15,8 +15,9 @@ Files are split into three categories by how often they change:
   flushed by hand.
 - ALWAYS-FRESH (no-cache): manifest.json — the client's change-detection
   beacon, re-fetched every session — and ``releases/latest/`` — the
-  stable-alias Windows installer URL handed to Microsoft Store (ADR-041),
-  which must never be edge-cached across a release cutover.
+  human-facing stable installer alias (the store submission uses the
+  versioned ``releases/<X.Y.Z>/`` URL, ADR-041); the alias must never be
+  edge-cached across a release cutover.
 
 Any path matching no rule falls back to the conservative release-updated
 policy: a 5-min 304 revalidation is cheap when unchanged and bounds staleness

--- a/scripts/tests/test_cdn_cache.py
+++ b/scripts/tests/test_cdn_cache.py
@@ -60,7 +60,7 @@ def test_versioned_installer_archive_is_release_updated():
     # poison the edge for a year (PR #182 lesson). 5-min must-revalidate
     # self-heals the overwrite.
     assert (
-        cache_control_for("releases/v1.2.3/Origa_x64-setup.exe") == RELEASE_UPDATED
+        cache_control_for("releases/1.2.3/Origa_x64-setup.exe") == RELEASE_UPDATED
     )
 
 

--- a/scripts/tests/test_cdn_s3.py
+++ b/scripts/tests/test_cdn_s3.py
@@ -425,7 +425,7 @@ def test_upload_file_passes_chunk_size_config_and_checksum(tmp_path, monkeypatch
     chunk = 8 * 1024 * 1024
     upload_file(
         local,
-        "releases/v1.2.3/Origa_x64-setup.exe",
+        "releases/1.2.3/Origa_x64-setup.exe",
         "public, max-age=300, must-revalidate",
         dry_run=False,
         chunk_size=chunk,
@@ -595,5 +595,5 @@ def test_stat_object_returns_none_with_warning_on_error(monkeypatch, capsys):
     err = ClientError({"Error": {"Code": "404", "Message": "NoSuchKey"}}, "HeadObject")
     monkeypatch.setattr(_cdn_s3, "_s3_upload_client", lambda: _FakeHeadClient(exc=err))
 
-    assert _cdn_s3.stat_object("releases/v9.9.9/missing.exe") is None
+    assert _cdn_s3.stat_object("releases/9.9.9/missing.exe") is None
     assert "WARNING" in capsys.readouterr().err

--- a/scripts/tests/test_upload_release_artifacts.py
+++ b/scripts/tests/test_upload_release_artifacts.py
@@ -76,7 +76,7 @@ def test_release_entries_versioned_key_precedes_latest_alias():
     entries = ura.release_entries("1.2.3")
 
     assert [key for key, _ in entries] == [
-        "releases/v1.2.3/Origa_x64-setup.exe",
+        "releases/1.2.3/Origa_x64-setup.exe",
         "releases/latest/Origa_x64-setup.exe",
     ]
     # Policies come from the shared tiered cache: archive is revalidatable
@@ -162,7 +162,7 @@ def test_dry_run_prints_plan_without_uploads(tmp_path, monkeypatch, capsys):
     ura.main()
 
     out = capsys.readouterr().out
-    assert "[DRY-RUN] releases/v1.2.3/Origa_x64-setup.exe" in out
+    assert "[DRY-RUN] releases/1.2.3/Origa_x64-setup.exe" in out
     assert "[DRY-RUN] releases/latest/Origa_x64-setup.exe" in out
 
 
@@ -196,7 +196,7 @@ def test_main_uploads_both_keys_versioned_first(tmp_path, monkeypatch):
     ura.main()
 
     assert [u["key"] for u in uploads] == [
-        "releases/v1.2.3/Origa_x64-setup.exe",
+        "releases/1.2.3/Origa_x64-setup.exe",
         "releases/latest/Origa_x64-setup.exe",
     ]
     assert all(u["dry"] is False for u in uploads)
@@ -220,7 +220,7 @@ def _ok_metadata(payload: bytes, checksum: str | None) -> _cdn_s3.ObjectMetadata
 def test_verify_head_accepts_simple_checksum_match(monkeypatch, capsys):
     payload = b"x" * 100
     _, sha_b64 = _digests(payload)
-    key = "releases/v1.2.3/Origa_x64-setup.exe"
+    key = "releases/1.2.3/Origa_x64-setup.exe"
     monkeypatch.setattr(
         _cdn_s3,
         "stat_object",
@@ -243,7 +243,7 @@ def test_verify_head_treats_composite_checksum_as_informational(
     # every stable release. Integrity rests on the public GET check.
     payload = b"x" * 100
     _, sha_b64 = _digests(payload)
-    key = "releases/v1.2.3/Origa_x64-setup.exe"
+    key = "releases/1.2.3/Origa_x64-setup.exe"
     composite = "nQJRx6+aaaaaaaaaaaaa==-7"
     monkeypatch.setattr(
         _cdn_s3, "stat_object", _FakeStat({key: _ok_metadata(payload, composite)})
@@ -259,7 +259,7 @@ def test_verify_head_treats_composite_checksum_as_informational(
 def test_verify_head_fails_on_simple_checksum_mismatch(monkeypatch):
     payload = b"x" * 100
     _, local_b64 = _digests(payload)
-    key = "releases/v1.2.3/Origa_x64-setup.exe"
+    key = "releases/1.2.3/Origa_x64-setup.exe"
     wrong_b64 = base64.b64encode(hashlib.sha256(b"other").digest()).decode("ascii")
     monkeypatch.setattr(
         _cdn_s3, "stat_object", _FakeStat({key: _ok_metadata(payload, wrong_b64)})
@@ -340,7 +340,7 @@ def test_verify_head_falls_back_to_plain_head_when_checksum_mode_rejected(
     # A store that rejects ChecksumMode makes the first HEAD return None;
     # the plain retry must keep the mandatory metadata checks alive.
     payload = b"x" * 10
-    key = "releases/v1.2.3/Origa_x64-setup.exe"
+    key = "releases/1.2.3/Origa_x64-setup.exe"
     _, local_b64 = _digests(payload)
     plain = _cdn_s3.ObjectMetadata(
         cache_control="public, max-age=300, must-revalidate",
@@ -372,7 +372,7 @@ def test_empty_cdn_base_url_env_falls_back_to_default(tmp_path, monkeypatch, cap
     _make_installer(tmp_path, payload)
     sha_hex, sha_b64 = _digests(payload)
     stat_map = {
-        "releases/v1.2.3/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
+        "releases/1.2.3/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
             "public, max-age=300, must-revalidate", len(payload), None
         ),
         "releases/latest/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
@@ -398,7 +398,7 @@ def test_main_happy_path_prints_ms_store_link(tmp_path, monkeypatch, capsys):
     _make_installer(tmp_path, payload)
     sha_hex, sha_b64 = _digests(payload)
     stat_map = {
-        "releases/v1.2.3/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
+        "releases/1.2.3/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
             "public, max-age=300, must-revalidate", len(payload), sha_b64
         ),
         "releases/latest/Origa_x64-setup.exe": _cdn_s3.ObjectMetadata(
@@ -427,12 +427,18 @@ def test_main_happy_path_prints_ms_store_link(tmp_path, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert uploads == [
-        "releases/v1.2.3/Origa_x64-setup.exe",
+        "releases/1.2.3/Origa_x64-setup.exe",
         "releases/latest/Origa_x64-setup.exe",
     ]
     assert (
         f"{ura.DEFAULT_CDN_BASE_URL}/releases/latest/{ura.INSTALLER_NAME}" in out
     )
+    # The store submission contract: the VERSIONED URL (no "v" prefix) is
+    # what goes into the MS Store form, and it must be labeled as such.
+    assert (
+        f"{ura.DEFAULT_CDN_BASE_URL}/releases/1.2.3/{ura.INSTALLER_NAME}" in out
+    )
+    assert "store submission (versioned)" in out
     # Bootstrap contract: the full sha256 (for cross-checking against the
     # GitHub Release digest) and the version are part of the output.
     sha_hex, _ = _digests(payload)

--- a/scripts/upload_release_artifacts.py
+++ b/scripts/upload_release_artifacts.py
@@ -7,7 +7,7 @@ script uploads the fixed-name NSIS installer (the ADR-025 alias built by
 ``_build-tauri.yml``) to the S3-backed CDN behind ``s3.origa.uwuwu.net``,
 producing two keys per stable release (ADR-041):
 
-- ``releases/v<version>/Origa_x64-setup.exe`` — permanent versioned archive.
+- ``releases/<version>/Origa_x64-setup.exe`` (no "v" prefix — see release_entries) — permanent versioned archive.
   Release-updated Cache-Control on purpose: a re-run of the same tag
   overwrites the key with different installer bytes, so ``immutable`` would
   poison the edge for a year (the PR #182 lesson).
@@ -61,8 +61,15 @@ def _fail(message: str) -> NoReturn:
 
 
 def release_entries(version: str) -> list[tuple[str, str]]:
-    """(key, Cache-Control) pairs; the versioned key MUST precede the alias."""
-    versioned = f"releases/v{version}/{INSTALLER_NAME}"
+    """(key, Cache-Control) pairs; the versioned key MUST precede the alias.
+
+    The version path segment carries NO \"v\" prefix: Microsoft Store parses
+    the version out of the package URL (their example is
+    ``.../downloads/1.1/setup.exe\") and rejects \"v0.6.4\" as a versioned
+    URL — the submission fails with a generic \"must point to a versioned
+    package\" error.
+    """
+    versioned = f"releases/{version}/{INSTALLER_NAME}"
     latest = f"releases/latest/{INSTALLER_NAME}"
     return [
         (versioned, _cdn_cache.cache_control_for(versioned)),
@@ -219,7 +226,9 @@ def main() -> None:
     for key, _ in entries:
         verify_public_get(f"{base_url}/{key}", sha256_hex, size)
 
-    print(f"\nMicrosoft Store direct link:\n  {base_url}/releases/latest/{INSTALLER_NAME}")
+    print("\nRelease URLs:")
+    print(f"  store submission (versioned): {base_url}/releases/{args.version}/{INSTALLER_NAME}")
+    print(f"  latest alias (humans):        {base_url}/releases/latest/{INSTALLER_NAME}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Store's example `.../downloads/1.1/setup.exe` shows it parses the version from the URL path — `v0.6.4` fails validation. Key scheme is now `releases/<X.Y.Z>/Origa_x64-setup.exe` (that URL goes into the store form each release); `releases/latest/` remains a human alias.

Bootstrap done: 0.6.4 re-uploaded under the new key (sha256 identical to the release artifact, verified HEAD+GET), old `v`-prefixed keys deleted.

- [x] 335 tests green, ruff/actionlint clean