### PR TITLE
fix(ci): skip updater signing on Dependabot builds via --no-sign

### DIFF
--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -80,13 +80,14 @@ jobs:
             SENTRY_DSN: ${{ vars.SENTRY_DSN }}
             SENTRY_ENVIRONMENT: ${{ inputs.version_type == 'stable' && 'production' || inputs.version_type == 'prerelease' && 'staging' || 'development' }}
             # Skip updater signing for Dependabot PRs. GitHub hides repository
-            # `secrets.*` from Dependabot runs, but caller workflows pass a
-            # dummy private key via `vars.TAURI_CI_DUMMY_PRIVATE_KEY` (vars are
-            # visible to Dependabot). The dummy key reaches the build, yet its
-            # password is empty — Tauri fails with "incorrect updater private
-            # key password: Wrong password for that key". Short-circuiting to
-            # an empty value makes Tauri skip the updater signing step entirely,
-            # which is the desired behaviour for compile-only verification.
+            # `secrets.*` from Dependabot runs; the caller's dummy-key fallback
+            # (`vars.TAURI_CI_DUMMY_PRIVATE_KEY`) is neutralized here by
+            # short-circuiting to an empty value. NOTE: an empty-string key does
+            # NOT make the bundler skip signing by itself — `env::var().ok()`
+            # yields Some("") which still enters key decoding and fails with
+            # "failed to decode secret key: … Missing comment in secret key".
+            # The actual skip is done by passing --no-sign to `cargo tauri build`
+            # in the build steps below (bundler returns before touching keys).
             TAURI_SIGNING_PRIVATE_KEY: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key || '' }}
             TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ github.actor != 'dependabot[bot]' && secrets.tauri-signing-private-key-password || '' }}
             XWIN_CACHE_DIR: ${{ github.workspace }}/.xwin-cache
@@ -138,7 +139,16 @@ jobs:
 
             - name: Build Tauri app for Windows
               working-directory: tauri
-              run: cargo tauri build --runner cargo-xwin --target x86_64-pc-windows-msvc
+              # --no-sign for Dependabot: the real signing key is unavailable on
+              # bot runs, and even an empty TAURI_SIGNING_PRIVATE_KEY makes the
+              # bundler attempt key decoding (see env comment above). --no-sign
+              # skips updater signing entirely — compile+bundle-only verification.
+              run: |
+                  EXTRA_FLAGS=""
+                  if [ "$GITHUB_ACTOR" = "dependabot[bot]" ]; then
+                      EXTRA_FLAGS="--no-sign"
+                  fi
+                  cargo tauri build --runner cargo-xwin --target x86_64-pc-windows-msvc $EXTRA_FLAGS
               env:
                   TAURI_BUNDLE_NSIS: "true"
 
@@ -242,7 +252,13 @@ jobs:
 
             - name: Build Tauri app for Linux
               working-directory: tauri
-              run: cargo tauri build --target x86_64-unknown-linux-gnu
+              # --no-sign for Dependabot — see build-windows for the rationale.
+              run: |
+                  EXTRA_FLAGS=""
+                  if [ "$GITHUB_ACTOR" = "dependabot[bot]" ]; then
+                      EXTRA_FLAGS="--no-sign"
+                  fi
+                  cargo tauri build --target x86_64-unknown-linux-gnu $EXTRA_FLAGS
 
             - name: Create fixed-name aliases
               working-directory: target/x86_64-unknown-linux-gnu/release/bundle


### PR DESCRIPTION
## Problem

All 13 open Dependabot PRs fail `Build Tauri / Build Windows` and `Build Tauri / Build Linux` with the same error regardless of what they change:

```
Error failed to decode secret key: incorrect updater private key password: Missing comment in secret key
```

This blocks every Dependabot PR in CI Gate (`mergeStateStatus: BLOCKED`), including the critical tauri 2.10.3 → 2.11.1 security bump (#436, #380).

## Root cause

1. GitHub hides repository **secrets** from workflows triggered by Dependabot PRs, so `secrets.TAURI_SIGNING_PRIVATE_KEY` is empty.
2. The caller's fallback `${{ secrets.TAURI_SIGNING_PRIVATE_KEY || vars.TAURI_CI_DUMMY_PRIVATE_KEY }}` supplies a dummy key, which the reusable workflow neutralizes by short-circuiting to `''` for `dependabot[bot]`.
3. However, an **empty-string** key does not make the bundler skip signing: in `tauri-cli`'s `sign_updaters()` (`crates/tauri-cli/src/bundle.rs`), `std::env::var("TAURI_SIGNING_PRIVATE_KEY").ok()` yields `Some("")` — the "no private key" guard only triggers on `None`. The empty key then fails minisign decoding → *"Missing comment in secret key"*.
4. The existing `tauri/build.rs` mitigation from #340 (patching `bundle.createUpdaterArtifacts: false` via `TAURI_CONFIG`) cannot help here: the build script runs as a cargo child process, so its `set_var` never reaches the CLI's already-loaded config used for bundling.

## Fix

Pass **`--no-sign`** to `cargo tauri build` when `GITHUB_ACTOR == 'dependabot[bot]'` in both build jobs of `_build-tauri.yml`.

In `tauri-cli`, `settings.no_sign()` returns early from `sign_updaters()` *before* any key/password handling:

```rust
if settings.no_sign() {
    log::warn!("Updater signing is skipped due to --no-sign flag.");
    return Ok(());
}
```

So Dependabot builds still fully compile and bundle the app on all three platforms (real verification), just without `.sig` updater files — which are never published outside release builds anyway.

Also updates the stale comment that claimed an empty key value makes Tauri skip signing.

## Verification

- Non-Dependabot runs are untouched: `GITHUB_ACTOR != 'dependabot[bot]'` ⇒ `EXTRA_FLAGS=""` ⇒ command identical to before. This PR's own CI exercises that path.
- The `.sig` extraction steps already tolerate missing signature files (`|| true` + `ls … | head -1 || true`), so artifact upload works unchanged for Dependabot builds.
- Android job is already actor-gated; Apple builds don't run on Dependabot PRs.
- After merge: `@dependabot rebase` on the open PRs will re-run CI and confirm the green path.