### PR TITLE
fix(core): make bulk card imports linear instead of quadratic (N2 onboarding slow import)

### DIFF
--- a/docs/decisions/ADR-043-bulk-import-mode-knowledge-set.md
+++ b/docs/decisions/ADR-043-bulk-import-mode-knowledge-set.md
@@ -1,0 +1,103 @@
+# ADR-043: Bulk-import mode for KnowledgeSet (O(n) card creation)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-09-01
+
+## Context
+
+Bug: onboarding import is unusably slow for JLPT N2 users. Picking N2
+queues the cumulative `jlpt_n5+n4+n3+n2` sets (~4.9k words → **6341 cards**:
+vocabulary + kanji + companion vocab + grammar). Every
+`KnowledgeSet::create_card` ran **two O(n) full scans**:
+
+1. `validate_unique_card` — linear scan over all existing cards;
+2. `recalculate_daily_stats` — two full passes (aggregate stats + rating
+   fold) over all cards.
+
+Per-card cost therefore grew linearly with card count → **O(n²) imports**.
+Measured (native debug): N5 import = 916 cards / 47 ms (51 527 ns/card);
+N2 import = 6341 cards / 1584 ms (249 799 ns/card) — **per-card ratio 4.86**
+(the smoking gun; linear code stays near 1.0). On release-WASM in the
+browser this froze the UI for the whole "Start import" step, and N1 /
+extra app sets scale it further.
+
+The same quadratic pattern existed in three paths:
+
+- `ImportOnboardingSetsUseCase` (onboarding, the reported bug),
+- `ImportAnkiPackUseCase` (Anki pack import),
+- `MigrateKanjiCompanionsUseCase` (runs on **every cold start**, iterating
+  companions per kanji + a delete loop with a full stats recalc per
+  delete).
+
+## Decision
+
+Add a **transient bulk-import mode** to `KnowledgeSet`:
+
+- `#[serde(skip)] import_dedup_index: Option<HashSet<(CardType, String)>>`
+  — never serialized, rebuilt from `study_cards` on
+  `begin_bulk_import()`, dropped on `end_bulk_import()`.
+- While active: `create_card` checks uniqueness against the index (O(1))
+  and **defers** the daily-stats recalc; `delete_card` also defers.
+  `end_bulk_import()` performs **one** recalc for the whole batch.
+- Dedup key = `(CardType, content_key())`: the type discriminates
+  cross-type collisions (vocabulary「日」and kanji「日」are distinct cards —
+  same semantics as the old same-type-only `match`).
+- Outside the bracket, behavior is byte-for-byte unchanged (linear
+  validate + per-card recalc).
+
+`User::begin_bulk_import` / `end_bulk_import` (`pub(crate)`) wrap the three
+use cases above. Result: N2 import **1584 ms → 139 ms (11.4x)**, per-card
+ratio N2/N5 → ~1.0.
+
+## Alternatives Considered
+
+### Permanent content-key index (always maintained)
+
+Pros: O(1) uniqueness everywhere, no bracket discipline.
+Cons: the index must be rebuilt on every deserialization (custom
+`Deserialize` for the whole struct — the wire format has a custom
+study-cards visitor + `#[serde(flatten)]` stats), and maintained in every
+mutation (`create`/`delete`/`update`/`merge`) forever. More invariants to
+break for a hot path only imports need. Rejected: transient mode gets the
+same complexity win with zero permanent invariants and no wire-format risk.
+
+### Incremental stats (running aggregates in StatsTracker)
+
+Pros: O(1) per create even outside imports.
+Cons: stateful counters, float drift on subtract, and `recalculate` also
+recomputes today's ratings from `last_review_date` — the incremental path
+would duplicate that logic. Rejected: the final recalc is a **pure
+function of the final card set + preserved day counters**, so deferring to
+one call is provably equivalent (verified by
+`bulk_import_creates_same_daily_stats_as_one_by_one_creation` and
+`bulk_import_after_same_day_reviews_preserves_counters_and_ratings`).
+
+### Batch-only fast path inside the use cases (local HashSet per import)
+
+Rejected: companion creation (`create_companion_vocab_cards`) also needs
+dedup, so the use case would have to replicate domain dedup logic — leaky.
+
+## Consequences
+
+- Bracket discipline: callers must pair `begin_bulk_import` with
+  `end_bulk_import`. An unclosed bracket cannot corrupt persistence (early
+  error returns drop the unsaved local `User`; the index is
+  `#[serde(skip)]` so a restart clears it) but would leave daily stats
+  stale until the next recalc trigger (any rate/delete).
+- `update_card_content` and `merge` **drop the index** (degrade to the
+  linear scan) instead of maintaining it: content replacement could alias
+  keys (one key owned by two cards → false-negative uniqueness after a
+  delete), so the invariant "one card ↔ one key" is made unbreakable
+  rather than patched. These paths are not bulk paths.
+- Only divergence from the per-card recalc sequence: a batch spanning
+  UTC midnight loses the previous-day snapshot item the per-card path
+  would have written (window ≈ 140 ms; accepted).
+- Regression guard: `import_cost_grows_linearly_with_card_count`
+  (journeys) runs the real production sets from `cdn/` best-of-3 per
+  scenario and asserts per-card cost ratio N2/N5 < 2.0 (quadratic code
+  measures ~4.86; linear ~1.0).

--- a/origa/src/domain/knowledge/card.rs
+++ b/origa/src/domain/knowledge/card.rs
@@ -206,6 +206,25 @@ pub enum CardType {
     Phrase,
 }
 
