### PR TITLE
fix(i18n): natural Russian phrasing for username placeholder

### DIFF
--- a/.github/actions/download-cdn/action.yml
+++ b/.github/actions/download-cdn/action.yml
@@ -141,7 +141,7 @@ runs:
         declare -A MIN_SIZES
         MIN_SIZES["well_known_set/well_known_sets_meta.json"]=100000
         MIN_SIZES["well_known_set/well_known_types_meta.json"]=100
-        MIN_SIZES["dictionaries/metadata.json"]=100
+        MIN_SIZES["dictionaries/sudachidict-20260723/metadata.json"]=100
         MIN_SIZES["manifest.json"]=100
         MIN_SIZES["dictionaries/JmdictFurigana.txt"]=1000
         MIN_SIZES["phrases/phrase_index.json"]=100

--- a/.github/actions/download-cdn/action.yml
+++ b/.github/actions/download-cdn/action.yml
@@ -141,7 +141,7 @@ runs:
         declare -A MIN_SIZES
         MIN_SIZES["well_known_set/well_known_sets_meta.json"]=100000
         MIN_SIZES["well_known_set/well_known_types_meta.json"]=100
-        MIN_SIZES["dictionaries/sudachidict-20260723/metadata.json"]=100
+        MIN_SIZES["dictionaries/metadata.json"]=100
         MIN_SIZES["manifest.json"]=100
         MIN_SIZES["dictionaries/JmdictFurigana.txt"]=1000
         MIN_SIZES["phrases/phrase_index.json"]=100

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -27,7 +27,7 @@
     "tooltip_new": "Новое слово",
     "language_aria_label": "Выберите язык",
     "more_details": "Подробнее",
-    "username_placeholder": "Как вас называть?"
+    "username_placeholder": "Как вас зовут?"
   },
   "app": {
     "logging_in": "Вход..."


### PR DESCRIPTION
The onboarding/profile username placeholder read "Как вас называть?" — unnatural Russian. Now "Как вас зовут?".

- `origa_ui/locales/ru.json` → `common.username_placeholder`
- touches both usages (onboarding `intro_step.rs`, profile `personal_data_card.rs`) via the shared key
- EN locale untouched

Localization-only change; RU landing/docs glossary has no occurrences.