### PR TITLE
cargo: bump lindera and lindera-dictionary to 6.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,14 @@ updates:
     rebase-strategy: "auto"
     commit-message:
       prefix: "cargo"
+    groups:
+      # lindera and lindera-dictionary are versioned in lockstep (lindera
+      # re-exports lindera-dictionary types), so they must always be bumped
+      # together in a single PR — separate bumps leave two incompatible
+      # versions in the dependency graph and break the build.
+      lindera:
+        patterns:
+          - "lindera*"
 
   - package-ecosystem: "npm"
     directory: "/end2end"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "crawdad"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fbd1ecd2ed790e11c8fbe034f9b3e7687404818d1bdfd8218d26ec645ec7c5"
+checksum = "abed0ad19907fc8472dae05f0418dfa82fdf0eaef18427c7c7cc4e42db41534b"
 
 [[package]]
 name = "crc32fast"
@@ -1587,9 +1587,9 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "daachorse"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d358f1fa877be3097baa74c1fc22288626450392cb37d844f850baa60e6439a0"
+checksum = "cd10668980c9e7ba8aa2e616207d9ec52f7db66ebb47db857ed1f3c342530dad"
 
 [[package]]
 name = "darling"
@@ -1882,7 +1882,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2185,7 +2185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3228,7 +3228,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4769,9 +4769,9 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65015f4b12a1b869058a602e3cf7b39239ca1fbedd4b451bc9bb2fd2c9989eee"
+checksum = "2ba619c086410a8d3b82f0208e45a8d496d895a8b883fe8975713abd340957db"
 dependencies = [
  "anyhow",
  "lindera-dictionary",
@@ -4786,9 +4786,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647b3dd3102151b82d6995f5fafdb4fe512f8b65b5f92ccf6bfde2ba33596423"
+checksum = "5c1b3280d38586314078049deb66f332f544765cc23b683c56c28e335cabcb20"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5318,7 +5318,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6921,7 +6921,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7609,7 +7609,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7667,7 +7667,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9266,7 +9266,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9895,7 +9895,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10693,7 +10693,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ hmac = "0.12"
 
 # Japan
 rs-fsrs = "1.2"
-lindera = { version = "5.3.0", default-features = false }
-lindera-dictionary = { version = "5.3.0" }
+lindera = { version = "6.0.0", default-features = false }
+lindera-dictionary = { version = "6.0.0" }
 flate2 = "1.1"
 zip = { version = "4", default-features = false, features = ["deflate"] }
 rkyv = { version = "0.8", features = ["bytecheck"] }

--- a/origa_ui/build.rs
+++ b/origa_ui/build.rs
@@ -92,7 +92,8 @@ fn handle_i18n() {
 fn handle_lindera_dictionary() {
     // The tokenizer dictionary ships as pre-built deflate files in
     // cdn/dictionaries/sudachidict-20260723/ (SudachiDict compiled with the
-    // lindera 5.x builder — see docs/src/sudachidict.md in the lindera repo).
+    // lindera 5.x builder; the lindera 6.x runtime reads the same format —
+    // see docs/src/sudachidict.md in the lindera repo).
     // Nothing to build at compile time; verify the files exist so a broken
     // checkout fails fast.
     //

--- a/origa_ui/src/loaders/dictionary.rs
+++ b/origa_ui/src/loaders/dictionary.rs
@@ -9,7 +9,7 @@ use crate::utils::{now_ms, yield_to_browser};
 use origa::traits::CdnProvider;
 
 /// The eight raw lindera dictionary files (deflate-compressed on the CDN,
-/// inflated on device). lindera 5.x walks the trie in place, so no pre-built
+/// inflated on device). lindera walks the trie in place, so no pre-built
 /// rkyv blob is needed anymore — the raw files ARE the cache.
 /// Ordered so the largest file (dict.words, 28 MB deflated → 223 MB raw)
 /// inflates FIRST, while every other file is still compressed: peak heap
@@ -35,7 +35,7 @@ pub fn dict_path(file: &str) -> String {
 /// Load the SudachiDict tokenizer dictionary.
 ///
 /// Unified path for cache-hit and cache-miss: fetch eight deflate-compressed
-/// files (from Cache API or CDN), inflate, hand the raw bytes to lindera 5.x
+/// files (from Cache API or CDN), inflate, hand the raw bytes to the lindera
 /// loaders. Peak WASM heap is bounded by compressed+inflated bytes coexisting
 /// during inflate (~420 MB on first load, ~350 MB steady state).
 pub async fn load_dictionary() -> Result<(), OrigaError> {

--- a/origa_ui/src/repository/cache_manager.rs
+++ b/origa_ui/src/repository/cache_manager.rs
@@ -241,7 +241,8 @@ async fn invalidate_stale_entries(cache: &web_sys::Cache, stale_paths: &[String]
     }
 }
 
-/// Invalidate the raw dictionary-file cache (lindera 5.x era) so the next
+/// Invalidate the raw dictionary-file cache (introduced when the app switched
+/// to raw lindera dictionary files) so the next
 /// load fetches fresh files from the CDN.
 #[cfg(target_arch = "wasm32")]
 async fn invalidate_dictionary_files() -> Result<(), OrigaError> {

--- a/origa_ui/src/repository/dictionary_cache.rs
+++ b/origa_ui/src/repository/dictionary_cache.rs
@@ -2,7 +2,8 @@ use origa::domain::OrigaError;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
-/// Cache name for the raw (deflated) dictionary files (lindera 5.x era).
+/// Cache name for the raw (deflated) dictionary files (introduced when the
+/// app switched to raw lindera dictionary files instead of an rkyv blob).
 pub const DICTIONARY_FILES_CACHE_NAME: &str = "origa-dictionary-files-v1";
 
 /// Cache key prefix for each deflated dictionary file.


### PR DESCRIPTION
Supersedes #454.

## Problem

Dependabot bumped only `lindera-dictionary` 5.3.0 → 6.0.0 (#454), leaving `lindera` at 5.3.0. The two crates are versioned in lockstep (`lindera` re-exports `lindera-dictionary` types), so the dependency graph ended up with two incompatible `Dictionary` types:

```
error[E0308]: mismatched types
  --> origa/src/domain/tokenizer/mod.rs:155:73
note: there are multiple different versions of crate `lindera_dictionary` in the dependency graph
```

This cascaded into failures of Lint, Test, WASM Component Tests, E2E Build and Docker Build (ui) → CI Gate blocked the PR.

## Fix

- Bump **both** `lindera` and `lindera-dictionary` to 6.0.0 (lockstep), preserving `default-features = false` (bundled dictionaries stay disabled; SudachiDict is loaded from CDN).
- Targeted `Cargo.lock` update (`cargo update -p lindera@5.3.0 --precise 6.0.0`), no blanket refresh. Scope: lindera 6.0.0, lindera-dictionary 6.0.0, `crawdad` 0.3.0→0.4.1, `daachorse` 4.0.0→5.0.0 (versions + checksums), **plus** resolver-driven consolidation of `windows-sys` dep pins (0.52.0/0.59.0 → single 0.61.2; quinn-udp ref → 0.60.2) and `windows-core` 0.58.0→0.61.2 — all within semver ranges already declared by their consumers (e.g. errno `>=0.52,<0.62`, iana-time-zone `<=0.62`).
- Group `lindera*` in the dependabot cargo section so future lockstep bumps arrive as a single PR (prevents recurrence of the #454 failure mode).
- Update stale `lindera 5.x` comments (runtime is 6.x now; CDN binaries remain 5.x-built — format is compatible).

## Verification

**Local (branch vs fresh master baseline):**

| Check | Result |
| --- | --- |
| `cargo check -p origa -p origa_ui` | ✅ clean |
| `cargo test -p origa --lib` | ✅ 1709/1709 (baseline on master: 1709/1709) |
| `cargo clippy --workspace --all-targets -- -D warnings` (with CI env vars) | ✅ clean |
| `cargo fmt --check --all` | ✅ |
| `cargo tree -i lindera-dictionary` | ✅ single 6.0.0, no duplicates; `daachorse` 4.x / `crawdad` 0.3.x gone |
| Raw 5.x-built SudachiDict binaries under 6.0 runtime | ✅ integration tests with real dictionary pass |

**CI-only surface** (documented honestly, verified by this PR's CI): WASM Component Tests, E2E Build/Run, Docker Build (ui), macOS/tauri `--locked` jobs. All of them previously failed on the same E0308 compile error.

## Notes for reviewers

- lindera 6.0.0 breaking changes (lattice refactor, WASM binding API, package renames, daachorse 5) — none touch origa's API usage; code compiles without changes.
- After merge, #454 will be closed automatically by dependabot on its next weekly cycle (fallback: manual close).
