### PR TITLE
ci(macos): App Store upload on stable tags only

### DIFF
--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -587,10 +587,15 @@ jobs:
 
             - name: Upload to App Store Connect
               id: upload
-              # Release-time only (tag pushes: stable/prerelease). CI-run
-              # macOS builds (version_type: alpha) must never touch App
-              # Store Connect — no duplicate versions, no ITMS conflicts.
-              if: inputs.version_type == 'stable' || inputs.version_type == 'prerelease'
+              # Stable-only. macOS prerelease tags share the version_base
+              # (e.g. v0.7.0-rc1 and v0.7.0-rc2 both bundle CFBundleVersion
+              # 0.7.0), so a second upload is always rejected by App Store
+              # Connect with -19232 "bundle version must be higher" — this
+              # is exactly what broke v0.6.5 and v0.7.0-rc2. RC builds ship
+              # via the GitHub Release assets (.pkg is uploaded there);
+              # App Store Connect gets exactly one build per version, from
+              # the stable tag. CI/dispatch builds (alpha) never upload.
+              if: inputs.version_type == 'stable'
               timeout-minutes: 15
               env:
                   APPLE_API_ISSUER: ${{ secrets.apple-api-issuer }}


### PR DESCRIPTION
## Контекст

`v0.7.0-rc2` вскрыл вторую половину истории красной macOS-джобы: keychain-фикс (#458) сработал (сборка/подпись/пост-шаги чистые), но `altool` упал с `-19232: bundle version must be higher than '0.7.0'` — **rc1 успел залить 0.7.0 в App Store Connect** ещё в «красном» ране (upload стоял до падавшего post-step), а rc2 с тем же CFBundleVersion отклонён. Та же причина ломала и стабильный `v0.6.5` (его rc1 залил 0.6.5 первым).

## Фикс

Upload в App Store Connect — только `version_type == stable`: macOS rc-теги делят один version_base, повторная заливка неизбежно отбивается. RC поставляются через GitHub Release (там есть `.pkg`-ассет); стор получает ровно один билд на версию — со стабильного тега. Поведение iOS не тронуто (его версионированные билды не конфликтуют между rc).

## Заметка

В App Store Connect уже сидит билд 0.7.0 (залит rc1) — стабильному v0.7.0 понадобится purge этого билда в ASC или bump на 0.7.1.

## Follow-up

После мержа — чистый `v0.7.0-rc2` (битый тег/релиз удалены).