### PR TITLE
ci(macos): fix codesign post-step exit 50; build macOS in CI

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -28,6 +28,12 @@ on:
             skip_apple:
                 type: boolean
                 default: false
+            # Skip the iOS build only (macOS still builds). ci.yml runs
+            # macOS-only to keep macOS runner minutes bounded on every
+            # push; iOS stays a release-time target (tauri.yml).
+            skip_ios:
+                type: boolean
+                default: false
         secrets:
             apple-api-issuer:
                 required: false
@@ -63,7 +69,7 @@ env:
 jobs:
     build-ios:
         name: Build iOS
-        if: github.actor != 'dependabot[bot]' && inputs.skip_apple != true
+        if: github.actor != 'dependabot[bot]' && inputs.skip_apple != true && inputs.skip_ios != true
         runs-on: macos-15
         permissions:
             contents: read
@@ -301,15 +307,37 @@ jobs:
                   name: ${{ inputs.wasm_artifact_name }}
                   path: origa_ui/dist/
 
-            - name: Import Mac App cert + create keychain
+            - name: Create build keychain
+              env:
+                  APPLE_MAC_CERT_PASSWORD: ${{ secrets.apple-mac-cert-password }}
+              run: |
+                  # The final "Cleanup API key and keychain" step deletes
+                  # build.keychain itself. import-codesign-certs@v7 ALSO
+                  # deletes the keychain in its post-step whenever it was
+                  # the creator (create-keychain: true) — so a v7-created
+                  # keychain is deleted twice, and the action's post-step
+                  # then fails with SecKeychainDelete exit 50, marking the
+                  # whole job red (build artifacts are fine). Creating the
+                  # keychain here and importing with create-keychain: false
+                  # keeps BOTH v7 post-steps inert; the explicit cleanup
+                  # step stays the single owner of keychain disposal.
+                  security create-keychain -p "$APPLE_MAC_CERT_PASSWORD" build.keychain
+                  security set-keychain-settings -lut 21600 build.keychain
+                  security unlock-keychain -p "$APPLE_MAC_CERT_PASSWORD" build.keychain
+                  security list-keychains -d user -s build.keychain login.keychain
+
+            - name: Import Mac App cert
               uses: apple-actions/import-codesign-certs@v7
               with:
                   p12-file-base64: ${{ secrets.apple-mac-app-cert-p12 }}
                   p12-password: ${{ secrets.apple-mac-cert-password }}
                   keychain: build
-                  # Use the same password for both keychain and .p12 to
-                  # simplify the second action call below (which must
-                  # unlock the existing keychain).
+                  # The keychain was created by the "Create build keychain"
+                  # step above — never let the action create (and then
+                  # post-delete) it. See that step for the exit-50 story.
+                  create-keychain: false
+                  # Same password for keychain and .p12 — the second action
+                  # call below reuses this keychain.
                   keychain-password: ${{ secrets.apple-mac-cert-password }}
 
             - name: Import Mac Installer cert (reuse keychain)
@@ -559,6 +587,10 @@ jobs:
 
             - name: Upload to App Store Connect
               id: upload
+              # Release-time only (tag pushes: stable/prerelease). CI-run
+              # macOS builds (version_type: alpha) must never touch App
+              # Store Connect — no duplicate versions, no ITMS conflicts.
+              if: inputs.version_type == 'stable' || inputs.version_type == 'prerelease'
               timeout-minutes: 15
               env:
                   APPLE_API_ISSUER: ${{ secrets.apple-api-issuer }}
@@ -599,6 +631,9 @@ jobs:
                   if [ "${{ steps.upload.outcome }}" = "success" ]; then
                     echo "status=success" >> "$GITHUB_OUTPUT"
                     echo "✅ macOS build uploaded to App Store Connect"
+                  elif [ "${{ steps.upload.outcome }}" = "skipped" ]; then
+                    echo "status=skipped" >> "$GITHUB_OUTPUT"
+                    echo "ℹ️ App Store upload skipped (non-release run)"
                   else
                     echo "status=failure" >> "$GITHUB_OUTPUT"
                     echo "::warning::xcrun altool upload failed. Download the macos-pkg-build artifact and upload manually via Transporter.app"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,6 +525,35 @@ jobs:
             android-key-password: ${{ secrets.ANDROID_KEY_PASSWORD }}
             android-key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}
 
