### PR TITLE
fix(ui): clarify acquaintance completion subtitle

### DIFF
--- a/origa_ui/locales/en.json
+++ b/origa_ui/locales/en.json
@@ -234,7 +234,7 @@
     "strip_presentation": "Slide",
     "strip_training": "Cards closed",
     "completed_title": "Acquaintance complete",
-    "completed_subtitle": "The new cards meet their first review — back to the lesson",
+    "completed_subtitle": "New material covered — moving on to review",
     "to_reviews": "To reviews"
   },
   "lesson": {

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -234,7 +234,7 @@
     "strip_presentation": "Слайд",
     "strip_training": "Карт закрыто",
     "completed_title": "Знакомство завершено",
-    "completed_subtitle": "Новые карты встретят первое повторение — продолжаем урок",
+    "completed_subtitle": "Новый материал пройден — переходим к повторению",
     "to_reviews": "К повторению"
   },
   "lesson": {


### PR DESCRIPTION
## Что не так

Подзаголовок экрана завершения знакомства — «Новые карты встретят первое повторение — продолжаем урок» — читается как бессмыслица и, хуже того, обещает не то, что происходит: новые карты после закрытой руки уходят в SRS с первым ревью только завтра, а кнопка «К повторению» открывает обычное ревью должных карт урока.

## Что меняется

Простая формулировка о том, что дальше:

| Локаль | Было | Стало |
|---|---|---|
| ru | Новые карты встретят первое повторение — продолжаем урок | Новый материал пройден — переходим к повторению |
| en | The new cards meet their first review — back to the lesson | New material covered — moving on to review |

Только строки в `locales/ru.json` / `locales/en.json`; ключи локалей синхронны, тесты на текст не завязаны (только на testid `acquaintance-completed`).
