### PR TITLE
ci: path-based job filtering with fail-closed gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,150 @@ permissions:
     contents: read
     actions: write
 
+# Path-based job filtering
+# ========================
+# The `changes` job detects which components a PR touches (via
+# dorny/paths-filter, SHA-pinned) and turns them into per-job `run_*`
+# flags. Filtered jobs skip themselves with
+# `if: needs.changes.outputs.run_<job> == 'true'`.
+# Non-PR events (release tags, workflow_dispatch) force every run_* to
+# true — the release pipeline is always a full run. Exception:
+# run_macos_check carries the dependabot actor clause and can be false
+# on non-PR events too.
+#
+# Invariants — violate these and CI silently rots:
+# 1. CI Gate: a `skipped` result is legal ONLY when the job's run_* flag
+#    is false (path-filter skip). A skip with run_*=true means an
+#    upstream dependency failed/was cancelled and MUST fail the gate.
+#    This is what keeps the single required check fail-closed under
+#    auto-merge. Do NOT remove `if: always()` from the check job.
+# 2. A filtered job's run_* condition must be a subset of the union of
+#    its filtered needs' conditions — otherwise a skipped dependency
+#    silently skips the job even when its own flag is true.
+# 3. `changes` and `version` are never path-filtered: the gate asserts
+#    them success-only (a failed detection run must turn the PR red,
+#    not green).
+# 4. e2e-report has no run flag of its own: it follows e2e's RESULT
+#    (`!= 'skipped'`) and is asserted in the gate through run_e2e.
+#
+# Adding a job: add a run_* output to `changes`, wire the job's if, add
+# the job to check.needs AND a gate() assertion line.
+
 jobs:
