### PR TITLE
feat(ui): display name instead of email-prefix username (Apple relay fix)

### DIFF
--- a/origa/src/use_cases/mod.rs
+++ b/origa/src/use_cases/mod.rs
@@ -62,4 +62,4 @@ pub use select_cards_to_lesson::SelectCardsToLessonUseCase;
 pub use take_acquaintance_replacement::TakeAcquaintanceReplacementUseCase;
 pub use toggle_favorite::ToggleFavoriteUseCase;
 pub use transcribe_audio::TranscribeAudioUseCase;
-pub use update_user_profile::UpdateUserProfileUseCase;
+pub use update_user_profile::{USERNAME_MAX_CHARS, UpdateUserProfileUseCase};

--- a/origa/src/use_cases/tests/journeys/onboarding.rs
+++ b/origa/src/use_cases/tests/journeys/onboarding.rs
@@ -30,7 +30,12 @@ async fn update_user_profile_updates_fields() {
     let use_case = UpdateUserProfileUseCase::new(&repo);
 
     use_case
-        .execute(NativeLanguage::English, Default::default(), Some(123456789))
+        .execute(
+            NativeLanguage::English,
+            Default::default(),
+            Some(123456789),
+            None,
+        )
         .await
         .unwrap();
 
@@ -40,12 +45,105 @@ async fn update_user_profile_updates_fields() {
 }
 
 #[tokio::test]
+async fn update_user_profile_with_username_trims_and_persists_it() {
+    let repo = InMemoryUserRepository::with_user(User::new(
+        "test@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    ));
+    let use_case = UpdateUserProfileUseCase::new(&repo);
+
+    use_case
+        .execute(
+            NativeLanguage::Russian,
+            Default::default(),
+            None,
+            Some("  Иван Иванов  "),
+        )
+        .await
+        .unwrap();
+
+    let updated = repo.get_current_user().await.unwrap().unwrap();
+    assert_eq!(updated.username(), "Иван Иванов");
+}
+
+#[tokio::test]
+async fn update_user_profile_without_username_keeps_current_name() {
+    let repo = InMemoryUserRepository::with_user(User::new(
+        "test@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    ));
+    let use_case = UpdateUserProfileUseCase::new(&repo);
+
+    use_case
+        .execute(NativeLanguage::English, Default::default(), None, None)
+        .await
+        .unwrap();
+
+    let updated = repo.get_current_user().await.unwrap().unwrap();
+    assert_eq!(updated.username(), "test");
+}
+
+#[tokio::test]
+async fn update_user_profile_caps_overlong_username() {
+    let repo = InMemoryUserRepository::with_user(User::new(
+        "test@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    ));
+    let use_case = UpdateUserProfileUseCase::new(&repo);
+
+    let long_name = "я".repeat(crate::use_cases::USERNAME_MAX_CHARS + 10);
+    use_case
+        .execute(
+            NativeLanguage::Russian,
+            Default::default(),
+            None,
+            Some(&long_name),
+        )
+        .await
+        .unwrap();
+
+    let updated = repo.get_current_user().await.unwrap().unwrap();
+    assert_eq!(
+        updated.username().chars().count(),
+        crate::use_cases::USERNAME_MAX_CHARS
+    );
+}
+
+#[tokio::test]
+async fn update_user_profile_with_blank_username_clears_the_name() {
+    let repo = InMemoryUserRepository::with_user(User::new(
+        "test@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    ));
+    let use_case = UpdateUserProfileUseCase::new(&repo);
+
+    // Clearing the name field is a deliberate "show my email instead" choice:
+    // the empty name is persisted (the UI falls back to the email).
+    use_case
+        .execute(
+            NativeLanguage::Russian,
+            Default::default(),
+            None,
+            Some("   "),
+        )
+        .await
+        .unwrap();
+
+    let updated = repo.get_current_user().await.unwrap().unwrap();
+    assert_eq!(updated.username(), "");
+}
+
+#[tokio::test]
 async fn update_user_profile_returns_error_for_nonexistent_user() {
     let repo = InMemoryUserRepository::new();
     let use_case = UpdateUserProfileUseCase::new(&repo);
 
     let result = use_case
-        .execute(NativeLanguage::English, Default::default(), None)
+        .execute(NativeLanguage::English, Default::default(), None, None)
         .await;
 
     assert!(matches!(result, Err(OrigaError::CurrentUserNotExist)));

--- a/origa/src/use_cases/update_user_profile.rs
+++ b/origa/src/use_cases/update_user_profile.rs
@@ -2,6 +2,10 @@ use crate::domain::{DailyLoad, NativeLanguage, OrigaError};
 use crate::traits::UserRepository;
 use tracing::{debug, info};
 
+/// Cap for the display name persisted via [`UpdateUserProfileUseCase`].
+/// Keeps the free-form name bounded without rejecting the user's input.
+pub const USERNAME_MAX_CHARS: usize = 40;
+
 #[derive(Clone)]
 pub struct UpdateUserProfileUseCase<'a, R: UserRepository> {
     repository: &'a R,
@@ -12,11 +16,16 @@ impl<'a, R: UserRepository> UpdateUserProfileUseCase<'a, R> {
         Self { repository }
     }
 
+    /// Updates profile fields. `username` is a free-form display name: `None`
+    /// keeps the current value; `Some` trims it and caps it at
+    /// [`USERNAME_MAX_CHARS`]. An empty name is allowed — the UI displays the
+    /// account email in its place.
     pub async fn execute(
         &self,
         native_language: NativeLanguage,
         daily_load: DailyLoad,
         telegram_user_id: Option<u64>,
+        username: Option<&str>,
     ) -> Result<(), OrigaError> {
         debug!("Updating user profile");
 
@@ -29,6 +38,12 @@ impl<'a, R: UserRepository> UpdateUserProfileUseCase<'a, R> {
         user.set_native_language(native_language);
         user.set_daily_load(daily_load);
         user.set_telegram_user_id(telegram_user_id);
+
+        if let Some(username) = username {
+            let trimmed = username.trim();
+            let capped: String = trimmed.chars().take(USERNAME_MAX_CHARS).collect();
+            user.set_username(capped);
+        }
 
         self.repository.save_sync(&user).await?;
 

--- a/origa_ui/locales/en.json
+++ b/origa_ui/locales/en.json
@@ -26,7 +26,8 @@
     "tooltip_known": "Already in dictionary",
     "tooltip_new": "New word",
     "language_aria_label": "Select language",
-    "more_details": "More details"
+    "more_details": "More details",
+    "username_placeholder": "How should we call you?"
   },
   "app": {
     "logging_in": "Logging in..."

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -26,7 +26,8 @@
     "tooltip_known": "Уже в словаре",
     "tooltip_new": "Новое слово",
     "language_aria_label": "Выберите язык",
-    "more_details": "Подробнее"
+    "more_details": "Подробнее",
+    "username_placeholder": "Как вас называть?"
   },
   "app": {
     "logging_in": "Вход..."

--- a/origa_ui/src/pages/home/content.rs
+++ b/origa_ui/src/pages/home/content.rs
@@ -12,6 +12,7 @@ use crate::loaders::recalculate_user_jlpt_progress;
 use crate::repository::{HybridUserRepository, set_last_sync_time};
 use crate::store::ConnectivityStore;
 use crate::ui_components::{ToastContainer, ToastData};
+use crate::utils::display_name::display_name_for;
 use leptos::prelude::*;
 use leptos::task::spawn_local;
 use origa::domain::JlptProgress;
@@ -63,7 +64,7 @@ pub fn HomeContent(#[prop(optional, into)] test_id: Signal<String>) -> impl Into
                         return;
                     }
                     recalculate_user_jlpt_progress(&mut user);
-                    user_name.set(user.username().to_string());
+                    user_name.set(display_name_for(user.username(), user.email()));
 
                     let ks = user.knowledge_set();
                     jlpt_progress.set(user.jlpt_progress().clone());

--- a/origa_ui/src/pages/login/auth_handlers.rs
+++ b/origa_ui/src/pages/login/auth_handlers.rs
@@ -3,6 +3,7 @@ use crate::repository::{
     TrailBaseClient, get_session, set_session_async, take_pkce_verifier_async, uuid_to_ulid,
 };
 use crate::store::auth_store::AuthStore;
+use crate::utils::display_name::default_username_for_email;
 use chrono::Utc;
 use origa::domain::{DailyLoad, JlptProgress, KnowledgeSet, User};
 use origa::traits::UserRepository;
@@ -107,7 +108,7 @@ pub(super) fn create_new_user_from_session(
         return Err("Invalid TrailBase session id: please log in again".to_string());
     }
 
-    let username = email.split('@').next().unwrap_or(email).to_string();
+    let username = default_username_for_email(email);
 
     let native_language = locale_to_native_language(&i18n.get_locale_untracked());
 

--- a/origa_ui/src/pages/login/auth_handlers_wasm_tests.rs
+++ b/origa_ui/src/pages/login/auth_handlers_wasm_tests.rs
@@ -15,11 +15,11 @@ use crate::test_support::{create_wrapper, mount_with_i18n};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-fn seed_session() {
+fn seed_session(email: &str) {
     let session = TrailBaseSession {
         auth_token: "token".to_string(),
         refresh_token: "refresh".to_string(),
-        email: "new.user@example.com".to_string(),
+        email: email.to_string(),
         trailbase_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
         record_id: None,
         expires_at: 0,
@@ -31,16 +31,17 @@ fn seed_session() {
 /// `I18nContext` the login page rendered with (explicit argument — the
 /// function must not read ambient context because it runs after `.await`
 /// inside `spawn_local`, where no reactive owner is scoped).
-fn new_user_for_locale(locale: Locale) -> origa::domain::User {
+fn new_user_for_locale(locale: Locale, email: &str) -> origa::domain::User {
     let wrapper = create_wrapper();
     let captured = Rc::new(RefCell::new(None));
     let sink = captured.clone();
+    let email = email.to_string();
     mount_with_i18n(&wrapper, move || {
         let i18n = crate::i18n::use_i18n();
         i18n.set_locale(locale);
-        seed_session();
+        seed_session(&email);
         *sink.borrow_mut() = Some(
-            super::auth_handlers::create_new_user_from_session("new.user@example.com", &i18n)
+            super::auth_handlers::create_new_user_from_session(&email, &i18n)
                 .expect("user creation must succeed"),
         );
         view! { <div></div> }.into_any()
@@ -50,7 +51,7 @@ fn new_user_for_locale(locale: Locale) -> origa::domain::User {
 
 #[wasm_bindgen_test]
 async fn new_user_language_follows_english_login_selection() {
-    let user = new_user_for_locale(Locale::en);
+    let user = new_user_for_locale(Locale::en, "new.user@example.com");
 
     assert_eq!(
         user.native_language(),
@@ -61,11 +62,38 @@ async fn new_user_language_follows_english_login_selection() {
 
 #[wasm_bindgen_test]
 async fn new_user_language_follows_russian_login_selection() {
-    let user = new_user_for_locale(Locale::ru);
+    let user = new_user_for_locale(Locale::ru, "new.user@example.com");
 
     assert_eq!(
         user.native_language(),
         &origa::domain::NativeLanguage::Russian,
         "a brand-new profile must inherit the language picked on the login screen"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn new_user_from_regular_email_seeds_email_prefix_as_name() {
+    let user = new_user_for_locale(Locale::en, "ivan.petrov@example.com");
+
+    assert_eq!(
+        user.username(),
+        "ivan.petrov",
+        "a regular email must seed its local part as the display name"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn new_user_from_apple_relay_email_seeds_empty_name() {
+    let user = new_user_for_locale(Locale::en, "g55jkfzf5p@privaterelay.appleid.com");
+
+    assert_eq!(
+        user.username(),
+        "",
+        "an Apple relay local part is opaque noise and must not become the display name"
+    );
+    assert_eq!(
+        user.email(),
+        "g55jkfzf5p@privaterelay.appleid.com",
+        "the relay email stays the account identity"
     );
 }

--- a/origa_ui/src/pages/login/login_wasm_tests.rs
+++ b/origa_ui/src/pages/login/login_wasm_tests.rs
@@ -287,11 +287,13 @@ async fn personal_data_card_idle_status_renders_controls() {
     mount_with_i18n(&wrapper, || {
         view! {
             <crate::pages::profile::personal_data_card::PersonalDataCard
+                username=RwSignal::new("ivan.petrov".to_string())
                 selected_language=RwSignal::new(origa::domain::NativeLanguage::Russian)
                 selected_daily_load=RwSignal::new(origa::domain::DailyLoad::Medium)
                 save_status=Signal::from(
                     crate::pages::profile::content::AutoSaveStatus::Idle
                 )
+                on_username_change=Callback::new(|_| ())
                 on_language_change=Callback::new(|_| ())
                 on_daily_load_change=Callback::new(|_| ())
                 on_retry=Callback::new(|_| ())
@@ -312,5 +314,16 @@ async fn personal_data_card_idle_status_renders_controls() {
             .unwrap()
             .is_some(),
         "the native-language toggle must be embedded"
+    );
+    // The display-name editor renders, prefilled with the current username
+    let name_input = card
+        .query_selector("[data-testid=\"profile-username-input\"]")
+        .unwrap()
+        .unwrap()
+        .unchecked_into::<web_sys::HtmlInputElement>();
+    assert_eq!(
+        name_input.value(),
+        "ivan.petrov",
+        "the name input must be prefilled with the stored username"
     );
 }

--- a/origa_ui/src/pages/onboarding/intro_step.rs
+++ b/origa_ui/src/pages/onboarding/intro_step.rs
@@ -1,11 +1,16 @@
 use crate::i18n::*;
-use crate::ui_components::{NativeLanguageToggle, Text, TextSize, TypographyVariant};
+use crate::ui_components::{Input, NativeLanguageToggle, Text, TextSize, TypographyVariant};
 use leptos::prelude::*;
 use origa::domain::NativeLanguage;
 
+/// The greeting step: language toggle plus the very first personalization
+/// question — the display name. The name is optional: leaving it empty (e.g.
+/// for Apple relay emails, which seed no usable default) keeps the current
+/// profile name, and it can always be changed later on the profile page.
 #[component]
 pub fn IntroStep(
     selected_language: RwSignal<NativeLanguage>,
+    username: RwSignal<String>,
     #[prop(optional, into)] test_id: Signal<String>,
 ) -> impl IntoView {
     let i18n = use_i18n();
@@ -13,6 +18,11 @@ pub fn IntroStep(
         let val = test_id.get();
         if val.is_empty() { None } else { Some(val) }
     };
+    let i18n_for_placeholder = i18n;
+    let username_placeholder = Signal::derive(move || {
+        let locale = i18n_for_placeholder.get_locale();
+        td_string!(locale, common.username_placeholder).to_string()
+    });
 
     view! {
         <div data-testid=test_id_val class="intro-step max-w-xl mx-auto text-center">
@@ -28,6 +38,20 @@ pub fn IntroStep(
                 <Text size=TextSize::Default variant=TypographyVariant::Muted test_id="intro-step-subtitle">
                     {t!(i18n, onboarding.intro.subtitle)}
                 </Text>
+            </div>
+            <div class="intro-name flex flex-col items-center gap-2 mb-8 w-full max-w-md mx-auto" data-testid="intro-step-name">
+                <label class="label-muted block w-full text-left" for="intro-step-name-input" data-testid="intro-step-name-label">
+                    {t!(i18n, profile.username)}
+                </label>
+                <Input
+                    value=username
+                    placeholder=username_placeholder
+                    id=Signal::derive(|| "intro-step-name-input".to_string())
+                    name=Signal::derive(|| "display_name".to_string())
+                    maxlength=Signal::derive(|| Some(origa::use_cases::USERNAME_MAX_CHARS))
+                    class=Signal::derive(|| "w-full".to_string())
+                    test_id=Signal::derive(|| "intro-step-name-input".to_string())
+                />
             </div>
         </div>
     }

--- a/origa_ui/src/pages/onboarding/mod.rs
+++ b/origa_ui/src/pages/onboarding/mod.rs
@@ -25,6 +25,7 @@ use crate::ui_components::{
     Button, ButtonVariant, CardLayout, CardLayoutSize, Modal, PageLayout, PageLayoutVariant,
     Spinner, Stepper, StepperStep, Text, TextSize, TypographyVariant,
 };
+use crate::utils::display_name::editable_username_for;
 use apps_step::AppsStep;
 use intro_step::IntroStep;
 use jlpt_step::JlptStep;
@@ -34,6 +35,7 @@ use leptos_router::hooks::use_navigate;
 use load_step::LoadStep;
 use onboarding_actions::{
     create_on_finish_callback, create_on_skip_callback, create_on_start_import_callback,
+    create_save_intro_username_callback,
 };
 use onboarding_state::{OnboardingState, OnboardingStep};
 use origa::domain::NativeLanguage;
@@ -69,6 +71,10 @@ pub fn Onboarding() -> impl IntoView {
 
     let state = RwSignal::new(OnboardingState::new());
     let current_user: RwSignal<Option<User>> = RwSignal::new(None);
+    // Display name typed on the intro step; prefilled from the profile once
+    // the user loads. Stays empty for Apple relay emails (no usable default)
+    // — the input's placeholder asks the question instead.
+    let intro_username: RwSignal<String> = RwSignal::new(String::new());
     let sets_loaded = RwSignal::new(false);
     let is_loading = RwSignal::new(true);
     let is_importing = RwSignal::new(false);
@@ -125,7 +131,7 @@ pub fn Onboarding() -> impl IntoView {
                 let use_case = UpdateUserProfileUseCase::new(&repo);
                 let daily_load = *user.daily_load();
                 let telegram_id = user.telegram_user_id().copied();
-                if let Err(e) = use_case.execute(lang, daily_load, telegram_id).await {
+                if let Err(e) = use_case.execute(lang, daily_load, telegram_id, None).await {
                     tracing::error!("Failed to save language on onboarding: {:?}", e);
                 }
             }
@@ -200,6 +206,7 @@ pub fn Onboarding() -> impl IntoView {
                     if disposed.is_disposed() {
                         return;
                     }
+                    intro_username.set(editable_username_for(user.username(), user.email()));
                     current_user.set(Some(user.clone()));
                     if user.is_onboarding_completed() {
                         nav("/home", Default::default());
@@ -245,7 +252,15 @@ pub fn Onboarding() -> impl IntoView {
         });
     });
 
+    let save_intro_username =
+        create_save_intro_username_callback(repository.clone(), intro_username);
+
     let on_next = Callback::new(move |_: ()| {
+        // Leaving the intro step commits the display name (fire-and-forget:
+        // the name is optional, failures are logged inside the callback).
+        if matches!(state.get_untracked().current_step, OnboardingStep::Intro) {
+            save_intro_username.run(());
+        }
         state.update(|s| {
             s.go_to_next_step();
         });
@@ -289,7 +304,7 @@ pub fn Onboarding() -> impl IntoView {
 
                         <div class="onboarding-content mt-8">
                             <Show when=move || matches!(state.get().current_step, OnboardingStep::Intro)>
-                                <IntroStep selected_language=selected_language test_id=Signal::derive(|| "onboarding-intro-step".to_string()) />
+                                <IntroStep selected_language=selected_language username=intro_username test_id=Signal::derive(|| "onboarding-intro-step".to_string()) />
                             </Show>
 
                             <Show when=move || matches!(state.get().current_step, OnboardingStep::Load)>

--- a/origa_ui/src/pages/onboarding/onboarding_actions.rs
+++ b/origa_ui/src/pages/onboarding/onboarding_actions.rs
@@ -5,9 +5,55 @@ use leptos::task::spawn_local;
 use leptos_router::NavigateOptions;
 use origa::domain::User;
 use origa::traits::UserRepository;
-use origa::use_cases::{CompleteOnboardingScoringUseCase, ImportOnboardingSetsUseCase};
+use origa::use_cases::{
+    CompleteOnboardingScoringUseCase, ImportOnboardingSetsUseCase, USERNAME_MAX_CHARS,
+};
 
 use super::onboarding_state::OnboardingState;
+
+/// Persists the display name entered on the intro step when the user moves on.
+///
+/// Fire-and-forget by design: the name is optional personalization, so a save
+/// failure is logged and the user still proceeds (the profile page can fix the
+/// name later). An empty input skips the save; an unchanged name skips the
+/// write (one read still goes out to compare against the current profile).
+///
+/// Reads-modifies-writes the *current* profile rather than replaying a
+/// snapshot captured at page load: the user can flip the language on this very
+/// step, and a stale `native_language`/`daily_load` would silently roll the
+/// choice back on the full-record save.
+pub(super) fn create_save_intro_username_callback(
+    repository: crate::repository::HybridUserRepository,
+    username: RwSignal<String>,
+) -> Callback<()> {
+    Callback::new(move |_: ()| {
+        let name: String = username
+            .get_untracked()
+            .trim()
+            .chars()
+            .take(USERNAME_MAX_CHARS)
+            .collect();
+        if name.is_empty() {
+            return;
+        }
+
+        let repo = repository.clone();
+        spawn_local(async move {
+            let Ok(Some(mut user)) = repo.get_current_user().await else {
+                tracing::error!("Onboarding intro: get_current_user error");
+                return;
+            };
+            if name == user.username() {
+                return;
+            }
+
+            user.set_username(name);
+            if let Err(e) = repo.save_sync(&user).await {
+                tracing::error!("Failed to save username on onboarding intro: {:?}", e);
+            }
+        });
+    })
+}
 
 pub(super) fn create_on_skip_callback<N>(
     repository: crate::repository::HybridUserRepository,

--- a/origa_ui/src/pages/onboarding/onboarding_wasm_tests.rs
+++ b/origa_ui/src/pages/onboarding/onboarding_wasm_tests.rs
@@ -25,7 +25,8 @@ async fn intro_step_renders_title_subtitle_and_language_bar() {
     let wrapper = create_wrapper();
     mount_with_i18n(&wrapper, || {
         let lang = RwSignal::new(origa::domain::NativeLanguage::Russian);
-        view! { <IntroStep selected_language=lang test_id="is1" /> }.into_any()
+        let username = RwSignal::new(String::new());
+        view! { <IntroStep selected_language=lang username=username test_id="is1" /> }.into_any()
     });
     tick().await;
 
@@ -66,7 +67,8 @@ async fn intro_step_language_toggle_switches_signal() {
     mount_with_i18n(&wrapper, move || {
         let lang = RwSignal::new(origa::domain::NativeLanguage::Russian);
         set_lang.set(Some(lang));
-        view! { <IntroStep selected_language=lang test_id="is2" /> }.into_any()
+        let username = RwSignal::new(String::new());
+        view! { <IntroStep selected_language=lang username=username test_id="is2" /> }.into_any()
     });
     let lang = get_lang.get().expect("captured");
     tick().await;
@@ -83,6 +85,49 @@ async fn intro_step_language_toggle_switches_signal() {
         lang.get(),
         origa::domain::NativeLanguage::English,
         "the embedded toggle must drive the signal"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn intro_step_name_input_prefilled_from_profile_username() {
+    let wrapper = create_wrapper();
+    let (set_username, get_username) = shared_cell::<RwSignal<String>>();
+    mount_with_i18n(&wrapper, move || {
+        let username = RwSignal::new("ivan.petrov".to_string());
+        set_username.set(Some(username));
+        let lang = RwSignal::new(origa::domain::NativeLanguage::Russian);
+        view! { <IntroStep selected_language=lang username=username test_id="is3" /> }.into_any()
+    });
+    tick().await;
+
+    let input = wrapper
+        .query_selector("[data-testid=\"intro-step-name-input\"]")
+        .unwrap()
+        .unwrap()
+        .unchecked_into::<web_sys::HtmlInputElement>();
+    assert_eq!(
+        input.value(),
+        "ivan.petrov",
+        "the name input must be prefilled with the stored username"
+    );
+    assert!(
+        wrapper
+            .query_selector("[data-testid=\"intro-step-name-label\"]")
+            .unwrap()
+            .is_some(),
+        "the name label must render"
+    );
+
+    // Typing into the input must drive the shared signal that the intro
+    // step's Next button commits.
+    input.set_value("");
+    input
+        .dispatch_event(&web_sys::Event::new("input").unwrap())
+        .unwrap();
+    let username = get_username.get().expect("captured");
+    assert!(
+        username.get_untracked().is_empty(),
+        "clearing the input must clear the signal value"
     );
 }
 

--- a/origa_ui/src/pages/profile/content.rs
+++ b/origa_ui/src/pages/profile/content.rs
@@ -2,6 +2,7 @@ use super::{DangerZoneCard, PasswordCard, PersonalDataCard, SettingsCard, legal_
 use crate::i18n::{native_language_to_locale, t, use_i18n};
 use crate::store::AuthStore;
 use crate::ui_components::{Card, OfflineBundleCard};
+use crate::utils::display_name::{display_name_for, editable_username_for};
 use leptos::prelude::*;
 use leptos::task::spawn_local;
 use leptos_router::hooks::use_navigate;
@@ -23,10 +24,22 @@ const AUTOSAVE_STATUS_DISPLAY_MS: u32 = 1500;
 pub fn ProfileContent() -> impl IntoView {
     let auth_store = use_context::<AuthStore>().expect("AuthStore not provided");
 
+    // Initial value of the editable input: empty for Apple relay profiles
+    // that have no meaningful name yet (placeholder question shows instead).
+    let stored_username = Memo::new(move |_| {
+        auth_store.user.with(|u: &Option<User>| {
+            u.as_ref()
+                .map(|u| editable_username_for(u.username(), u.email()))
+                .unwrap_or_default()
+        })
+    });
+
+    // Displayed name: email when the username is empty, so the breadcrumbs
+    // never render a blank or an opaque relay local part on its own.
     let user_name = Memo::new(move |_| {
         auth_store.user.with(|u: &Option<User>| {
             u.as_ref()
-                .map(|u| u.username().to_string())
+                .map(|u| display_name_for(u.username(), u.email()))
                 .unwrap_or_default()
         })
     });
@@ -69,6 +82,15 @@ pub fn ProfileContent() -> impl IntoView {
         selected_daily_load.set(daily_load.get());
     });
 
+    let selected_username = RwSignal::new(stored_username.get_untracked());
+
+    // Re-sync the input after a remote refresh (autosave round-trip). Typing
+    // between the save and the refresh may be clobbered — same trade-off the
+    // language and daily-load selectors already accept.
+    Effect::new(move |_| {
+        selected_username.set(stored_username.get());
+    });
+
     let save_status: RwSignal<AutoSaveStatus> = RwSignal::new(AutoSaveStatus::Idle);
     let is_logging_out = RwSignal::new(false);
     let is_deleting = RwSignal::new(false);
@@ -93,9 +115,18 @@ pub fn ProfileContent() -> impl IntoView {
             loop {
                 let language = selected_language.get_untracked();
                 let daily_load_val = selected_daily_load.get_untracked();
+                // NOTE: the name input's editable value is always what gets
+                // persisted — including the empty string. For a legacy relay
+                // profile (stored garbage name, blank input) a language or
+                // daily-load change therefore also normalizes the stored name
+                // to empty; the display fallback (email) makes that
+                // invisible and it is the intended end state.
+                let username_val = selected_username.get_untracked();
 
                 let use_case = UpdateUserProfileUseCase::new(&repository);
-                let result = use_case.execute(language, daily_load_val, None).await;
+                let result = use_case
+                    .execute(language, daily_load_val, None, Some(&username_val))
+                    .await;
 
                 if disposed.is_disposed() {
                     return;
@@ -147,6 +178,18 @@ pub fn ProfileContent() -> impl IntoView {
         })
     };
 
+    // The Input fires `change` on blur/Enter, so this commits the typed name
+    // once — not per keystroke. Skipping the trigger when the value is
+    // unchanged avoids a redundant network save on a plain focus pass.
+    let on_username_change = {
+        let trigger = trigger_save;
+        Callback::new(move |(): ()| {
+            if selected_username.get_untracked().trim() != stored_username.get_untracked().trim() {
+                trigger.run(());
+            }
+        })
+    };
+
     let on_retry = trigger_save;
 
     let navigate = use_navigate();
@@ -195,9 +238,11 @@ pub fn ProfileContent() -> impl IntoView {
                 <div class="profile-col">
                     <Card shadow=Signal::derive(|| true)>
                         <PersonalDataCard
+                            username={selected_username}
                             selected_language={selected_language}
                             selected_daily_load={selected_daily_load}
                             save_status={Signal::derive(move || save_status.get())}
+                            on_username_change={on_username_change}
                             on_language_change={on_language_change}
                             on_daily_load_change={on_daily_load_change}
                             on_retry={on_retry}

--- a/origa_ui/src/pages/profile/mod.rs
+++ b/origa_ui/src/pages/profile/mod.rs
@@ -12,36 +12,14 @@ pub use password_card::PasswordCard;
 pub use personal_data_card::PersonalDataCard;
 pub use settings_card::SettingsCard;
 
-use crate::repository::HybridUserRepository;
 use crate::ui_components::{CardLayout, CardLayoutSize, PageLayout, PageLayoutVariant};
 use leptos::prelude::*;
-use leptos::task::spawn_local;
-use origa::domain::User;
-use origa::traits::UserRepository;
 
+/// The profile page mounts [`ProfileContent`], which owns its user state via
+/// the shared `AuthStore` (the display-name fallback lives in
+/// `crate::utils::display_name`).
 #[component]
 pub fn Profile() -> impl IntoView {
-    let repository =
-        use_context::<HybridUserRepository>().expect("repository context not provided");
-
-    let current_user: RwSignal<Option<User>> = RwSignal::new(None);
-    let username = RwSignal::new(String::new());
-    let disposed = StoredValue::new(());
-    let repo_for_init = repository.clone();
-
-    Effect::new(move |_| {
-        let repo = repo_for_init.clone();
-        spawn_local(async move {
-            if let Ok(Some(user)) = repo.get_current_user().await {
-                if disposed.is_disposed() {
-                    return;
-                }
-                username.set(user.username().to_string());
-                current_user.set(Some(user));
-            }
-        });
-    });
-
     view! {
         <PageLayout variant=PageLayoutVariant::Full test_id="profile-page">
             <CardLayout size=CardLayoutSize::Adaptive test_id="profile-card">

--- a/origa_ui/src/pages/profile/personal_data_card.rs
+++ b/origa_ui/src/pages/profile/personal_data_card.rs
@@ -1,6 +1,6 @@
 use crate::i18n::*;
 use crate::pages::shared::DailyLoadSelector;
-use crate::ui_components::NativeLanguageToggle;
+use crate::ui_components::{Input, NativeLanguageToggle};
 use leptos::prelude::*;
 use origa::domain::{DailyLoad, NativeLanguage};
 
@@ -9,9 +9,11 @@ use super::content::AutoSaveStatus;
 #[component]
 pub fn PersonalDataCard(
     #[prop(optional, into)] test_id: Signal<String>,
+    username: RwSignal<String>,
     selected_language: RwSignal<NativeLanguage>,
     selected_daily_load: RwSignal<DailyLoad>,
     save_status: Signal<AutoSaveStatus>,
+    on_username_change: Callback<()>,
     on_language_change: Callback<NativeLanguage>,
     on_daily_load_change: Callback<DailyLoad>,
     on_retry: Callback<()>,
@@ -21,10 +23,33 @@ pub fn PersonalDataCard(
         let val = test_id.get();
         if val.is_empty() { None } else { Some(val) }
     };
+    let i18n_for_placeholder = i18n;
+    let username_placeholder = Signal::derive(move || {
+        let locale = i18n_for_placeholder.get_locale();
+        td_string!(locale, common.username_placeholder).to_string()
+    });
+    let on_username_input_change = Callback::new(move |_ev: leptos::ev::Event| {
+        on_username_change.run(());
+    });
 
     view! {
         <div data-testid=test_id_val class="p-6">
             <div class="flex flex-col gap-4">
+                <div class="profile-section">
+                    <label class="label-muted block" for="profile-username-input">
+                        {t!(i18n, profile.username)}
+                    </label>
+                    <Input
+                        value=username
+                        placeholder=username_placeholder
+                        id=Signal::derive(|| "profile-username-input".to_string())
+                        name=Signal::derive(|| "display_name".to_string())
+                        maxlength=Signal::derive(|| Some(origa::use_cases::USERNAME_MAX_CHARS))
+                        class=Signal::derive(|| "w-full".to_string())
+                        on_change=on_username_input_change
+                        test_id=Signal::derive(|| "profile-username-input".to_string())
+                    />
+                </div>
                 <div class="profile-section-row">
                     <div class="label-muted">{t!(i18n, profile.interface_language)}</div>
                     <NativeLanguageToggle

--- a/origa_ui/src/ui_components/input.rs
+++ b/origa_ui/src/ui_components/input.rs
@@ -8,6 +8,7 @@ pub fn Input(
     #[prop(optional, into)] placeholder: Signal<String>,
     #[prop(optional, into)] disabled: Signal<bool>,
     #[prop(optional, into)] rows: Signal<Option<usize>>,
+    #[prop(optional, into)] maxlength: Signal<Option<usize>>,
     #[prop(optional, into)] class: Signal<String>,
     #[prop(optional, into)] input_type: Signal<String>,
     #[prop(optional, into)] autocomplete: Signal<String>,
@@ -33,6 +34,7 @@ pub fn Input(
         let val = name.get();
         if val.is_empty() { None } else { Some(val) }
     };
+    let maxlength_val = move || maxlength.get();
     let test_id_val = move || {
         let val = test_id.get();
         if val.is_empty() { None } else { Some(val) }
@@ -64,6 +66,7 @@ pub fn Input(
                     autocomplete=autocomplete
                     id=id_val
                     name=name_val
+                    maxlength=maxlength_val
                     data-testid=test_id_val
                     rows=r
                     bind:value=value
@@ -89,6 +92,7 @@ pub fn Input(
                     autocomplete=autocomplete
                     id=id_val
                     name=name_val
+                    maxlength=maxlength_val
                     data-testid=test_id_val
                     bind:value=value
                     on:change=move |ev| {

--- a/origa_ui/src/ui_components/sidebar.rs
+++ b/origa_ui/src/ui_components/sidebar.rs
@@ -3,6 +3,7 @@ use crate::store::auth_store::AuthStore;
 use crate::ui_components::avatar::AvatarSize;
 use crate::ui_components::nav_config::NavRoute;
 use crate::ui_components::{Avatar, Logo, LogoSize, derive_test_id};
+use crate::utils::display_name::display_name_for;
 use leptos::prelude::*;
 use leptos_icons::Icon;
 use leptos_router::components::A;
@@ -34,7 +35,10 @@ pub fn Sidebar(
         current_user
             .with(|u| {
                 u.as_ref()
-                    .and_then(|u| u.username().chars().next())
+                    // Empty/untouched relay names must not render a blank
+                    // avatar: fall back to the account email's initial.
+                    .map(|u| display_name_for(u.username(), u.email()))
+                    .and_then(|name| name.chars().next())
                     .map(|c| c.to_uppercase().to_string())
             })
             .unwrap_or_default()

--- a/origa_ui/src/utils/display_name.rs
+++ b/origa_ui/src/utils/display_name.rs
@@ -1,0 +1,128 @@
+//! Display-name helpers shared by login, onboarding, profile and home.
+//!
+//! The username is a free-form display name, not a login identifier. It can
+//! legitimately be empty (e.g. Apple "Hide My Email" accounts, whose opaque
+//! relay local part makes for an unreadable name) — in that case the UI shows
+//! the account email instead and the name inputs start blank with a
+//! placeholder question.
+
+/// Apple's "Hide My Email" relay domain: the local part is an opaque random
+/// string (e.g. `g55jkfzf5p@privaterelay.appleid.com`).
+const APPLE_RELAY_DOMAIN: &str = "@privaterelay.appleid.com";
+
+pub fn is_apple_relay_email(email: &str) -> bool {
+    email.to_ascii_lowercase().ends_with(APPLE_RELAY_DOMAIN)
+}
+
+/// Derives the initial `username` (display name) for a brand-new profile.
+///
+/// Regular emails seed the local part (`ivan.petrov@…` → `ivan.petrov`);
+/// Apple relay emails seed an empty name — the user is then asked during
+/// onboarding (the input's placeholder shows the question).
+pub fn default_username_for_email(email: &str) -> String {
+    if is_apple_relay_email(email) {
+        return String::new();
+    }
+
+    email.split('@').next().unwrap_or(email).to_string()
+}
+
+/// True when the stored username is just the untouched local part of an Apple
+/// relay email — the opaque noise these helpers replace. Covers legacy
+/// profiles created before the onboarding name question existed.
+pub fn is_untouched_relay_username(username: &str, email: &str) -> bool {
+    is_apple_relay_email(email) && username == email.split('@').next().unwrap_or(email)
+}
+
+/// Initial value for a username input: an untouched relay local part is
+/// treated as absent so the placeholder question shows instead of the noise.
+pub fn editable_username_for(username: &str, email: &str) -> String {
+    if is_untouched_relay_username(username, email) {
+        return String::new();
+    }
+
+    username.to_string()
+}
+
+/// Name displayed in place of the raw username: falls back to the account
+/// email when the name is blank or is still an untouched relay local part.
+pub fn display_name_for(username: &str, email: &str) -> String {
+    if username.trim().is_empty() || is_untouched_relay_username(username, email) {
+        return email.to_string();
+    }
+
+    username.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        default_username_for_email, display_name_for, editable_username_for,
+        is_untouched_relay_username,
+    };
+
+    #[test]
+    fn regular_email_seeds_local_part_as_name() {
+        assert_eq!(
+            default_username_for_email("ivan.petrov@example.com"),
+            "ivan.petrov"
+        );
+    }
+
+    #[test]
+    fn apple_relay_email_seeds_empty_name() {
+        assert_eq!(
+            default_username_for_email("g55jkfzf5p@privaterelay.appleid.com"),
+            ""
+        );
+    }
+
+    #[test]
+    fn apple_relay_detection_ignores_domain_case() {
+        assert_eq!(
+            default_username_for_email("g55jkfzf5p@PrivateRelay.AppleID.com"),
+            ""
+        );
+    }
+
+    #[test]
+    fn email_without_at_sign_seeds_whole_string() {
+        assert_eq!(default_username_for_email("no-at-sign"), "no-at-sign");
+    }
+
+    #[test]
+    fn legacy_relay_prefix_counts_as_untouched() {
+        assert!(is_untouched_relay_username(
+            "g55jkfzf5p",
+            "g55jkfzf5p@privaterelay.appleid.com"
+        ));
+        assert!(!is_untouched_relay_username(
+            "Ivan",
+            "g55jkfzf5p@privaterelay.appleid.com"
+        ));
+        // A regular email's prefix is a legitimate name, not noise.
+        assert!(!is_untouched_relay_username("ivan", "ivan@example.com"));
+    }
+
+    #[test]
+    fn editable_name_is_blank_for_untouched_relay_prefix() {
+        assert_eq!(
+            editable_username_for("g55jkfzf5p", "g55jkfzf5p@privaterelay.appleid.com"),
+            ""
+        );
+        assert_eq!(
+            editable_username_for("ivan.petrov", "x@example.com"),
+            "ivan.petrov"
+        );
+    }
+
+    #[test]
+    fn display_name_falls_back_to_email_for_blank_or_untouched_relay_name() {
+        assert_eq!(display_name_for("", "a@b.com"), "a@b.com");
+        assert_eq!(
+            display_name_for("g55jkfzf5p", "g55jkfzf5p@privaterelay.appleid.com"),
+            "g55jkfzf5p@privaterelay.appleid.com"
+        );
+        assert_eq!(display_name_for("Иван", "a@b.com"), "Иван");
+    }
+}

--- a/origa_ui/src/utils/mod.rs
+++ b/origa_ui/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod display_name;
 mod drag_drop;
 mod fetch;
 pub mod file;


### PR DESCRIPTION
## Problem

Users signing in with Apple "Hide My Email" ended up with the opaque relay local part as their username — `g55jkfzf5p` — rendered in the home greeting, profile header/breadcrumbs and the sidebar avatar. The name is a display name, not a login identifier, so it should never be machine noise.

## Solution (as agreed)

1. **Onboarding intro asks for the name** — optional, one line under the welcome block. Prefilled with the email local part for regular addresses; blank with a placeholder question ("How should we call you?" / «Как вас называть?») for relay emails. Saved on Next (fire-and-forget: the name is optional personalization, failures are logged and non-blocking). Skip (the whole-onboarding skip with its confirm modal) intentionally discards the name.
2. **Profile: editable name field** in the personal-data card, wired into the existing autosave pipeline (saves on blur/Enter, not per keystroke).
3. **Smart defaults**: new profiles seed an empty name for `@privaterelay.appleid.com` and the local part otherwise.
4. **Legacy profiles** (the original `g55jkfzf5p` cohort): an untouched relay prefix is detected (`is_untouched_relay_username`) and
   - displayed as the **account email** everywhere (home greeting, profile header + breadcrumbs, sidebar avatar initial),
   - offered as a **blank input + placeholder question** in onboarding resume and the profile field, so entering a name fixes it once, everywhere.

## Engineering notes

- `UpdateUserProfileUseCase::execute` takes `username: Option<&str>` (`None` = keep; `Some` = trim + cap at `USERNAME_MAX_CHARS = 40`); inputs enforce the same cap via a new optional `maxlength` prop on the `Input` component.
- The intro save **reads-modifies-writes the current profile** — it must not replay a stale `native_language`/`daily_load` snapshot captured at page load (the user can flip the language on that very step; a full-record save would silently roll it back).
- a11y: label/`for`/`id` wiring on both new inputs; `maxlength` (UTF-16 in the browser) never admits more than the Rust `chars` cap, so client and server caps agree.
- Documented trade-offs (also in code comments):
  - a language/daily-load change persists the *editable* name as-is — for a legacy relay profile that normalizes the stored garbage to empty (invisible: the email fallback is already what's displayed, and it's the intended end state);
  - profile resync after `refresh_user` can clobber in-flight typing (same trade-off the language/daily-load selectors already accept) — known UX debt;
  - a sub-second full-record write race remains between the onboarding language-save effect and the intro name save (both read-modify-write; the deterministic stale-snapshot bug is gone) — same class of accepted races as the existing autosave paths.

## Tests

- `origa`: 4 new use-case tests (trim+persist, keep-on-None, length cap, blank clears the name) — 1709 green.
- `origa_ui` native: 7 tests for `utils/display_name` (relay/regular/case-insensitive/legacy-prefix/blank/editable/display fallbacks) — 451 green.
- WASM (headless Chrome): intro name input renders + prefilled + drives the signal; auth handler seeds (relay → empty, regular → prefix); personal-data card prefill — 283 green.
- `cargo fmt --check --all` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

Pre-existing (not touched here, fails on clean master too): `cargo test --workspace` drops 2 `on_quiz_toggle` tests via the `sandboxed-arenas` feature unification.