### PR TITLE
docs: drop remaining lindera 5 version pins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ cargo fmt --check && cargo fmt
 ## Ключевые зависимости
 
 `rs-fsrs` (FSRS), `ort` + NDLOCR-Lite (OCR), `ort` + `rustfft` (Whisper STT),
-`lindera 5` + SudachiDict (токенизация; сборка: `scripts/build_sudachidict.py`), `serde`/`bincode`/`rkyv` (сериализация),
+`lindera 6` + SudachiDict (токенизация; сборка: `scripts/build_sudachidict.py`), `serde`/`bincode`/`rkyv` (сериализация),
 `rusqlite` (БД), Leptos 0.8 + `leptos_router`/`leptos-use`/`leptos_i18n` (frontend),
 `sha2`/`hmac` (TrailBase auth), `tracing`/`tracing-wasm` (логирование).
 Плагины: opener, tts, deep-link (`origa://`), single-instance, updater, process.

--- a/origa_ui/src/loaders/dictionary.rs
+++ b/origa_ui/src/loaders/dictionary.rs
@@ -10,7 +10,7 @@ use origa::traits::CdnProvider;
 
 /// The eight raw lindera dictionary files (deflate-compressed on the CDN,
 /// inflated on device). lindera walks the trie in place, so no pre-built
-/// rkyv blob is needed anymore — the raw files ARE the cache.
+/// rkyv blob is needed — the raw files ARE the cache.
 /// Ordered so the largest file (dict.words, 28 MB deflated → 223 MB raw)
 /// inflates FIRST, while every other file is still compressed: peak heap
 /// stays at ~dict.words-raw + everything-compressed instead of the reverse.

--- a/utils/README.md
+++ b/utils/README.md
@@ -231,8 +231,9 @@ utils find-missing --help
 
 ## Dictionary Requirements
 
-The tokenizer commands require the SudachiDict dictionary (lindera 5 format,
-built by `scripts/build_sudachidict.py`). The CLI resolves it in the
+The tokenizer commands require the SudachiDict dictionary (lindera dictionary
+format, built by `scripts/build_sudachidict.py`; readable by the lindera 6.x
+runtime). The CLI resolves it in the
 following locations:
 
 1. the directory passed via `--dictionary-dir` (if it exists)


### PR DESCRIPTION
Follow-up to #474 code review (approved with documentation remarks):

- **AGENTS.md**: stack description still said `lindera 5` after the 6.0.0 bump → `lindera 6`
- **utils/README.md**: "lindera 5 format" → version-neutral wording with explicit 6.x-runtime compatibility note
- **origa_ui/src/loaders/dictionary.rs**: dropped the stale "anymore" in a comment

ADR-039 intentionally untouched (historical decision record), as is the "5.x builder" fact in `origa_ui/build.rs` (the CDN binaries really were built by the 5.x builder — the 6.x runtime reads the same format).

Docs-only change: no code, no manifest. `cargo fmt --check --all` ✅