### PR TITLE
fix(auth): route Apple OAuth callback via direct scheme redirect (App Review 2.1(a))

### DIFF
--- a/docs/decisions/ADR-008-mobile-oauth-tauri-android.md
+++ b/docs/decisions/ADR-008-mobile-oauth-tauri-android.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+Accepted — redirect_uri contract updated by ADR-044 (Apple platforms now
+use the direct `origa://` scheme redirect; Android/Windows/Linux keep this
+ADR's desktop-callback flow)
 
 ## Date
 

--- a/docs/decisions/ADR-044-apple-oauth-direct-scheme-redirect.md
+++ b/docs/decisions/ADR-044-apple-oauth-direct-scheme-redirect.md
@@ -1,0 +1,115 @@
+# ADR-044: Apple OAuth callback via direct server-side scheme redirect
+
+## Status
+
+Accepted
+
+## Date
+
+2026-09-02
+
+## Context
+
+Mac App Store review of v0.7.3 rejected Sign in with Apple (Guideline
+2.1(a): "the app showed error message while logging in via Sign in with
+Apple"). Production HTTP logs (Railway, 2026-09-02 09:51–09:53) show the
+reviewer attempted SIWA four times; every attempt completed server-side —
+
+```
+GET  /api/auth/v1/oauth/apple/login            303
+POST /api/auth/v1/oauth/apple/callback         303   (code exchanged)
+GET  /public/auth/desktop-callback.html        200
+—— no follow-up code-exchange request from the app ——
+```
+
+— and stalled at the interstitial page. Root cause:
+`desktop-callback.html` hands control back to the app with a JavaScript
+hop (`window.location.href = "origa://…"`), but
+`ASWebAuthenticationSession` on macOS only intercepts
+**redirect-initiated** navigations to the callback scheme. A JS hop from
+an intermediate page is silently dropped, the auth sheet hangs forever,
+and the app never receives the callback.
+
+Why the interstitial page exists at all: on opener platforms
+(Android/Windows/Linux) the default browser cannot be trusted to follow
+custom-scheme redirects on its own — Chromium blocks scheme navigations
+without a fresh user gesture (the no-consent-screen re-login case), so
+`desktop-callback.html` carries a manual fallback button that is the only
+guaranteed delivery path there (see wiki
+`oauth-desktop-callback-chromium`, ADR-008).
+
+## Decision
+
+Split the `redirect_uri` per platform class (`native_oauth_redirect_uri`
+in `origa_ui/src/pages/login/oauth_buttons.rs`):
+
+- **Apple platforms (macOS/iOS), inside Tauri**: `origa://auth/callback`.
+  TrailBase answers the provider callback with a server-side 303 straight
+  to the scheme (private-use URI scheme, RFC 8252), which the auth session
+  intercepts reliably. The frontend already receives the intercepted URL
+  via the `tauri-plugin-aswebauth` Promise and feeds it into the shared
+  `process_oauth_url` contract — no other code changes.
+- **Other native platforms**: keep `desktop-callback.html` byte-identical
+  to the legacy value (released builds depend on this exact URI being
+  accepted server-side; Chromium needs the interstitial fallback button).
+- **Web**: same-origin `/login`, unchanged.
+
+Server-side prerequisite: `auth.custom_uri_schemes: "origa"` in the
+production TrailBase `config.textproto` (Railway volume
+`/app/traildepot/config.textproto`). `validate_redirect_impl` in the
+TrailBase fork already supports custom schemes; the config line is
+additive and inert for existing flows (same-host and relative redirects
+pass separate validation branches). Deployed 2026-09-02, verified with
+positive (`origa://` → 303), negative (`evil://` → 400) and legacy
+(`desktop-callback.html` → 303) probes.
+
+## Threat model
+
+`custom_uri_schemes` allow-lists the **scheme only**: any
+`origa://<any-host>/<any-path>` redirect_uri is accepted. The callback's
+integrity control is PKCE — the verifier lives on the client and the
+authorization code is bound to the challenge server-side — which is
+unchanged. An attacker who can register the `origa` scheme on the same
+machine could complete a login for their own account in our app; the
+`ASWebAuthenticationSession` guarantee (only the session that started the
+flow receives the callback) mitigates this on Apple platforms, and this
+is the standard trade-off of the RFC 8252 private-use scheme pattern.
+
+## Rollback coupling
+
+Before release 0.7.4: revert = remove the config line + restart (the app
+change alone is inert for non-Apple platforms). **After** 0.7.4 ships:
+reverting the config line breaks login on Apple builds (`400 invalid
+redirect`) until a revert release goes out — config rollback and app
+rollback must travel together.
+
+## Verification
+
+- Sandbox boot of the exact production image
+  (`ghcr.io/yurvon-screamo/trailbase:apple-formpost`, `v0.33.5-4-gbff9bd50`) with the edited
+  config: parse + vault merge + full `validate_config` green.
+- Unit tests: `redirect_uri_tests` (Apple → scheme; non-Apple →
+  byte-identical legacy value, which is what legalizes skipping
+  Win/Android regression smoke for this change).
+- Manual (gates the 0.7.4 resubmission): complete all three provider
+  logins on macOS — in `cargo tauri dev` **and** in the signed
+  store-like CI artifact (dev ≠ signed sandbox for
+  ASWebAuthenticationSession presentation).
+
+## Consequences
+
+- iOS gets the same fix for free (it shared the broken JS-hop pattern).
+- `desktop-callback.html` stays deployed forever-ish: released
+  Android/Windows/Linux builds keep pointing at it. New builds of those
+  platforms also keep using it (interstitial is load-bearing there).
+- ADR-008's redirect_uri contract (desktop-callback for all native
+  platforms) is superseded for Apple platforms by this ADR.
+
+## References
+
+- App Review rejection b67a5273-2dd2-47f0-8920-dea001eafe75 (Guideline 4,
+  2.1(a), 2.4.5(i))
+- RFC 8252 (OAuth 2.0 for Native Apps, private-use URI scheme)
+- Chromium gesture requirement for external-protocol redirects
+  (crbug.com/41328386, AppAuth-Android #448)
+- wiki: `oauth-desktop-callback-chromium`, `trailbase-apple-oauth-form-post`

--- a/origa_ui/src/pages/login/oauth_buttons.rs
+++ b/origa_ui/src/pages/login/oauth_buttons.rs
@@ -235,6 +235,33 @@ fn open_url_external(url: &str, debug_sink: Option<OAuthDebugSink>) {
     }
 }
 
+/// Chooses the OAuth `redirect_uri` for native (Tauri) builds.
+///
+/// Apple platforms (macOS/iOS) get the private-use URI scheme (RFC 8252):
+/// TrailBase answers the provider callback with a server-side 303 straight
+/// to `origa://auth/callback?code=...`, which `ASWebAuthenticationSession`
+/// intercepts reliably. On macOS the auth session only intercepts
+/// redirect-initiated navigations — a JavaScript hop from an interstitial
+/// page is silently dropped (App Review 2.1(a) rejection of v0.7.3: the
+/// reviewer stalled on `desktop-callback.html` four times in a row).
+///
+/// Other native platforms (Android/Windows/Linux) keep the
+/// `desktop-callback.html` interstitial: default browsers cannot be trusted
+/// to follow custom-scheme redirects on their own (Chromium blocks scheme
+/// navigations without a fresh user gesture), so the page's manual fallback
+/// button is the guaranteed delivery path.
+fn native_oauth_redirect_uri(on_apple: bool) -> String {
+    if on_apple {
+        "origa://auth/callback".to_string()
+    } else {
+        format!(
+            "{}{}",
+            trailbase_url(),
+            "/public/auth/desktop-callback.html"
+        )
+    }
+}
+
 async fn open_oauth_url(
     provider: OAuthProvider,
     debug_sink: Option<OAuthDebugSink>,
@@ -244,20 +271,17 @@ async fn open_oauth_url(
     use crate::repository::TrailBaseClient;
     use crate::repository::trailbase_auth::{generate_pkce_challenge, generate_pkce_verifier};
 
-    // Reuse the canonical backend host (`https://app.origa.uwuwu.net` in
-    // production) instead of `ORIGA_PUBLIC_BASE_URL`, which has been empty
-    // since commit eeee03ad (mobile OIDC redirect refactor) and produced a
-    // relative `redirect_uri` that TrailBase could not redirect to.
+    // Native builds pick the platform-appropriate target (see
+    // `native_oauth_redirect_uri`); the web app returns to same-origin
+    // `/login`. `ORIGA_PUBLIC_BASE_URL` has been empty since commit eeee03ad
+    // (mobile OIDC redirect refactor) and produced a relative `redirect_uri`
+    // that TrailBase could not redirect to.
     let redirect_uri = if tauri::is_tauri() {
-        format!(
-            "{}{}",
-            trailbase_url(),
-            "/public/auth/desktop-callback.html"
-        )
+        native_oauth_redirect_uri(tauri::is_apple())
     } else {
         let window = web_sys::window().expect("window not available");
         let base_url = window.location().origin().unwrap_or_default();
-        format!("{}/login", base_url)
+        format!("{base_url}/login")
     };
 
     let verifier = generate_pkce_verifier();
@@ -268,12 +292,13 @@ async fn open_oauth_url(
         provider.as_str()
     );
 
-    // Persist the PKCE verifier BEFORE opening the external browser.
-    // On Android, the OS may kill the app process while the user is in the
-    // external browser, so localStorage (which is unreliable under process
-    // kills) is insufficient — we must fsync to the native store first.
-    // The await ensures the IPC write + Store::save() completes before we
-    // leave the app.
+    // Persist the PKCE verifier BEFORE leaving the app for the auth page
+    // (external browser or ASWebAuthenticationSession sheet). On Android,
+    // the OS may kill the app process while the user is in the external
+    // browser, so localStorage (which is unreliable under process kills) is
+    // insufficient — we must fsync to the native store first. The await
+    // ensures the IPC write + Store::save() completes before we leave the
+    // app.
     if let Err(e) = set_pkce_verifier_async(&verifier).await {
         report_debug!(debug_sink, "pkce verifier persist failed: {e}");
     }
@@ -284,16 +309,16 @@ async fn open_oauth_url(
 
     // Apple platforms (iOS + macOS), inside the Tauri WebView only:
     // ASWebAuthenticationSession opens the OAuth page in a dedicated auth
-    // context and intercepts the `origa://` callback directly — the callback
-    // URL is returned via the Tauri command's Promise, bypassing the
-    // deep-link listener entirely. App Review rejects default-browser
-    // sign-in on the Mac App Store (Guideline 4), so the packaged app must
-    // never take the opener path. The `is_tauri()` conjunct keeps plain
-    // browser sessions on macOS on the web redirect flow, where no Tauri
-    // invoke exists.
+    // context and intercepts the server-side 303 to `origa://auth/callback`
+    // (see `native_oauth_redirect_uri`) — the callback URL is returned via
+    // the Tauri command's Promise, bypassing the deep-link listener
+    // entirely. App Review rejects default-browser sign-in on the Mac App
+    // Store (Guideline 4), so the packaged app must never take the opener
+    // path. The `is_tauri()` conjunct keeps plain browser sessions on macOS
+    // on the web redirect flow, where no Tauri invoke exists.
     //
     // Other platforms (Android, Windows, Linux, web): opener + deep-link
-    // listener flow.
+    // listener flow via the `desktop-callback.html` interstitial.
     if tauri::is_tauri() && tauri::is_apple() {
         auth_store.oauth_error.set(None);
         auth_store.is_oauth_loading.set(true);
@@ -396,6 +421,40 @@ async fn start_aswebauth(url: &str, callback_scheme: &str) -> Result<String, Str
         .ok()
         .and_then(|v| v.as_string())
         .ok_or("missing 'url' field in start_auth response".to_string())
+}
+
+#[cfg(test)]
+mod redirect_uri_tests {
+    use super::*;
+
+    /// Apple platforms must use the private-use scheme: ASWebAuthenticationSession
+    /// only intercepts redirect-initiated navigations, so the auth session has to
+    /// be pointed straight at `origa://` (App Review 2.1(a), v0.7.3).
+    #[test]
+    fn native_redirect_uri_on_apple_uses_private_use_scheme() {
+        assert_eq!(
+            native_oauth_redirect_uri(true),
+            "origa://auth/callback",
+            "Apple platforms must redirect straight to the custom scheme"
+        );
+    }
+
+    /// Non-Apple native platforms must stay byte-identical to the legacy
+    /// desktop-callback value: released Android/Windows/Linux builds depend on
+    /// this exact URI being accepted server-side, and Chromium needs the
+    /// interstitial page for its fallback button (scheme navigations without a
+    /// fresh user gesture are blocked).
+    #[test]
+    fn native_redirect_uri_off_apple_is_byte_identical_to_legacy() {
+        assert_eq!(
+            native_oauth_redirect_uri(false),
+            format!(
+                "{}{}",
+                trailbase_url(),
+                "/public/auth/desktop-callback.html"
+            )
+        );
+    }
 }
 
 #[component]

--- a/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
+++ b/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
@@ -5,8 +5,10 @@
 //
 // Replaces the tauri-plugin-opener + desktop-callback.html + custom-scheme
 // flow on iOS. ASWebAuthenticationSession opens Safari in a dedicated auth
-// context, intercepts the `origa://` callback directly, and returns the
-// callback URL via the completion handler — no CFBundleURLTypes needed.
+// context, intercepts the server-side 303 to `origa://auth/callback`
+// (redirect-initiated navigation — JavaScript hops from an interstitial page
+// are NOT intercepted), and returns the callback URL via the completion
+// handler — no CFBundleURLTypes needed.
 //
 // `prefersEphemeralWebBrowserSession` is intentionally `false`: Google OAuth
 // rejects ephemeral (incognito-like) browser sessions, blocking login.

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -79,10 +79,15 @@ tauri-plugin-haptics.workspace = true
 # Apple-only: ASWebAuthenticationSession plugin for OAuth. Wraps Apple's
 # native auth session API so the browser returns to the app after the OAuth
 # redirect — required by App Review Guideline 4 (default-browser login is
-# rejected for Mac App Store distribution). On iOS the tauri-plugin-deep-link
-# build.rs does NOT register CFBundleURLTypes for custom schemes, so the old
-# opener + desktop-callback.html flow cannot return from Safari; on macOS the
-# session intercepts the `origa://` callback itself.
+# rejected for Mac App Store distribution). The frontend sends
+# redirect_uri = origa://auth/callback (see native_oauth_redirect_uri) and
+# TrailBase answers the provider callback with a server-side 303 straight to
+# the scheme: the auth session only intercepts redirect-initiated
+# navigations, not JavaScript hops from an interstitial page (App Review
+# 2.1(a) of v0.7.3). On iOS the tauri-plugin-deep-link build.rs does NOT
+# register CFBundleURLTypes for custom schemes, so the old opener +
+# desktop-callback.html flow cannot return from Safari; on macOS the session
+# intercepts the `origa://` callback itself.
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 tauri-plugin-aswebauth.workspace = true
 


### PR DESCRIPTION
## Summary

Fixes the Mac App Store rejection of 0.7.3 (**Guideline 2.1(a)** — Sign in with Apple error on macOS).

**Root cause** (proven by production HTTP logs, 2026-09-02 09:51–09:53 — four reviewer attempts): the OAuth callback chain ended at the `desktop-callback.html` interstitial, which hands control back via a **JavaScript** hop to `origa://`. `ASWebAuthenticationSession` on macOS only intercepts **redirect-initiated** navigations — the JS hop was silently dropped, the auth sheet hung forever, the app never received the callback.

**Fix**: Apple platforms now send `redirect_uri = origa://auth/callback`; TrailBase answers the provider callback with a **server-side 303 straight to the scheme**, which the auth session intercepts reliably (RFC 8252 private-use scheme). Opener platforms (Android/Windows/Linux) keep the interstitial **byte-identically** — Chromium needs its fallback button for scheme navigations without a fresh user gesture. Web flow unchanged.

**Server-side prerequisite — already deployed and verified** (2026-09-02): `auth.custom_uri_schemes: "origa"` added to the production TrailBase `config.textproto` (backups: local + on-server). Pre-validated by a full sandbox boot of the exact production image (`v0.33.5-4-gbff9bd50`, digest-matched); post-restart probes: `origa://` → 303, `evil://` → 400 (allowlist is scheme-scoped), legacy interstitial → 303, healthcheck 200.

## Changes

- `oauth_buttons.rs`: `native_oauth_redirect_uri(on_apple)` — the platform split with rationale documented; comments updated (PKCE block, aswebauth branch)
- Unit tests: Apple → scheme; non-Apple → byte-identical legacy URI (this property legalizes skipping Win/Android regression smoke)
- Comment-only: `tauri/Cargo.toml`, `AsWebAuthPlugin.swift`
- **ADR-044** (threat model: PKCE is the callback integrity control for the scheme-only allowlist; rollback coupling after 0.7.4 ships); ADR-008 marked updated

## Verification

| Check | Result |
|---|---|
| `cargo fmt -p origa_ui -- --check` | ✅ |
| `cargo clippy -p origa_ui --all-targets -- -D warnings` | ✅ |
| `cargo test -p origa_ui` | ✅ 453 passed, 0 failed (incl. 2 new) |
| Server probes (prod) | ✅ 303 / 400 / 303 / 200 |

**Pending (gates the App Store resubmission, needs a Mac):** behavioral check of all three provider logins on macOS — in `cargo tauri dev` **and** in the signed store-like CI artifact (see ADR-044 verification section).

Follow-up after this merges: tag `v0.7.4` → release; App Review reply drafts for 2.4.5(i) (microphone = live STT) and Guideline 4 (ASWebAuthenticationSession confirmation).