### PR TITLE
chore(docker): test TrailBase image with Apple form_post fix

### DIFF
--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -113,7 +113,9 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     trunk build --release --dist dist
 
 # Runtime: TrailBase + SPA static files
-FROM trailbase/trailbase:0.33.5
+# TEMP: test image carrying the Apple `response_mode=form_post` fix
+# (trailbaseio/trailbase#282) until an upstream release ships it. Based on v0.33.5.
+FROM ghcr.io/yurvon-screamo/trailbase:apple-formpost
 
 USER root
 WORKDIR /app


### PR DESCRIPTION
## What

Temporarily switches the runtime base image in `origa_ui/Dockerfile` to a test build of TrailBase that carries the Apple Sign-in fix for [trailbaseio/trailbase#282](https://github.com/trailbaseio/trailbase/issues/282):

`trailbase/trailbase:0.33.5` → `ghcr.io/yurvon-screamo/trailbase:apple-formpost` (same official root Dockerfile, linux/amd64, public; source: fork branch [`fix/apple-oauth-form-post`](https://github.com/yurvon-screamo/trailbase/tree/fix/apple-oauth-form-post)).

## Why

Apple login on the stand (`app.origa.uwuwu.net`) fails with `invalid_request: response_mode must be form_post when name or email scope is requested` — an upstream TrailBase bug. The fix adds `response_mode=form_post` for Apple, a POST-form OAuth callback, and `SameSite=None` for the OAuth state cookie (cross-site POST navigation). Upstream maintainer asked us to build & verify the fix before a PR (`issue #282`).

## Scope / safety

- Single line (+comment) in `origa_ui/Dockerfile`; no code changes.
- Google/Yandex flows unchanged (covered by upstream tests); no DB migrations.
- Rollback: revert to `trailbase/trailbase:0.33.5` + redeploy.

## Follow-up

Once upstream merges/releases the fix, swap back to the official image tag.