+/// Uniqueness identity of a card for bulk-import deduplication: card type
+/// plus content key. A vocabulary word and a kanji may share the same
+/// surface text (「日」), so the type discriminates otherwise-equal keys —
+/// mirroring the same-type-only semantics of the linear uniqueness scan.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ImportDedupKey {
+    card_type: CardType,
+    content: String,
+}
+
+impl ImportDedupKey {
+    pub fn new(card: &Card) -> Self {
+        Self {
+            card_type: CardType::from(card),
+            content: card.content_key(),
+        }
+    }
+}
+
 impl From<&Card> for CardType {
     fn from(card: &Card) -> Self {
         match card {

--- a/origa/src/domain/knowledge/mod.rs
+++ b/origa/src/domain/knowledge/mod.rs
@@ -79,6 +79,11 @@ pub struct KnowledgeSet {
     deleted_companion_words: HashSet<String>,
     #[serde(flatten)]
     stats: StatsTracker,
+    // Transient bulk-import dedup index (see `begin_bulk_import`): never
+    // serialized, rebuilt from `study_cards` when a bulk import starts, and
+    // always `None` outside an import batch.
+    #[serde(skip)]
+    import_dedup_index: Option<HashSet<(CardType, String)>>,
 }
 
 fn deserialize_study_cards<'de, D>(deserializer: D) -> Result<HashMap<Ulid, StudyCard>, D::Error>
@@ -129,10 +134,16 @@ impl KnowledgeSet {
             deleted_cards: HashSet::new(),
             deleted_companion_words: HashSet::new(),
             stats: StatsTracker::new(),
+            import_dedup_index: None,
         }
     }
 
     pub fn merge(&mut self, new_values: &KnowledgeSet) {
+        // Merge is a sync path, never a bulk import: drop any active dedup
+        // index so `create_card` falls back to the linear uniqueness scan
+        // (merge itself validates uniqueness per card below).
+        self.import_dedup_index = None;
+
         for deleted_id in &new_values.deleted_cards {
             self.study_cards.remove(deleted_id);
             self.deleted_cards.insert(*deleted_id);
@@ -203,20 +214,21 @@ impl KnowledgeSet {
                 .insert(vocab.word().text().to_string());
         }
         self.deleted_cards.insert(card_id);
-        self.recalculate_daily_stats();
+        if let Some(index) = &mut self.import_dedup_index {
+            index.remove(&Self::import_dedup_key(removed.card()));
+        } else {
+            self.recalculate_daily_stats();
+        }
         Ok(())
     }
 
-    pub fn deleted_cards(&self) -> &HashSet<Ulid> {
-        &self.deleted_cards
-    }
-
-    #[cfg(test)]
-    pub fn deleted_companion_words_for_test(&self) -> &HashSet<String> {
-        &self.deleted_companion_words
-    }
-
     pub fn update_card_content(&mut self, card_id: Ulid, new_card: Card) -> Result<(), OrigaError> {
+        // Content replacement can break the bulk index invariant (one card ↔
+        // one key: a `new_card` whose key is already owned by another card
+        // would alias keys). Drop the index so subsequent `create_card` calls
+        // degrade to the linear uniqueness scan — semantics preserved, and
+        // the invariant cannot be violated. (Mirrors the `merge` policy.)
+        self.import_dedup_index = None;
         let study_card = self
             .study_cards
             .get_mut(&card_id)
@@ -228,8 +240,19 @@ impl KnowledgeSet {
     pub fn create_card(&mut self, card: Card) -> Result<StudyCard, OrigaError> {
         let study_card = StudyCard::new(card);
         let card_id = *study_card.card_id();
+        let dedup_key = Self::import_dedup_key(study_card.card());
 
-        self.validate_unique_card(study_card.card())?;
+        // Bulk-import mode checks uniqueness against the dedup index (O(1));
+        // outside it, the linear scan keeps the single-card path as-is.
+        if let Some(index) = &self.import_dedup_index {
+            if index.contains(&dedup_key) {
+                return Err(OrigaError::DuplicateCard {
+                    question: study_card.card().content_key(),
+                });
+            }
+        } else {
+            self.validate_unique_card(study_card.card())?;
+        }
 
         if self
             .study_cards
@@ -250,8 +273,53 @@ impl KnowledgeSet {
             self.deleted_companion_words.remove(vocab.word().text());
         }
 
-        self.recalculate_daily_stats();
+        if let Some(index) = &mut self.import_dedup_index {
+            index.insert(dedup_key);
+        } else {
+            self.recalculate_daily_stats();
+        }
         Ok(study_card)
+    }
+
+    /// Uniqueness identity of a card: card type + content key. Cross-type
+    /// collisions are legitimate (a vocabulary word and a kanji may share the
+    /// same surface text), so the type discriminates the key.
+    fn import_dedup_key(card: &Card) -> (CardType, String) {
+        (CardType::from(card), card.content_key())
+    }
+
+    /// Enters bulk-import mode: builds a dedup index over the current cards
+    /// so `create_card` uniqueness checks are O(1) instead of a full scan,
+    /// and daily-stats recalculation is deferred. Onboarding/Anki imports
+    /// create thousands of cards; per-card full scans made those imports
+    /// quadratic (the "N2 onboarding import is unusably slow" bug).
+    pub(crate) fn begin_bulk_import(&mut self) {
+        self.import_dedup_index = Some(
+            self.study_cards
+                .values()
+                .map(|sc| Self::import_dedup_key(sc.card()))
+                .collect(),
+        );
+    }
+
+    /// Leaves bulk-import mode: drops the dedup index and recalculates the
+    /// daily stats once for the whole batch. The recalc is a pure function
+    /// of the final card set plus the day's preserved counters, so it lands
+    /// on the same today-item the per-card recalcs would have (the only
+    /// divergence is a batch spanning UTC midnight, where the per-card path
+    /// would additionally snapshot the previous day).
+    pub(crate) fn end_bulk_import(&mut self) {
+        self.import_dedup_index = None;
+        self.recalculate_daily_stats();
+    }
+
+    pub fn deleted_cards(&self) -> &HashSet<Ulid> {
+        &self.deleted_cards
+    }
+
+    #[cfg(test)]
+    pub fn deleted_companion_words_for_test(&self) -> &HashSet<String> {
+        &self.deleted_companion_words
     }
 
     fn build_cards_by_type(&self) -> HashMap<CardType, Vec<Card>> {

--- a/origa/src/domain/knowledge/mod.rs
+++ b/origa/src/domain/knowledge/mod.rs
@@ -13,6 +13,7 @@ mod stats_updater;
 mod tests;
 pub mod vocabulary;
 
+use card::ImportDedupKey;
 pub use card::{Card, CardType, StudyCard};
 pub use daily_history::{DailyHistoryItem, estimate_completion_date};
 pub use empty_diagnosis::{LessonEmptyDiagnosis, diagnose_empty_lesson};
@@ -83,8 +84,12 @@ pub struct KnowledgeSet {
     // serialized, rebuilt from `study_cards` when a bulk import starts, and
     // always `None` outside an import batch.
     #[serde(skip)]
-    import_dedup_index: Option<HashSet<(CardType, String)>>,
+    import_dedup_index: Option<ImportDedupIndex>,
 }
+
+/// Dedup index maintained while a bulk import is active: one
+/// [`ImportDedupKey`] per existing card.
+type ImportDedupIndex = HashSet<ImportDedupKey>;
 
 fn deserialize_study_cards<'de, D>(deserializer: D) -> Result<HashMap<Ulid, StudyCard>, D::Error>
 where
@@ -215,7 +220,7 @@ impl KnowledgeSet {
         }
         self.deleted_cards.insert(card_id);
         if let Some(index) = &mut self.import_dedup_index {
-            index.remove(&Self::import_dedup_key(removed.card()));
+            index.remove(&ImportDedupKey::new(removed.card()));
         } else {
             self.recalculate_daily_stats();
         }
@@ -240,7 +245,7 @@ impl KnowledgeSet {
     pub fn create_card(&mut self, card: Card) -> Result<StudyCard, OrigaError> {
         let study_card = StudyCard::new(card);
         let card_id = *study_card.card_id();
-        let dedup_key = Self::import_dedup_key(study_card.card());
+        let dedup_key = ImportDedupKey::new(study_card.card());
 
         // Bulk-import mode checks uniqueness against the dedup index (O(1));
         // outside it, the linear scan keeps the single-card path as-is.
@@ -281,23 +286,17 @@ impl KnowledgeSet {
         Ok(study_card)
     }
 
-    /// Uniqueness identity of a card: card type + content key. Cross-type
-    /// collisions are legitimate (a vocabulary word and a kanji may share the
-    /// same surface text), so the type discriminates the key.
-    fn import_dedup_key(card: &Card) -> (CardType, String) {
-        (CardType::from(card), card.content_key())
-    }
-
     /// Enters bulk-import mode: builds a dedup index over the current cards
-    /// so `create_card` uniqueness checks are O(1) instead of a full scan,
-    /// and daily-stats recalculation is deferred. Onboarding/Anki imports
-    /// create thousands of cards; per-card full scans made those imports
-    /// quadratic (the "N2 onboarding import is unusably slow" bug).
+    /// (one [`ImportDedupKey`] per card) so `create_card` uniqueness checks
+    /// are O(1) instead of a full scan, and daily-stats recalculation is
+    /// deferred. Onboarding/Anki imports create thousands of cards; per-card
+    /// full scans made those imports quadratic (the "N2 onboarding import is
+    /// unusably slow" bug).
     pub(crate) fn begin_bulk_import(&mut self) {
         self.import_dedup_index = Some(
             self.study_cards
                 .values()
-                .map(|sc| Self::import_dedup_key(sc.card()))
+                .map(|sc| ImportDedupKey::new(sc.card()))
                 .collect(),
         );
     }

--- a/origa/src/domain/knowledge/tests.rs
+++ b/origa/src/domain/knowledge/tests.rs
@@ -1668,3 +1668,258 @@ mod deleted_companion_words {
         );
     }
 }
+
+// --- Bulk-import mode (begin_bulk_import / end_bulk_import) ---
+
+#[test]
+fn bulk_import_creates_same_daily_stats_as_one_by_one_creation() {
+    // Arrange
+    let mut one_by_one = KnowledgeSet::new();
+    let mut bulk = KnowledgeSet::new();
+    let words: Vec<Card> = (0..30)
+        .map(|i| create_vocab_card(&format!("word_{i}")))
+        .collect();
+    for card in &words {
+        one_by_one.create_card(card.clone()).unwrap();
+    }
+
+    // Act
+    bulk.begin_bulk_import();
+    for card in &words {
+        bulk.create_card(card.clone()).unwrap();
+    }
+    bulk.end_bulk_import();
+
+    // Assert — deferred recalculation must land on exactly the history
+    // item the per-card recalcs would have produced.
+    assert_eq!(bulk.study_cards().len(), one_by_one.study_cards().len());
+    assert_eq!(
+        bulk.lesson_history().len(),
+        one_by_one.lesson_history().len()
+    );
+    let (individual, batched) = (&one_by_one.lesson_history()[0], &bulk.lesson_history()[0]);
+    assert_eq!(batched.total_words(), individual.total_words());
+    assert_eq!(batched.new_words(), individual.new_words());
+    assert_eq!(batched.known_words(), individual.known_words());
+    assert_eq!(batched.in_progress_words(), individual.in_progress_words());
+    assert_eq!(
+        batched.high_difficulty_words(),
+        individual.high_difficulty_words()
+    );
+    assert_eq!(batched.avg_stability(), individual.avg_stability());
+    assert_eq!(batched.avg_difficulty(), individual.avg_difficulty());
+}
+
+#[test]
+fn bulk_import_after_same_day_reviews_preserves_counters_and_ratings() {
+    // Arrange — both sets start with one already-reviewed card, so the
+    // today-item carries preserved counters and recomputed ratings before
+    // the batch runs (the realistic shape: an import into an active day).
+    let set_with_reviewed_base_card = || {
+        let mut knowledge_set = KnowledgeSet::new();
+        let base = knowledge_set
+            .create_card(create_vocab_card("base"))
+            .unwrap();
+        knowledge_set
+            .rate_card(*base.card_id(), Rating::Good, RateMode::StandardLesson)
+            .unwrap();
+        knowledge_set
+    };
+    let mut one_by_one = set_with_reviewed_base_card();
+    let mut bulk = set_with_reviewed_base_card();
+    let words: Vec<Card> = (0..10)
+        .map(|i| create_vocab_card(&format!("extra_{i}")))
+        .collect();
+    for card in &words {
+        one_by_one.create_card(card.clone()).unwrap();
+    }
+
+    // Act
+    bulk.begin_bulk_import();
+    for card in &words {
+        bulk.create_card(card.clone()).unwrap();
+    }
+    bulk.end_bulk_import();
+
+    // Assert — preserved day counters and rating aggregates must match
+    // the per-card path exactly.
+    let (individual, batched) = (&one_by_one.lesson_history()[0], &bulk.lesson_history()[0]);
+    assert_eq!(
+        batched.new_cards_studied_today(),
+        individual.new_cards_studied_today()
+    );
+    assert_eq!(
+        batched.phrase_cards_studied_today(),
+        individual.phrase_cards_studied_today()
+    );
+    assert_eq!(batched.positive_ratings(), individual.positive_ratings());
+    assert_eq!(batched.negative_ratings(), individual.negative_ratings());
+    assert_eq!(batched.total_ratings(), individual.total_ratings());
+    assert_eq!(batched.total_words(), individual.total_words());
+}
+
+#[test]
+fn bulk_import_rejects_duplicate_created_within_batch() {
+    // Arrange
+    let mut knowledge_set = KnowledgeSet::new();
+    knowledge_set.begin_bulk_import();
+    knowledge_set.create_card(create_vocab_card("猫")).unwrap();
+
+    // Act
+    let duplicate = knowledge_set.create_card(create_vocab_card("猫"));
+
+    // Assert
+    assert!(
+        matches!(duplicate, Err(OrigaError::DuplicateCard { .. })),
+        "a word created earlier in the same batch must be rejected"
+    );
+    knowledge_set.end_bulk_import();
+    assert_eq!(knowledge_set.study_cards().len(), 1);
+}
+
+#[test]
+fn bulk_import_rejects_duplicate_of_card_created_before_batch() {
+    // Arrange
+    let mut knowledge_set = KnowledgeSet::new();
+    knowledge_set.create_card(create_vocab_card("猫")).unwrap();
+    knowledge_set.begin_bulk_import();
+
+    // Act
+    let duplicate = knowledge_set.create_card(create_vocab_card("猫"));
+
+    // Assert
+    assert!(
+        matches!(duplicate, Err(OrigaError::DuplicateCard { .. })),
+        "the dedup index must include cards created before the batch"
+    );
+}
+
+#[test]
+fn bulk_import_allows_same_text_for_vocabulary_and_kanji_cards() {
+    // Arrange — "日" as a vocabulary word and as a kanji are distinct
+    // cards; the dedup key must not collapse them into one.
+    let mut knowledge_set = KnowledgeSet::new();
+    knowledge_set.begin_bulk_import();
+
+    // Act
+    knowledge_set.create_card(create_vocab_card("日")).unwrap();
+    knowledge_set
+        .create_card(Card::Kanji(KanjiCard::new_test("日".to_string())))
+        .unwrap();
+    knowledge_set.end_bulk_import();
+
+    // Assert
+    assert_eq!(knowledge_set.study_cards().len(), 2);
+}
+
+#[test]
+fn bulk_import_delete_then_recreate_same_word_succeeds() {
+    // Arrange
+    let mut knowledge_set = KnowledgeSet::new();
+    knowledge_set.begin_bulk_import();
+    let created = knowledge_set.create_card(create_vocab_card("猫")).unwrap();
+    knowledge_set.delete_card(*created.card_id()).unwrap();
+
+    // Act
+    let recreated = knowledge_set.create_card(create_vocab_card("猫"));
+
+    // Assert — deleting inside the batch must evict the word from the
+    // dedup index so it can be re-created.
+    assert!(
+        recreated.is_ok(),
+        "recreating a deleted word inside the batch must succeed"
+    );
+    knowledge_set.end_bulk_import();
+    assert_eq!(knowledge_set.study_cards().len(), 1);
+}
+
+#[test]
+fn bulk_import_delete_defers_stats_recalc_to_end_of_batch() {
+    // Arrange — identical sets; the same delete runs outside vs inside a
+    // bulk batch.
+    let set_with_two_cards = || {
+        let mut knowledge_set = KnowledgeSet::new();
+        let doomed = knowledge_set
+            .create_card(create_vocab_card("doomed"))
+            .unwrap();
+        knowledge_set
+            .create_card(create_vocab_card("keeper"))
+            .unwrap();
+        (knowledge_set, doomed)
+    };
+    let (mut one_by_one, doomed_individual) = set_with_two_cards();
+    let (mut batch, doomed_batched) = set_with_two_cards();
+
+    // Act
+    one_by_one
+        .delete_card(*doomed_individual.card_id())
+        .unwrap();
+
+    batch.begin_bulk_import();
+    batch.delete_card(*doomed_batched.card_id()).unwrap();
+    batch.end_bulk_import();
+
+    // Assert — the deferred recalc must reflect the deletion: the batched
+    // path cannot leave a stale (undeleted) word count behind.
+    let (individual, batched) = (&one_by_one.lesson_history()[0], &batch.lesson_history()[0]);
+    assert_eq!(individual.total_words(), 1);
+    assert_eq!(batched.total_words(), individual.total_words());
+    assert_eq!(batched.new_words(), individual.new_words());
+}
+
+#[test]
+fn bulk_import_content_update_drops_index_but_still_rejects_duplicates() {
+    // Arrange
+    let mut knowledge_set = KnowledgeSet::new();
+    knowledge_set.begin_bulk_import();
+    let target = knowledge_set.create_card(create_vocab_card("old")).unwrap();
+    knowledge_set
+        .create_card(create_vocab_card("other"))
+        .unwrap();
+
+    // Act — content replacement drops the bulk index (degradation policy,
+    // mirrors merge).
+    knowledge_set
+        .update_card_content(*target.card_id(), create_vocab_card("renamed"))
+        .unwrap();
+    let duplicate_other = knowledge_set.create_card(create_vocab_card("other"));
+    let duplicate_renamed = knowledge_set.create_card(create_vocab_card("renamed"));
+
+    // Assert — the linear fallback must keep rejecting duplicates after the
+    // index is dropped.
+    assert!(
+        matches!(duplicate_other, Err(OrigaError::DuplicateCard { .. })),
+        "duplicate of an untouched card must still be rejected"
+    );
+    assert!(
+        matches!(duplicate_renamed, Err(OrigaError::DuplicateCard { .. })),
+        "duplicate of the updated card must still be rejected"
+    );
+    assert_eq!(knowledge_set.study_cards().len(), 2);
+}
+
+#[test]
+fn bulk_import_merge_drops_index_but_still_rejects_duplicates() {
+    // Arrange
+    let mut knowledge_set = KnowledgeSet::new();
+    knowledge_set.begin_bulk_import();
+    knowledge_set
+        .create_card(create_vocab_card("base"))
+        .unwrap();
+
+    let mut remote = KnowledgeSet::new();
+    remote
+        .create_card(create_vocab_card("remote_word"))
+        .unwrap();
+
+    // Act — merge drops the bulk index (degradation policy).
+    knowledge_set.merge(&remote);
+    let duplicate = knowledge_set.create_card(create_vocab_card("remote_word"));
+
+    // Assert — the linear fallback must reject a duplicate of the card the
+    // merge just inserted.
+    assert!(
+        matches!(duplicate, Err(OrigaError::DuplicateCard { .. })),
+        "duplicate of a merged-in card must still be rejected"
+    );
+}

--- a/origa/src/domain/user.rs
+++ b/origa/src/domain/user.rs
@@ -337,6 +337,21 @@ impl User {
         self.knowledge_set.create_card(card)
     }
 
+    /// Opens the bulk-import bracket for imports that create thousands of
+    /// cards (onboarding sets, Anki packs): until
+    /// [`User::end_bulk_import`], uniqueness checks are index-backed and
+    /// daily-stats recalculation is deferred, keeping the import linear
+    /// instead of quadratic.
+    pub(crate) fn begin_bulk_import(&mut self) {
+        self.knowledge_set.begin_bulk_import();
+    }
+
+    /// Closes the bulk-import bracket opened by [`User::begin_bulk_import`]:
+    /// recalculates the daily stats once for the whole batch.
+    pub(crate) fn end_bulk_import(&mut self) {
+        self.knowledge_set.end_bulk_import();
+    }
+
     pub fn update_card_content(&mut self, card_id: Ulid, new_card: Card) -> Result<(), OrigaError> {
         self.knowledge_set.update_card_content(card_id, new_card)
     }

--- a/origa/src/use_cases/import_anki_pack.rs
+++ b/origa/src/use_cases/import_anki_pack.rs
@@ -121,6 +121,12 @@ impl<'a, R: UserRepository> ImportAnkiPackUseCase<'a, R> {
         let mut total_created = 0;
         let mut skipped = Vec::new();
 
+        // Bulk bracket: an Anki pack can contain thousands of cards; the
+        // index-backed uniqueness check + deferred stats recalc keep the
+        // import linear (an early `return Err` below discards the unsaved
+        // local user, so the unclosed bracket has no effect).
+        user.begin_bulk_import();
+
         for anki_card in cards {
             let question = anki_card.word.clone();
             let result = VocabularyCard::from_text(&question, user.native_language());
@@ -141,6 +147,8 @@ impl<'a, R: UserRepository> ImportAnkiPackUseCase<'a, R> {
                 skipped.push(s.clone());
             }
         }
+
+        user.end_bulk_import();
 
         self.repository.save_sync(&user).await?;
 

--- a/origa/src/use_cases/import_onboarding_sets.rs
+++ b/origa/src/use_cases/import_onboarding_sets.rs
@@ -55,30 +55,18 @@ impl<'a, R: UserRepository, C: CdnProvider> ImportOnboardingSetsUseCase<'a, R, C
         let mut created_kanji_chars: HashSet<String> = HashSet::new();
         let mut grammar_levels: HashSet<JapaneseLevel> = HashSet::new();
 
-        for (set_id, set) in sets {
-            debug!(set_id = %set_id, words_count = set.words().len(), "Processing set");
+        // Thousands of cards are created below; the bulk bracket keeps each
+        // create O(1) (index-backed uniqueness + deferred stats recalc) —
+        // per-card full scans made N2-scale imports quadratic.
+        user.begin_bulk_import();
 
-            let set_level = *set.level();
-            // Grammar is keyed by JLPT level, so any set contributes its own
-            // level — previously gated to "Jlpt"-prefixed ids only, which left
-            // Minna / Irodori / Duolingo without grammar.
-            grammar_levels.insert(set_level);
-
-            let words_result = VocabularyCard::from_text(&set.words().join(" "), &native_language);
-
-            result.skipped_no_translation += words_result.skipped_no_translation.len();
-
-            for vocab_card in words_result.cards {
-                if self
-                    .create_vocabulary_card(&mut user, vocab_card, &mut result.skipped_duplicates)
-                    .is_ok()
-                {
-                    result.created_vocabulary += 1;
-                }
-            }
-
-            result.imported_set_ids.push(set_id);
-        }
+        self.import_vocabulary_from_sets(
+            &mut user,
+            sets,
+            &native_language,
+            &mut result,
+            &mut grammar_levels,
+        );
 
         // Pull in every level at or below the target so a user picking N3 also
         // gets N5/N4/N2/... grammar rules and kanji they should already know,
@@ -89,9 +77,76 @@ impl<'a, R: UserRepository, C: CdnProvider> ImportOnboardingSetsUseCase<'a, R, C
             }
         }
 
+        self.import_grammar_for_levels(&mut user, &grammar_levels, &mut result);
+        self.import_kanji_up_to_level(
+            &mut user,
+            target_level,
+            &mut result,
+            &mut created_kanji_chars,
+        );
+
+        user.end_bulk_import();
+
+        user.mark_sets_as_imported(set_ids);
+        self.repository.save_sync(&user).await?;
+
+        info!(
+            user_id = %user.id(),
+            vocabulary = result.created_vocabulary,
+            kanji = result.created_kanji,
+            grammar = result.created_grammar,
+            duplicates = result.skipped_duplicates,
+            "Onboarding sets import completed"
+        );
+
+        Ok(result)
+    }
+
+    /// Creates vocabulary cards from every set's words; each set also
+    /// contributes its own level to `grammar_levels`.
+    fn import_vocabulary_from_sets(
+        &self,
+        user: &mut crate::domain::User,
+        sets: Vec<(String, WellKnownSet)>,
+        native_language: &crate::domain::NativeLanguage,
+        result: &mut ImportOnboardingResult,
+        grammar_levels: &mut HashSet<JapaneseLevel>,
+    ) {
+        for (set_id, set) in sets {
+            debug!(set_id = %set_id, words_count = set.words().len(), "Processing set");
+
+            let set_level = *set.level();
+            // Grammar is keyed by JLPT level, so any set contributes its own
+            // level — previously gated to "Jlpt"-prefixed ids only, which left
+            // Minna / Irodori / Duolingo without grammar.
+            grammar_levels.insert(set_level);
+
+            let words_result = VocabularyCard::from_text(&set.words().join(" "), native_language);
+
+            result.skipped_no_translation += words_result.skipped_no_translation.len();
+
+            for vocab_card in words_result.cards {
+                if self
+                    .create_vocabulary_card(user, vocab_card, &mut result.skipped_duplicates)
+                    .is_ok()
+                {
+                    result.created_vocabulary += 1;
+                }
+            }
+
+            result.imported_set_ids.push(set_id);
+        }
+    }
+
+    fn import_grammar_for_levels(
+        &self,
+        user: &mut crate::domain::User,
+        grammar_levels: &HashSet<JapaneseLevel>,
+        result: &mut ImportOnboardingResult,
+    ) {
         debug!(levels = ?grammar_levels, "Importing grammar rules for onboarding levels");
 
-        for level in &grammar_levels {
+        for level in grammar_levels {
             let grammar_rules = get_rules_by_level(level);
             for rule in grammar_rules {
                 if let Ok(grammar_card) = GrammarRuleCard::new(*rule.rule_id()) {
@@ -110,13 +165,21 @@ impl<'a, R: UserRepository, C: CdnProvider> ImportOnboardingSetsUseCase<'a, R, C
                 }
             }
         }
+    }
 
-        // Import kanji directly from the kanji dictionary for every level ≤
-        // target — symmetric with grammar above. Previously kanji were
-        // extracted FROM vocabulary words, which produced wrong results: a
-        // word at N4 might contain an N3 kanji, so the user got kanji they
-        // never asked for. Kanji→vocab companion cards are still created for
-        // each kanji (create_companion_vocab_cards).
+    /// Imports kanji directly from the kanji dictionary for every level ≤
+    /// target — symmetric with grammar. Previously kanji were extracted FROM
+    /// vocabulary words, which produced wrong results: a word at N4 might
+    /// contain an N3 kanji, so the user got kanji they never asked for.
+    /// Kanji→vocab companion cards are still created for each kanji
+    /// (`create_companion_vocab_cards`).
+    fn import_kanji_up_to_level(
+        &self,
+        user: &mut crate::domain::User,
+        target_level: JapaneseLevel,
+        result: &mut ImportOnboardingResult,
+        created_kanji_chars: &mut HashSet<String>,
+    ) {
         debug!(target_level = ?target_level, "Importing kanji from dictionary");
         for level in JapaneseLevel::ALL {
             if level > target_level {
@@ -127,29 +190,12 @@ impl<'a, R: UserRepository, C: CdnProvider> ImportOnboardingSetsUseCase<'a, R, C
                 if created_kanji_chars.contains(&kanji_char) {
                     continue;
                 }
-                if self
-                    .create_kanji_card(&mut user, &kanji_char, &mut result)
-                    .is_ok()
-                {
+                if self.create_kanji_card(user, &kanji_char, result).is_ok() {
                     result.created_kanji += 1;
                     created_kanji_chars.insert(kanji_char);
                 }
             }
         }
-
-        user.mark_sets_as_imported(set_ids);
-        self.repository.save_sync(&user).await?;
-
-        info!(
-            user_id = %user.id(),
-            vocabulary = result.created_vocabulary,
-            kanji = result.created_kanji,
-            grammar = result.created_grammar,
-            duplicates = result.skipped_duplicates,
-            "Onboarding sets import completed"
-        );
-
-        Ok(result)
     }
 
     async fn load_sets_via_cdn(

--- a/origa/src/use_cases/migrate_kanji_companions.rs
+++ b/origa/src/use_cases/migrate_kanji_companions.rs
@@ -49,8 +49,14 @@ impl<'a, R: UserRepository> MigrateKanjiCompanionsUseCase<'a, R> {
             "Starting kanji companion migration"
         );
 
+        // Bulk bracket: the migration loops below create/delete a companion
+        // card per kanji on every cold start; per-card full scans made that
+        // quadratic for N2-scale users. The steady-state early return below
+        // happens after the bracket closes, so nothing mutates afterwards.
+        user.begin_bulk_import();
         let total_deleted = Self::delete_removed_companions(&mut user, &removed_set);
         let total_created = Self::create_missing_companions(&mut user, &kanji_chars);
+        user.end_bulk_import();
 
         // Skip persistence in steady state: after the first run every
         // subsequent cold start finds nothing to delete or create and

--- a/origa/src/use_cases/tests/journeys/import_onboarding_n2_scale.rs
+++ b/origa/src/use_cases/tests/journeys/import_onboarding_n2_scale.rs
@@ -1,0 +1,104 @@
+use std::time::Instant;
+
+use crate::domain::{JapaneseLevel, NativeLanguage, User};
+use crate::traits::UserRepository;
+use crate::use_cases::ImportOnboardingSetsUseCase;
+use crate::use_cases::tests::fixtures::{
+    InMemoryUserRepository, MockCdnProvider, get_cdn_dir, init_real_dictionaries,
+};
+
+/// Runs the full onboarding import for the given well-known sets exactly as
+/// the onboarding UI queues them (real production JSONs from `cdn/`), on a
+/// fresh user, returning `(created card count, elapsed time)`.
+async fn import_sets(
+    set_ids: &[&str],
+    target_level: JapaneseLevel,
+) -> (usize, std::time::Duration) {
+    init_real_dictionaries();
+    let mut cdn = MockCdnProvider::new();
+    for id in set_ids {
+        let body = std::fs::read_to_string(
+            get_cdn_dir()
+                .join("well_known_set")
+                .join(format!("{id}.json")),
+        )
+        .unwrap_or_else(|e| panic!("{id}.json must exist in cdn/: {e}"));
+        cdn = cdn.with_text(&crate::domain::resolve_set_path(id), &body);
+    }
+    let repo = InMemoryUserRepository::with_user(User::new(
+        "n2-import@example.com".to_string(),
+        NativeLanguage::Russian,
+        None,
+    ));
+    let use_case = ImportOnboardingSetsUseCase::new(&repo, &cdn);
+    let start = Instant::now();
+    let result = use_case
+        .execute(
+            repo.get_current_user().await.unwrap().unwrap(),
+            set_ids.iter().map(|s| s.to_string()).collect(),
+            target_level,
+        )
+        .await
+        .unwrap();
+    let created = result.created_vocabulary + result.created_kanji + result.created_grammar;
+    (created, start.elapsed())
+}
+
+/// Best-of-3 import time per scenario: the minimum is robust against
+/// asymmetric CPU contention from parallel tests in the shared test pool,
+/// which would otherwise skew a single-shot ratio measurement.
+async fn fastest_import(
+    set_ids: &[&str],
+    target_level: JapaneseLevel,
+) -> (usize, std::time::Duration) {
+    let mut best = std::time::Duration::MAX;
+    let mut cards = 0;
+    for _ in 0..3 {
+        let (created, elapsed) = import_sets(set_ids, target_level).await;
+        cards = created;
+        best = best.min(elapsed);
+    }
+    (cards, best)
+}
+
+/// Regression guard for the "N2 onboarding import is unusably slow" bug.
+/// Every `create_card` used to run full scans over all existing cards
+/// (uniqueness validation + daily-stats recalculation), so import time grew
+/// quadratically with the card count: per-card cost for an N2 import
+/// (~6300 cards) measured ~5x the per-card cost of an N5 import (~900
+/// cards). With linear per-card cost the ratio stays near 1; the 2x ceiling
+/// is generous for CI noise but fails loudly on quadratic behaviour.
+#[tokio::test]
+async fn import_cost_grows_linearly_with_card_count() {
+    // Arrange — picking N5 queues only jlpt_n5; picking N2 cumulatively queues
+    // n5+n4+n3+n2 (see `OnboardingState::set_jlpt_level`).
+    let (n5_cards, n5_elapsed) = fastest_import(&["jlpt_n5"], JapaneseLevel::N5).await;
+    let (n2_cards, n2_elapsed) = fastest_import(
+        &["jlpt_n5", "jlpt_n4", "jlpt_n3", "jlpt_n2"],
+        JapaneseLevel::N2,
+    )
+    .await;
+
+    // Sanity: the N2 run must be the bigger import, otherwise the ratio
+    // asserted below would pass vacuously.
+    assert!(
+        n2_cards > 5 * n5_cards,
+        "N2 onboarding must create several times more cards than N5 \
+         (n5={n5_cards}, n2={n2_cards})",
+    );
+
+    // Act — per-card cost of each scenario's best run
+    let per_card_n5 = n5_elapsed.as_nanos() / n5_cards.max(1) as u128;
+    let per_card_n2 = n2_elapsed.as_nanos() / n2_cards.max(1) as u128;
+
+    // Assert
+    assert!(
+        per_card_n2 < per_card_n5 * 2,
+        "per-card import cost must stay flat as the card count grows — \
+         quadratic card creation is the N2 slow-import bug \
+         (n5={per_card_n5} ns/card over {n5_cards} cards, \
+         n2={per_card_n2} ns/card over {n2_cards} cards, \
+         ratio={:.2})",
+        per_card_n2 as f64 / per_card_n5 as f64,
+    );
+}

--- a/origa/src/use_cases/tests/journeys/mod.rs
+++ b/origa/src/use_cases/tests/journeys/mod.rs
@@ -6,6 +6,7 @@ mod create_cards_from_analysis;
 mod create_vocabulary_card;
 mod grammar;
 mod import_anki_pack;
+mod import_onboarding_n2_scale;
 mod import_onboarding_target_level;
 mod import_preview;
 mod jlpt_progress_journey;


### PR DESCRIPTION
## Bug

Onboarding import is unusably slow for JLPT N2 users. Picking N2 queues the cumulative `jlpt_n5+n4+n3+n2` sets (~4.9k words → **6341 cards**: vocabulary + kanji + companions + grammar). Every `KnowledgeSet::create_card` ran two O(n) full scans:

1. `validate_unique_card` — linear scan over all existing cards
2. `recalculate_daily_stats` — two full passes per created card

→ **O(n²) imports**. Measured (debug native): N5 = 916 cards / 47ms (51 527 ns/card) vs N2 = 6341 cards / 1584ms (249 799 ns/card) — per-card ratio **4.86** (linear code stays ~1.0). On release-WASM this froze the UI for the whole "Start import" step; N1 / extra app sets scale it further.

## Fix

Transient **bulk-import mode** in `KnowledgeSet` (ADR-043):

- `#[serde(skip)] import_dedup_index: Option<HashSet<(CardType, content_key)>>` — rebuilt on `begin_bulk_import()`, dropped on `end_bulk_import()` (wire format unchanged)
- While active: O(1) uniqueness checks + deferred stats recalc; `end_bulk_import()` recalcs **once** for the batch (provably equivalent — recalc is a pure function of the final card set + preserved day counters; verified by tests)
- Key = `(CardType, content_key)`: type discriminates cross-type collisions (vocab「日」≠ kanji「日」), same semantics as the old same-type-only match
- `update_card_content` / `merge` drop the index (degradation to linear scan) — the "one card ↔ one key" invariant is unbreakable rather than patched
- Outside the bracket, behavior is byte-for-byte unchanged

Applied to all three quadratic paths: **onboarding sets import**, **Anki pack import**, and the **kanji-companion migration that runs on every cold start**.

## Result

| Metric | Before | After |
|---|---|---|
| N2 import (6341 cards, debug native) | 1584 ms | **139 ms (11.4×)** |
| Per-card cost ratio N2/N5 | 4.86 (quadratic) | **~1.0 (linear)** |

## Tests

- `import_cost_grows_linearly_with_card_count` — regression guard: full imports over the real CDN sets, best-of-3 per scenario, asserts per-card ratio < 2.0
- 9 domain tests covering every branch of the bulk mode: stats equivalence (clean + active-day preserved counters/ratings), duplicates within batch and against pre-existing cards, cross-type keys, delete+recreate, delete-deferred recalc, index degradation on content update / merge
- Existing suites unchanged and green: `cargo test -p origa` 1719 passed, `origa_ui` 451 passed

## Docs

- `docs/decisions/ADR-043-bulk-import-mode-knowledge-set.md` — alternatives considered (permanent index, incremental stats), trade-offs (bracket discipline, midnight edge)