### PR TITLE
ci: bump github actions to node24 majors (checkout v7, download-artifact v8, upload-artifact v7, docker actions)

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -81,7 +81,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Select latest Xcode with iOS 26 SDK
               shell: bash
@@ -276,7 +276,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Select latest Xcode with macOS SDK
               shell: bash

--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -204,7 +204,7 @@ jobs:
                   ls -la "$IPA_PATH"
 
             - name: Upload .ipa artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ios-build
                   path: ${{ steps.ipa.outputs.path }}
@@ -551,7 +551,7 @@ jobs:
                   ls -la "$PKG_PATH"
 
             - name: Upload .pkg artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: macos-pkg-build
                   path: ${{ steps.pkg.outputs.path }}

--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -94,7 +94,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download WASM artifact
               uses: actions/download-artifact@v8
@@ -211,7 +211,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download WASM artifact
               uses: actions/download-artifact@v8
@@ -325,7 +325,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download WASM artifact
               uses: actions/download-artifact@v8

--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -181,7 +181,7 @@ jobs:
                   fi
 
             - name: Upload Windows artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: windows-build
                   path: |
@@ -286,7 +286,7 @@ jobs:
                   fi
 
             - name: Upload Linux artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: linux-build
                   path: |
@@ -450,7 +450,7 @@ jobs:
                   cp "$src" "origa.apk"
 
             - name: Upload Android APK
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: android-apk
                   path: |
@@ -522,7 +522,7 @@ jobs:
             - name: Upload Android AAB
               if: steps.rename-aab.outcome == 'success'
               continue-on-error: true
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               env:
                   VERSION: ${{ inputs.version }}
               with:

--- a/.github/workflows/_build-windows-store.yml
+++ b/.github/workflows/_build-windows-store.yml
@@ -82,7 +82,7 @@ jobs:
               run: ./scripts/build-msix.ps1 -Version '${{ inputs.version }}'
 
             - name: Upload MSIX artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: windows-msix
                   path: |

