### PR TITLE
ci(release): publish macOS .pkg on GitHub Releases

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -286,12 +286,17 @@ jobs:
                   # (frontend-dist WASM, *.sig signatures already embedded into
                   # latest.json) are excluded so the release stays small.
                   # cp -f (not -n): every tag is a fresh release, no accumulation.
+                  # macOS ships a productbuild .pkg (signed with the Mac
+                  # Installer cert) — there is no .dmg target in this repo;
+                  # the stale '*.dmg' pattern never matched. With App Store
+                  # upload now stable-only (PR #459), GitHub Release is the
+                  # only macOS channel for prereleases.
                   find artifacts -type f \( \
                       -name '*-setup.exe' -o \
                       -name '*.msi' -o \
                       -name '*.AppImage' -o \
                       -name '*.deb' -o \
-                      -name '*.dmg' -o \
+                      -name '*.pkg' -o \
                       -name '*.apk' -o \
                       -name '*.aab' -o \
                       -name 'latest.json' \


### PR DESCRIPTION
## Что

Фильтр ассетов релиза держал паттерн `*.dmg`, но `dmg` в репо никогда не собирается — macOS поставляется как `productbuild .pkg`. Паттерн не матчился никогда: ни один релиз (включая зелёный v0.6.4) не содержал macOS-ассета, pkg уходил только в App Store. Теперь, когда upload в ASC — stable-only (#459), GitHub Release — единственный macOS-канал для RC: добавлен `*.pkg`.

## Текущее состояние

`v0.7.0-rc2` уже дозаполнен вручную (`Origa.pkg` 115 МБ из артефакта рана) — этот PR делает будущие релизы самодостаточными.