+    changes:
+        name: Detect changes
+        permissions:
+            contents: read
+            pull-requests: read
+        runs-on: ubuntu-latest
+        outputs:
+            run_lint: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.wasm == 'true' ||
+              steps.components.outputs.landing == 'true' ||
+              steps.components.outputs.tauri == 'true' ||
+              steps.components.outputs.utils == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_macos_check: >-
+              ${{ (github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.tauri == 'true' ||
+              steps.components.outputs.ci == 'true') &&
+              github.actor != 'dependabot[bot]' }}
+            run_cdn_download: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.wasm == 'true' ||
+              steps.components.outputs.tauri == 'true' ||
+              steps.components.outputs.e2e == 'true' ||
+              steps.components.outputs.utils == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_test: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.wasm == 'true' ||
+              steps.components.outputs.tauri == 'true' ||
+              steps.components.outputs.utils == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_wasm_test: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.wasm == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_e2e_build: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.wasm == 'true' ||
+              steps.components.outputs.tauri == 'true' ||
+              steps.components.outputs.e2e == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_e2e_matrix_guard: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.wasm == 'true' ||
+              steps.components.outputs.e2e == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_e2e: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.wasm == 'true' ||
+              steps.components.outputs.e2e == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_build_tauri: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.tauri == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_build_macos: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.tauri == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_docker_landing: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.landing == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+            run_docker_ui: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.wasm == 'true' ||
+              steps.components.outputs.ci == 'true' }}
+        steps:
+            # PR-only: on tags/dispatch the step is skipped, its outputs
+            # stay empty, and the `github.event_name != 'pull_request'`
+            # prefix in every run_* forces a full run.
+            - name: Detect changed components
+              id: components
+              if: github.event_name == 'pull_request'
+              uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+              with:
+                  filters: |
+                      core:
+                          - origa/**
+                          - Cargo.toml
+                          - Cargo.lock
+                          - build_defaults.rs
+                          - .cargo/**
+                          - .dockerignore
+                          - .taurignore
+                          - .rustfmt.toml
+                          - clippy.toml
+                      wasm:
+                          - origa_ui/**
+                      landing:
+                          - origa_landing/**
+                      tauri:
+                          - tauri/**
+                          - tauri-plugin-aswebauth/**
+                      e2e:
+                          - end2end/**
+                      utils:
+                          - utils/**
+                      ci:
+                          - .github/**
+
     version:
         name: Version
         permissions:
@@ -52,8 +195,9 @@ jobs:
         name: Check (aarch64 macOS)
         permissions:
             contents: read
+        needs: [changes]
+        if: needs.changes.outputs.run_macos_check == 'true'
         runs-on: macos-15
-        if: github.actor != 'dependabot[bot]'
         env:
             ORIGA_CDN_BASE_URL: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
         steps:
@@ -86,6 +230,8 @@ jobs:
         name: Lint
         permissions:
             contents: read
+        needs: [changes]
+        if: needs.changes.outputs.run_lint == 'true'
         runs-on: ubuntu-24.04
         env:
             ORIGA_CDN_BASE_URL: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
@@ -143,6 +289,8 @@ jobs:
         name: Download CDN
         permissions:
             contents: read
+        needs: [changes]
+        if: needs.changes.outputs.run_cdn_download == 'true'
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout repository
@@ -165,7 +313,8 @@ jobs:
         name: Test
         permissions:
             contents: read
-        needs: cdn-download
+        needs: [changes, cdn-download]
+        if: needs.changes.outputs.run_test == 'true'
         runs-on: ubuntu-24.04
         env:
             ORIGA_CDN_BASE_URL: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
@@ -220,7 +369,8 @@ jobs:
         name: WASM Component Tests
         permissions:
             contents: read
-        needs: cdn-download
+        needs: [changes, cdn-download]
+        if: needs.changes.outputs.run_wasm_test == 'true'
         runs-on: ubuntu-24.04
         env:
             ORIGA_CDN_BASE_URL: "https://${{ vars.ORIGA_CDN_URI_PREFIX }}.${{ vars.ORIGA_BASE_URI }}"
@@ -266,7 +416,8 @@ jobs:
         name: E2E Build
         permissions:
             contents: read
-        needs: cdn-download
+        needs: [changes, cdn-download]
+        if: needs.changes.outputs.run_e2e_build == 'true'
         runs-on: ubuntu-24.04
         env:
             ORIGA_CDN_BASE_URL: http://localhost:8080
@@ -331,6 +482,8 @@ jobs:
         name: E2E Matrix Guard
         permissions:
             contents: read
+        needs: [changes]
+        if: needs.changes.outputs.run_e2e_matrix_guard == 'true'
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout repository
@@ -353,7 +506,8 @@ jobs:
         name: E2E ${{ matrix.group }}
         permissions:
             contents: read
-        needs: [e2e-build, e2e-matrix-guard]
+        needs: [changes, e2e-build, e2e-matrix-guard]
+        if: needs.changes.outputs.run_e2e == 'true'
         runs-on: ubuntu-24.04
         strategy:
             fail-fast: false
@@ -482,7 +636,10 @@ jobs:
         permissions:
             contents: read
         needs: [e2e]
-        if: always() && needs.e2e.result != 'cancelled'
+        # Follows e2e's RESULT (no run flag of its own): merges reports
+        # whenever e2e actually ran (success or failure); skipped along
+        # with a path-skipped e2e. Asserted in the gate via run_e2e.
+        if: ${{ !cancelled() && needs.e2e.result != 'skipped' }}
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout repository
@@ -537,7 +694,8 @@ jobs:
 
     build-tauri:
         name: Build Tauri
-        needs: [version, e2e-build]
+        needs: [changes, version, e2e-build]
+        if: needs.changes.outputs.run_build_tauri == 'true'
         uses: ./.github/workflows/_build-tauri.yml
         with:
             version: ${{ needs.version.outputs.version }}
@@ -558,7 +716,6 @@ jobs:
 
     build-macos:
         name: Build Tauri (macOS)
-        needs: [version, e2e-build]
         # macOS build in regular CI, mirroring build-tauri (windows/linux/
         # android): the universal .app/.pkg bundle path — Xcode selection,
         # cert import, tauri build, productbuild — is exercised on every
@@ -567,6 +724,8 @@ jobs:
         # iOS is skipped (skip_ios) — it stays a release-time target to
         # bound macOS runner minutes; App Store upload is gated by
         # version_type inside the reusable workflow.
+        needs: [changes, version, e2e-build]
+        if: needs.changes.outputs.run_build_macos == 'true'
         uses: ./.github/workflows/_build-tauri-apple.yml
         with:
             version: ${{ needs.version.outputs.version }}
@@ -589,6 +748,8 @@ jobs:
         name: Docker Build (landing)
         permissions:
             contents: read
+        needs: [changes]
+        if: needs.changes.outputs.run_docker_landing == 'true'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
@@ -612,6 +773,8 @@ jobs:
         name: Docker Build (ui)
         permissions:
             contents: read
+        needs: [changes]
+        if: needs.changes.outputs.run_docker_ui == 'true'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
@@ -636,29 +799,66 @@ jobs:
         name: CI Gate
         permissions:
             contents: read
-        needs: [lint, test, e2e, e2e-report, docker-build-landing, docker-build-ui, build-tauri, build-macos, macos-check]
+        # Single required check. `if: always()` is load-bearing: without
+        # it a skipped dependency (path-filtered PR) would skip the gate
+        # itself and the PR could never go green. Do not remove.
+        needs:
+            [
+                version,
+                changes,
+                lint,
+                macos-check,
+                cdn-download,
+                test,
+                wasm-test,
+                e2e-build,
+                e2e-matrix-guard,
+                e2e,
+                e2e-report,
+                build-tauri,
+                build-macos,
+                docker-build-landing,
+                docker-build-ui,
+            ]
         if: always()
         runs-on: ubuntu-latest
         steps:
             - name: Verify all jobs passed
               run: |
-                  check() {
-                    local job="$1" result="$2"
-                    shift 2
-                    for allowed in "$@"; do
-                      [[ "$result" == "$allowed" ]] && return 0
-                    done
-                    echo "::error::$job failed with result: $result"
+                  # Fail-closed gate. For every filtered job a `skipped`
+                  # result is legal ONLY when its run_* flag is false
+                  # (path-filter skip). A skip with run_*=true means an
+                  # upstream dependency failed or was cancelled — that
+                  # must fail the gate. `changes` and `version` are
+                  # never path-filtered, so for them skipped/failure are
+                  # always red. e2e-report follows e2e's result and is
+                  # asserted through run_e2e.
+                  gate() {
+                    local job="$1" result="$2" run="$3"
+                    if [[ "$result" == "success" ]]; then
+                      return 0
+                    fi
+                    if [[ "$result" == "skipped" && "$run" == "false" ]]; then
+                      return 0
+                    fi
+                    echo "::error::$job failed with result: $result (run flag: $run)"
                     return 1
                   }
 
-                  check "lint" "${{ needs.lint.result }}" "success"
-                  check "test" "${{ needs.test.result }}" "success"
-                  check "e2e" "${{ needs.e2e.result }}" "success"
-                  check "e2e-report" "${{ needs.e2e-report.result }}" "success" "skipped"
-                  check "docker-build-landing" "${{ needs.docker-build-landing.result }}" "success"
-                  check "docker-build-ui" "${{ needs.docker-build-ui.result }}" "success"
-                  check "build-tauri" "${{ needs.build-tauri.result }}" "success"
-                  check "build-macos" "${{ needs.build-macos.result }}" "success" "skipped"
+                  gate "version" "${{ needs.version.result }}" "true"
+                  gate "changes" "${{ needs.changes.result }}" "true"
+                  gate "lint" "${{ needs.lint.result }}" "${{ needs.changes.outputs.run_lint }}"
+                  gate "macos-check" "${{ needs.macos-check.result }}" "${{ needs.changes.outputs.run_macos_check }}"
+                  gate "cdn-download" "${{ needs.cdn-download.result }}" "${{ needs.changes.outputs.run_cdn_download }}"
+                  gate "test" "${{ needs.test.result }}" "${{ needs.changes.outputs.run_test }}"
+                  gate "wasm-test" "${{ needs.wasm-test.result }}" "${{ needs.changes.outputs.run_wasm_test }}"
+                  gate "e2e-build" "${{ needs.e2e-build.result }}" "${{ needs.changes.outputs.run_e2e_build }}"
+                  gate "e2e-matrix-guard" "${{ needs.e2e-matrix-guard.result }}" "${{ needs.changes.outputs.run_e2e_matrix_guard }}"
+                  gate "e2e" "${{ needs.e2e.result }}" "${{ needs.changes.outputs.run_e2e }}"
+                  gate "e2e-report" "${{ needs.e2e-report.result }}" "${{ needs.changes.outputs.run_e2e }}"
+                  gate "build-tauri" "${{ needs.build-tauri.result }}" "${{ needs.changes.outputs.run_build_tauri }}"
+                  gate "build-macos" "${{ needs.build-macos.result }}" "${{ needs.changes.outputs.run_build_macos }}"
+                  gate "docker-build-landing" "${{ needs.docker-build-landing.result }}" "${{ needs.changes.outputs.run_docker_landing }}"
+                  gate "docker-build-ui" "${{ needs.docker-build-ui.result }}" "${{ needs.changes.outputs.run_docker_ui }}"
 
             - run: echo "All checks passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,14 @@ CI: lint + test + e2e + docker build (2 images: landing + ui).
 CD: 2 Docker images (GHCR) + Railway deploy (2 services).
 Targets: Windows x86_64, Linux x86_64, macOS aarch64. Релиз при push `master` + tag `v*.*.*`.
 
+**Path-based job filtering** (`ci.yml`, PR-only): джоба `changes` (dorny/paths-filter, SHA-pinned) превращает изменённые компоненты в per-job флаги `run_*`; джобы скипаются через `if: needs.changes.outputs.run_<job> == 'true'`. Компоненты: `core` (origa/**, Cargo.*, build_defaults.rs, .cargo/**, .dockerignore, .taurignore, lint-конфиги), `wasm` (origa_ui), `landing`, `tauri` (+tauri-plugin-aswebauth), `e2e` (end2end), `utils`, `ci` (.github → полный прогон). Релизные теги и workflow_dispatch форсируют полный прогон. Docs/scripts-only PR скипает весь CI.
+
+Инварианты (нарушение = silent skip / дырявый gate, доктрина в шапке ci.yml):
+
+1. Gate: `skipped` легален ТОЛЬКО при `run_* == false` (path-skip); skip при `run=true` (каскадный отказ upstream) роняет CI Gate — единственный required check, fail-closed под auto-merge. `if: always()` на `check` не удалять.
+2. Условие джобы ⊆ объединение условий её фильтруемых needs (иначе skipped-dependency молча скипает джобу).
+3. Новая джоба: добавить `run_*` output в `changes`, `if`, строку в `check.needs` + `gate()`-ассерт.
+
 ## Границы
 
 ### ✅ ВСЕГДА

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,11 +147,14 @@ Targets: Windows x86_64, Linux x86_64, macOS aarch64. Релиз при push `ma
 
 **Path-based job filtering** (`ci.yml`, PR-only): джоба `changes` (dorny/paths-filter, SHA-pinned) превращает изменённые компоненты в per-job флаги `run_*`; джобы скипаются через `if: needs.changes.outputs.run_<job> == 'true'`. Компоненты: `core` (origa/**, Cargo.*, build_defaults.rs, .cargo/**, .dockerignore, .taurignore, lint-конфиги), `wasm` (origa_ui), `landing`, `tauri` (+tauri-plugin-aswebauth), `e2e` (end2end), `utils`, `ci` (.github → полный прогон). Релизные теги и workflow_dispatch форсируют полный прогон. Docs/scripts-only PR скипает весь CI.
 
-Инварианты (нарушение = silent skip / дырявый gate, доктрина в шапке ci.yml):
+Инварианты (нарушение = silent skip / дырявый gate; канон — доктрина в шапке ci.yml, номера совпадают):
 
 1. Gate: `skipped` легален ТОЛЬКО при `run_* == false` (path-skip); skip при `run=true` (каскадный отказ upstream) роняет CI Gate — единственный required check, fail-closed под auto-merge. `if: always()` на `check` не удалять.
 2. Условие джобы ⊆ объединение условий её фильтруемых needs (иначе skipped-dependency молча скипает джобу).
-3. Новая джоба: добавить `run_*` output в `changes`, `if`, строку в `check.needs` + `gate()`-ассерт.
+3. `changes` и `version` не фильтруются: gate ассертит их success-only (упавший detection = красный PR, не зелёный).
+4. `e2e-report` без своего run-флага: следует за result'ом e2e, в gate ассертится через `run_e2e`.
+
+Новая джоба: `run_*` output в `changes`, `if`, строка в `check.needs` + `gate()`-ассерт.
 
 ## Границы
 

--- a/tauri/src/updater_commands.rs
+++ b/tauri/src/updater_commands.rs
@@ -64,12 +64,23 @@ const PROGRESS_EVENT: &str = "origa-update-progress";
 /// Returns `Ok(None)` when the current build is already up to date. When an
 /// update exists, its metadata is returned AND the `Update` object is stashed
 /// in `PendingUpdate` so `install_update` can consume it without re-checking.
+///
+/// Dev builds skip the check entirely: their version is always behind the
+/// latest release, so the updater banner would offer to overwrite the dev
+/// binary with a released bundle. `tauri::is_dev()` is a compile-time signal
+/// (`!cfg!(feature = "custom-protocol")`, enabled only by `cargo tauri
+/// build`) — any binary not built through the Tauri CLI counts as dev.
 #[tauri::command]
 #[cfg(any(windows, target_os = "linux"))]
 pub async fn check_for_update(
     app: AppHandle,
     pending: State<'_, PendingUpdate>,
 ) -> Result<Option<UpdateMetadata>, String> {
+    if tauri::is_dev() {
+        tracing::debug!("updater: skipping check in dev build");
+        return Ok(None);
+    }
+
     let update = app
         .updater()
         .map_err(|e| e.to_string())?

--- a/tauri/tests/build_config.rs
+++ b/tauri/tests/build_config.rs
@@ -494,4 +494,42 @@ fn lib_rs_compiles_update_machinery_out_of_store_builds() {
     );
 }
 
+/// Regression guard: `check_for_update` must gate the endpoint check behind
+/// `tauri::is_dev()` BEFORE the `.updater()` call. Without the gate,
+/// `cargo tauri dev` builds (version behind the latest release) show the
+/// update banner and can overwrite the dev binary with a released bundle.
+///
+/// `is_dev()` is compile-time (`!cfg!(feature = "custom-protocol")`): in
+/// `cargo test` builds `custom-protocol` is never enabled, so `is_dev()` is
+/// always `true` here and the production branch (endpoint check runs) cannot
+/// be covered by a behavioural test — this structural guard is the ceiling.
+/// Positional check (gate before the network call) so the guard survives
+/// indentation/reflow churn and is not satisfied by a stray `is_dev()`
+/// mention elsewhere in the file.
+#[test]
+fn check_for_update_gates_endpoint_check_behind_is_dev() {
+    let updater_commands = include_str!("../src/updater_commands.rs");
+
+    let body_start = updater_commands
+        .find("pub async fn check_for_update")
+        .expect("check_for_update missing from updater_commands.rs");
+    let body_end = updater_commands[body_start..]
+        .find("pub async fn install_update")
+        .map(|offset| body_start + offset)
+        .unwrap_or(updater_commands.len());
+
+    let body = &updater_commands[body_start..body_end];
+    let gate_pos = body
+        .find("tauri::is_dev()")
+        .expect("check_for_update must gate on tauri::is_dev()");
+    let endpoint_call_pos = body
+        .find(".updater()")
+        .expect("check_for_update must call app.updater()");
+
+    assert!(
+        gate_pos < endpoint_call_pos,
+        "tauri::is_dev() gate must run BEFORE the .updater() endpoint check"
+    );
+}
+
 const NOT_APP_STORE_GATE: &str = "#[cfg(all(any(windows, target_os = \"linux\"), not(app_store)))]";


### PR DESCRIPTION
## What

PR runs now execute only the jobs whose inputs changed:

- New `changes` job (`dorny/paths-filter` v4.0.3, SHA-pinned) maps changed components (`core`/`wasm`/`landing`/`tauri`/`e2e`/`utils`/`ci`) to per-job `run_*` flags; jobs skip themselves via `needs.changes.outputs`.
- Release tags and `workflow_dispatch` force a full run.
- Docs/scripts-only PRs skip the whole CI (green via the gate).

| Change | Skipped jobs |
|---|---|
| `origa_ui` only | build-tauri, build-macos, macos-check, docker-build-landing |
| `tauri` only | e2e (5 groups), wasm-test, docker builds |
| `origa_landing` only | everything except lint + docker-build-landing |
| `end2end` only | everything except cdn-download, e2e-build, guard, e2e |

## Fail-closed CI Gate

`skipped` is legal only when the job's `run_*` flag is `false` (path skip). A cascade skip (upstream failure/cancel) fails the gate. `changes` and `version` are asserted success-only. The gate now also covers `wasm-test` and `macos-check` (the old success-only list missed them). `if: always()` on `check` is load-bearing — documented in the header.

## Root build inputs previously invisible to filtering

`build_defaults.rs`, `.cargo/**`, `.dockerignore`, `.taurignore` → `core`. `docker-build-landing` now also reacts to `core`: its Dockerfile copies root `Cargo.*`, `.cargo` and all crate manifests (a `Cargo.lock` bump can break the image build).

## Also here

- `🐛(tauri): skip updater endpoint check in dev builds` — dev builds must not offer to overwrite themselves with a released bundle (was uncommitted in the worktree).
- Invariants & doctrine pinned in the ci.yml header + AGENTS.md.

## Verification

- `actionlint` clean on all workflows
- YAML parse + structural simulator: 15 path scenarios, needs-subset invariant, gate coverage (15 needs = 15 assertions), negative cases (cascade failure / changes failure / version failure → gate RED), non-PR full run, dependabot macos-check skip