--- a/.github/workflows/_build-windows-store.yml
+++ b/.github/workflows/_build-windows-store.yml
@@ -46,7 +46,7 @@ jobs:
             SENTRY_ENVIRONMENT: ${{ inputs.version_type == 'stable' && 'production' || inputs.version_type == 'prerelease' && 'staging' || 'development' }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download WASM artifact
               uses: actions/download-artifact@v8

--- a/.github/workflows/_upload-rustore.yml
+++ b/.github/workflows/_upload-rustore.yml
@@ -54,7 +54,7 @@ jobs:
             RUSTORE_API: https://public-api.rustore.ru
         steps:
             - name: Download AAB artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: android-aab
                   path: aab/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             commit_short: ${{ steps.version.outputs.commit_short }}
             build_date: ${{ steps.version.outputs.build_date }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
                   filter: blob:none
@@ -58,7 +58,7 @@ jobs:
             ORIGA_CDN_BASE_URL: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Setup Rust
               uses: ./.github/actions/setup-rust
@@ -94,7 +94,7 @@ jobs:
             TRAILBASE_URL: "https://${{ vars.ORIGA_APP_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Cache APT packages
               uses: awalsh128/cache-apt-pkgs-action@v1.6.1
@@ -146,7 +146,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download CDN data
               uses: ./.github/actions/download-cdn
@@ -174,7 +174,7 @@ jobs:
             TRAILBASE_URL: "https://${{ vars.ORIGA_APP_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Cache APT packages
               uses: awalsh128/cache-apt-pkgs-action@v1.6.1
@@ -226,7 +226,7 @@ jobs:
             ORIGA_CDN_BASE_URL: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Cache APT packages
               uses: awalsh128/cache-apt-pkgs-action@v1.6.1
@@ -273,7 +273,7 @@ jobs:
             TRAILBASE_URL: http://localhost:4000
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Cache APT packages
               uses: awalsh128/cache-apt-pkgs-action@v1.6.1
@@ -341,7 +341,7 @@ jobs:
             CI: "true"
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download WASM artifact
               uses: actions/download-artifact@v8
@@ -455,7 +455,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Install Node.js dependencies
               working-directory: end2end
@@ -532,7 +532,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
@@ -555,7 +555,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
                   cdn-base-url: ${{ vars.ORIGA_CDN_BASE_URL }}
 
             - name: Upload CDN artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: cdn-data
                   path: cdn/
@@ -312,7 +312,7 @@ jobs:
                   TRAILBASE_URL: http://localhost:4000
 
             - name: Upload WASM artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: wasm-dist
                   path: origa_ui/dist/
@@ -440,7 +440,7 @@ jobs:
 
             - name: Upload blob report
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: blob-report-${{ matrix.group }}
                   path: end2end/blob-report/
@@ -498,7 +498,7 @@ jobs:
 
             - name: Upload merged Playwright report
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report-merged
                   path: end2end/playwright-report/
@@ -535,10 +535,10 @@ jobs:
               uses: actions/checkout@v7
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@v4
 
             - name: Build landing image
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@v7
               with:
                   context: .
                   file: ./origa_landing/Dockerfile
@@ -558,10 +558,10 @@ jobs:
               uses: actions/checkout@v7
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@v4
 
             - name: Build UI image
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@v7
               with:
                   context: .
                   file: ./origa_ui/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,7 @@ jobs:
               uses: actions/checkout@v7
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@v4
 
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v4
@@ -88,7 +88,7 @@ jobs:
                       type=sha,prefix=
 
             - name: Build and push Docker image
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@v7
               with:
                   context: .
                   file: ${{ matrix.dockerfile }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
             commit_short: ${{ steps.version.outputs.commit_short }}
             build_date: ${{ steps.version.outputs.build_date }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
                   filter: blob:none
@@ -65,7 +65,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
@@ -129,7 +129,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Wait for landing deployment
               run: sleep 30

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -105,7 +105,7 @@ jobs:
                   ORIGA_CDN_REGION: ${{ vars.ORIGA_CDN_REGION }}
 
             - name: Upload frontend artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: frontend-dist
                   path: origa_ui/dist/
@@ -244,7 +244,7 @@ jobs:
                   cat latest.json
 
             - name: Upload latest.json artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: latest-json
                   path: latest.json

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -38,7 +38,7 @@ jobs:
             commit_short: ${{ steps.version.outputs.commit_short }}
             build_date: ${{ steps.version.outputs.build_date }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
                   filter: blob:none
@@ -67,7 +67,7 @@ jobs:
             SENTRY_ENVIRONMENT: ${{ needs.version.outputs.version_type == 'stable' && 'production' || needs.version.outputs.version_type == 'prerelease' && 'staging' || 'development' }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Update version in config files
               uses: ./.github/actions/update-version


### PR DESCRIPTION
Single manual update superseding dependabot PRs #367 and #369, plus the same-class Node.js 20 deprecation fixes.

## Changes (2 commits)

**1. actions bumps (#367 + #369)**
- `actions/checkout` v4 → **v7** — 22 usages across all workflows. v7: ESM runtime; blocks fork-PR checkouts for `pull_request_target`/`workflow_run`.
- `actions/download-artifact` v4 → **v8** — `_upload-rustore.yml` (the only remaining v4; everywhere else already v8). v8: ESM; digest-mismatch now errors by default.

**2. Node.js 20 deprecation cleanup**
- `docker/build-push-action` v6 → **v7.3.0** (node24)
- `docker/setup-buildx-action` v3 → **v4.3.0** (node24)
- `actions/upload-artifact` v4 → **v7.0.1** (node24) — same warning class, 14 usages

All target versions verified to run on `node24`, silencing the "Node.js 20 is deprecated … forced to run on Node.js 24" runner warnings.