+    build-macos:
+        name: Build Tauri (macOS)
+        needs: [version, e2e-build]
+        # macOS build in regular CI, mirroring build-tauri (windows/linux/
+        # android): the universal .app/.pkg bundle path — Xcode selection,
+        # cert import, tauri build, productbuild — is exercised on every
+        # push, so workflow-level breakage (like the import-codesign-certs
+        # post-step exit 50) surfaces in CI instead of on a release tag.
+        # iOS is skipped (skip_ios) — it stays a release-time target to
+        # bound macOS runner minutes; App Store upload is gated by
+        # version_type inside the reusable workflow.
+        uses: ./.github/workflows/_build-tauri-apple.yml
+        with:
+            version: ${{ needs.version.outputs.version }}
+            version_base: ${{ needs.version.outputs.version_base }}
+            version_type: ${{ needs.version.outputs.version_type }}
+            commit_sha: ${{ needs.version.outputs.commit_sha }}
+            build_date: ${{ needs.version.outputs.build_date }}
+            wasm_artifact_name: wasm-dist
+            skip_ios: true
+        secrets:
+            apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
+            apple-api-key: ${{ secrets.APPLE_API_KEY }}
+            apple-api-key-content: ${{ secrets.APPLE_API_KEY_CONTENT }}
+            apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+            apple-mac-app-cert-p12: ${{ secrets.APPLE_MAC_APP_CERT_P12 }}
+            apple-mac-installer-cert-p12: ${{ secrets.APPLE_MAC_INSTALLER_CERT_P12 }}
+            apple-mac-cert-password: ${{ secrets.APPLE_MAC_CERT_PASSWORD }}
+
     docker-build-landing:
         name: Docker Build (landing)
         permissions:
@@ -576,7 +605,7 @@ jobs:
         name: CI Gate
         permissions:
             contents: read
-        needs: [lint, test, e2e, e2e-report, docker-build-landing, docker-build-ui, build-tauri, macos-check]
+        needs: [lint, test, e2e, e2e-report, docker-build-landing, docker-build-ui, build-tauri, build-macos, macos-check]
         if: always()
         runs-on: ubuntu-latest
         steps:
@@ -599,5 +628,6 @@ jobs:
                   check "docker-build-landing" "${{ needs.docker-build-landing.result }}" "success"
                   check "docker-build-ui" "${{ needs.docker-build-ui.result }}" "success"
                   check "build-tauri" "${{ needs.build-tauri.result }}" "success"
+                  check "build-macos" "${{ needs.build-macos.result }}" "success" "skipped"
 
             - run: echo "All checks passed"


### PR DESCRIPTION
## Что

1. **Фикс красной macOS-джобы** на последних трёх тегах (`v0.6.5-rc1`, `v0.6.5`, `v0.7.0-rc1`): #444 бампнул `import-codesign-certs` v3→v7; post-step v7 удаляет keychain, который уже удалил финальный cleanup-шаг джобы → `SecKeychainDelete` exit 50 → джоба красная (сами бандл и подпись собирались корректно — `productbuild` в логах прошёл).
2. **macOS-сборка в обычном CI** — аналогично windows/linux/android: новая джоба `Build Tauri (macOS)` (`_build-tauri-apple.yml`, `skip_ios: true` — iOS остаётся релизным таргетом), подключена в CI Gate. Workflow-поломки такого рода теперь ловятся в CI, а не на релизном теге.

## Как (без отката, остаёмся на v7)

- Явный шаг `Create build keychain` перед импортами; оба вызова action — `create-keychain: false` → оба post-step инертны; существующий cleanup-шаг остаётся единственным владельцем удаления keychain.
- App Store Connect upload теперь только для релизных `version_type` (stable/prerelease) — CI/dispatch-сборки не трогают App Store Connect (раньше dispatch-прогон с force_apple мог залить тестовый pkg).
- `upload-report` получил skipped-ветку (без warning-шума).

## Верификация

- YAML обоих workflow валиден.
- Этот PR сам прогонит новую macOS-джобу в CI до мержа (секреты same-repo доступны).

## Follow-up

После мержа — `v0.7.0-rc2`, чтобы RC вышел с macOS `.pkg`.