### PR TITLE
fix(android): own the ndk-context publication (tao 0.35 break) + emulator smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,25 @@ jobs:
                   echo "NDK_HOME=$NDK_PATH" >> "$GITHUB_ENV"
                   echo "ANDROID_NDK_ROOT=$NDK_PATH" >> "$GITHUB_ENV"
 
+            - name: Verify KVM availability
+              run: |
+                  if [ ! -e /dev/kvm ]; then
+                      echo "::error::/dev/kvm not available on this runner"
+                      exit 1
+                  fi
+
+            # Boot the emulator IN PARALLEL with the toolchain/APK build:
+            # boot takes minutes and does not compete for the CPU meaningfully,
+            # so starting it here hides the wait (the smoke script polls
+            # sys.boot_completed itself).
+            - name: Start emulator
+              run: |
+                  echo "no" | avdmanager create avd -n smoke \
+                      -k "system-images;android-34;google_apis;x86_64" -d pixel --force
+                  nohup emulator -avd smoke -no-window -no-audio -no-boot-anim \
+                      -gpu swiftshader_indirect -no-snapshot > /tmp/emulator.log 2>&1 &
+                  echo "emulator launching in background (log: /tmp/emulator.log)"
+
             - name: Cache Gradle
               uses: actions/cache@v6
               with:
@@ -580,21 +599,6 @@ jobs:
               # --target takes the short ABI name for android (not the rust
               # triple — `x86_64-linux-android` is rejected by the CLI).
               run: cargo tauri android build --debug --target x86_64 --apk
-
-            - name: Verify KVM availability
-              run: |
-                  if [ ! -e /dev/kvm ]; then
-                      echo "::error::/dev/kvm not available on this runner"
-                      exit 1
-                  fi
-
-            - name: Start emulator
-              run: |
-                  echo "no" | avdmanager create avd -n smoke \
-                      -k "system-images;android-34;google_apis;x86_64" -d pixel --force
-                  nohup emulator -avd smoke -no-window -no-audio -no-boot-anim \
-                      -gpu swiftshader_indirect -no-snapshot > /tmp/emulator.log 2>&1 &
-                  echo "emulator launching (log: /tmp/emulator.log)"
 
             - name: Run smoke test
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,9 +543,17 @@ jobs:
               run: |
                   echo "no" | avdmanager create avd -n smoke \
                       -k "system-images;android-34;google_apis;x86_64" -d pixel --force
+                  # setup-android installs the emulator package but does NOT
+                  # put its directory on PATH (adb is on it, emulator is not).
+                  EMU="${ANDROID_SDK_ROOT}/emulator/emulator"
+                  if [ ! -x "$EMU" ]; then
+                      echo "::error::emulator binary not found at $EMU"
+                      ls -1 "${ANDROID_SDK_ROOT}/emulator" 2>/dev/null || true
+                      exit 1
+                  fi
                   # -accel on: die loudly instead of silently falling back to
                   # pure-software emulation (30+ min boots).
-                  nohup emulator -avd smoke -no-window -no-audio -no-boot-anim \
+                  nohup "$EMU" -avd smoke -no-window -no-audio -no-boot-anim \
                       -gpu swiftshader_indirect -no-snapshot -accel on \
                       > /tmp/emulator.log 2>&1 &
                   # Surface early crashes (KVM permission, bad options) right

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,10 +541,22 @@ jobs:
             # sys.boot_completed itself).
             - name: Start emulator
               run: |
+                  # Pin the AVD home for BOTH tools: cmdline-tools may resolve
+                  # the Android user home through XDG_CONFIG_HOME (writing to
+                  # ~/.config/.android/avd) while the emulator binary only
+                  # searches $ANDROID_AVD_HOME, $ANDROID_SDK_HOME/avd and
+                  # $HOME/.android/avd — the mismatch made `create avd` a
+                  # silent no-op the emulator could never see.
+                  export ANDROID_AVD_HOME="$HOME/.android/avd"
+                  mkdir -p "$ANDROID_AVD_HOME"
                   echo "no" | avdmanager create avd -n smoke \
                       -k "system-images;android-34;google_apis;x86_64" -d pixel --force
-                  # setup-android installs the emulator package but does NOT
-                  # put its directory on PATH (adb is on it, emulator is not).
+                  if [ ! -f "$ANDROID_AVD_HOME/smoke.ini" ]; then
+                      echo "::error::AVD 'smoke' was not created at $ANDROID_AVD_HOME"
+                      ls -la "$ANDROID_AVD_HOME"
+                      "${ANDROID_SDK_ROOT}/emulator/emulator" -list-avds 2>/dev/null || true
+                      exit 1
+                  fi
                   EMU="${ANDROID_SDK_ROOT}/emulator/emulator"
                   if [ ! -x "$EMU" ]; then
                       echo "::error::emulator binary not found at $EMU"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,6 +530,10 @@ jobs:
                       echo "::error::/dev/kvm not available on this runner"
                       exit 1
                   fi
+                  if [ ! -w /dev/kvm ]; then
+                      sudo chmod a+rw /dev/kvm
+                  fi
+                  [ -w /dev/kvm ] || { echo "::error::/dev/kvm not writable"; exit 1; }
 
             # Boot the emulator IN PARALLEL with the toolchain/APK build:
             # boot takes minutes and does not compete for the CPU meaningfully,
@@ -539,9 +543,16 @@ jobs:
               run: |
                   echo "no" | avdmanager create avd -n smoke \
                       -k "system-images;android-34;google_apis;x86_64" -d pixel --force
+                  # -accel on: die loudly instead of silently falling back to
+                  # pure-software emulation (30+ min boots).
                   nohup emulator -avd smoke -no-window -no-audio -no-boot-anim \
-                      -gpu swiftshader_indirect -no-snapshot > /tmp/emulator.log 2>&1 &
-                  echo "emulator launching in background (log: /tmp/emulator.log)"
+                      -gpu swiftshader_indirect -no-snapshot -accel on \
+                      > /tmp/emulator.log 2>&1 &
+                  # Surface early crashes (KVM permission, bad options) right
+                  # in the job log instead of a silent wait-for-device hang.
+                  sleep 15
+                  echo "--- emulator.log (first 15s) ---"
+                  tail -n 30 /tmp/emulator.log || true
 
             - name: Cache Gradle
               uses: actions/cache@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,8 +549,14 @@ jobs:
 
             # Fail fast (minutes, not half an hour): the android-cfg code the
             # host clippy never sees is checked here before the APK build.
+            # cc-rs (ring) needs the NDK toolchain explicitly — the tauri CLI
+            # injects CC/AR only for its own `cargo tauri android build`.
             - name: Check Android target compiles
-              run: cargo check -p origa-app --lib --target x86_64-linux-android
+              run: |
+                  TOOLCHAIN="${NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+                  export CC_x86_64_linux_android="$TOOLCHAIN/x86_64-linux-android24-clang"
+                  export AR_x86_64_linux_android="$TOOLCHAIN/llvm-ar"
+                  cargo check -p origa-app --lib --target x86_64-linux-android
 
             - name: Install Tauri CLI (npm)
               working-directory: tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,7 +577,9 @@ jobs:
               working-directory: tauri
               # Explicit --apk: pin the output flavor instead of relying on
               # the CLI default (which may build apk+aab — double the time).
-              run: cargo tauri android build --debug --target x86_64-linux-android --apk
+              # --target takes the short ABI name for android (not the rust
+              # triple — `x86_64-linux-android` is rejected by the CLI).
+              run: cargo tauri android build --debug --target x86_64 --apk
 
             - name: Verify KVM availability
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,11 @@ jobs:
               steps.components.outputs.core == 'true' ||
               steps.components.outputs.tauri == 'true' ||
               steps.components.outputs.ci == 'true' }}
+            run_android_smoke: >-
+              ${{ github.event_name != 'pull_request' ||
+              steps.components.outputs.core == 'true' ||
+              steps.components.outputs.tauri == 'true' ||
+              steps.components.outputs.ci == 'true' }}
             run_docker_landing: >-
               ${{ github.event_name != 'pull_request' ||
               steps.components.outputs.core == 'true' ||
@@ -454,6 +459,139 @@ jobs:
                   name: wasm-dist
                   path: origa_ui/dist/
                   retention-days: 1
+
+    # Runs the Android app on an emulator — the only CI net for the class of
+    # startup bugs that compile fine and build fine but crash on launch
+    # (born from the tao 0.35 ndk-context break, ADR-044). Builds a debug
+    # APK for the SAME ABI as the emulator (x86_64); production release
+    # builds stay aarch64 via _build-tauri.yml. The WASM frontend is built
+    # in-job (self-contained: no artifact cascades, no skip-legal traps).
+    android-smoke:
+        name: Android Smoke (emulator)
+        permissions:
+            contents: read
+        needs: [changes, cdn-download]
+        if: needs.changes.outputs.run_android_smoke == 'true'
+        runs-on: ubuntu-24.04
+        timeout-minutes: 45
+        env:
+            ORIGA_CDN_BASE_URL: ${{ vars.ORIGA_CDN_BASE_URL }}
+            # NDK r26 exact version — single source of truth, same as
+            # _build-tauri.yml build-android.
+            NDK_VERSION: '26.1.10909125'
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+
+            # Android target: only protobuf-compiler is required from the
+            # system (the heavy webkit/speechd set is for desktop targets;
+            # see lint/e2e-build if an android build ever needs more).
+            - name: Cache APT packages
+              uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+              with:
+                  packages: protobuf-compiler
+                  version: 1.0
+
+            - name: Setup Rust
+              uses: ./.github/actions/setup-rust
+              with:
+                  targets: wasm32-unknown-unknown,x86_64-linux-android
+                  shared-key: origa-android-smoke-v1
+                  save-if: false
+
+            - name: Setup Java
+              uses: actions/setup-java@v6
+              with:
+                  distribution: temurin
+                  java-version: 21
+
+            - name: Setup Android SDK + NDK + emulator
+              uses: android-actions/setup-android@v4
+              with:
+                  packages: 'tools platform-tools ndk;${{ env.NDK_VERSION }} emulator system-images;android-34;google_apis;x86_64'
+
+            - name: Configure NDK environment
+              # setup-android@v4 exports ANDROID_SDK_ROOT/ANDROID_HOME but NOT
+              # NDK_HOME/ANDROID_NDK_ROOT (see _build-tauri.yml for the full
+              # rationale).
+              run: |
+                  NDK_PATH="${ANDROID_SDK_ROOT}/ndk/${{ env.NDK_VERSION }}"
+                  if [ ! -d "$NDK_PATH" ]; then
+                      echo "::error::NDK directory not found at: $NDK_PATH"
+                      ls -1 "${ANDROID_SDK_ROOT}/ndk/" 2>/dev/null || true
+                      exit 1
+                  fi
+                  echo "NDK_HOME=$NDK_PATH" >> "$GITHUB_ENV"
+                  echo "ANDROID_NDK_ROOT=$NDK_PATH" >> "$GITHUB_ENV"
+
+            - name: Cache Gradle
+              uses: actions/cache@v6
+              with:
+                  path: |
+                      ~/.gradle/caches
+                      ~/.gradle/wrapper
+                  key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*',
+                      '**/gradle-wrapper.properties') }}
+                  restore-keys: |
+                      ${{ runner.os }}-gradle-
+
+            - name: Setup frontend tools
+              uses: ./.github/actions/setup-frontend
+
+            - name: Add cargo bin to PATH
+              run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+            - name: Download CDN artifact
+              uses: actions/download-artifact@v8
+              with:
+                  name: cdn-data
+                  path: cdn/
+
+            # Fail fast (minutes, not half an hour): the android-cfg code the
+            # host clippy never sees is checked here before the APK build.
+            - name: Check Android target compiles
+              run: cargo check -p origa-app --lib --target x86_64-linux-android
+
+            - name: Install Tauri CLI (npm)
+              working-directory: tauri
+              run: npm install
+
+            - name: Build landing CSS
+              working-directory: origa_landing
+              run: npm ci && npm run build:css
+
+            # --release on purpose: the debug WASM bundle (~300 MB) OOM-kills
+            # the Android WebView heap (tauri-apps/tauri#13554) and would
+            # turn this job false-red on fixed code. Same profile as
+            # e2e-build / production artifact.
+            - name: Build WASM frontend
+              run: cd origa_ui && trunk build --release
+
+            - name: Build debug APK (x86_64)
+              working-directory: tauri
+              # Explicit --apk: pin the output flavor instead of relying on
+              # the CLI default (which may build apk+aab — double the time).
+              run: cargo tauri android build --debug --target x86_64-linux-android --apk
+
+            - name: Verify KVM availability
+              run: |
+                  if [ ! -e /dev/kvm ]; then
+                      echo "::error::/dev/kvm not available on this runner"
+                      exit 1
+                  fi
+
+            - name: Start emulator
+              run: |
+                  echo "no" | avdmanager create avd -n smoke \
+                      -k "system-images;android-34;google_apis;x86_64" -d pixel --force
+                  nohup emulator -avd smoke -no-window -no-audio -no-boot-anim \
+                      -gpu swiftshader_indirect -no-snapshot > /tmp/emulator.log 2>&1 &
+                  echo "emulator launching (log: /tmp/emulator.log)"
+
+            - name: Run smoke test
+              run: |
+                  apk="$(find tauri/gen/android/app/build/outputs/apk -name '*.apk' -type f | head -1)"
+                  tauri/scripts/android_smoke.sh "$apk"
 
     # Fails fast when a BDD scenario is silently excluded from the matrix
     # (dead) or runs in several groups (duplicated). Born from a real hole:
@@ -810,6 +948,7 @@ jobs:
                 e2e-matrix-guard,
                 e2e,
                 e2e-report,
+                android-smoke,
                 build-tauri,
                 build-macos,
                 docker-build-landing,
@@ -851,6 +990,7 @@ jobs:
                   gate "e2e-matrix-guard" "${{ needs.e2e-matrix-guard.result }}" "${{ needs.changes.outputs.run_e2e_matrix_guard }}"
                   gate "e2e" "${{ needs.e2e.result }}" "${{ needs.changes.outputs.run_e2e }}"
                   gate "e2e-report" "${{ needs.e2e-report.result }}" "${{ needs.changes.outputs.run_e2e }}"
+                  gate "android-smoke" "${{ needs.android-smoke.result }}" "${{ needs.changes.outputs.run_android_smoke }}"
                   gate "build-tauri" "${{ needs.build-tauri.result }}" "${{ needs.changes.outputs.run_build_tauri }}"
                   gate "build-macos" "${{ needs.build-macos.result }}" "${{ needs.changes.outputs.run_build_macos }}"
                   gate "docker-build-landing" "${{ needs.docker-build-landing.result }}" "${{ needs.changes.outputs.run_docker_landing }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,14 @@ $env:TRUNK_BUILD_CARGO_PROFILE = "wasm-dev"
 cd tauri && cargo tauri android dev
 ```
 
+**JNI-контекст (ADR-044):** с Tauri 2.11 (tao 0.35) никто не публикует
+JavaVM/Application в `ndk-context` — инвариант принадлежит
+`tauri/src/android_context.rs` (публикация в `JNI_OnLoad`, Application через
+`ActivityThread.currentApplication()`). Не читайте `ndk_context` до
+`ensure_initialized()`, не добавляйте второй паблишер (ndk-context паникует
+на re-publish). Smoke-тест запуска: `tauri/scripts/android_smoke.sh
+<apk>` (используется CI-джобой `android-smoke`, маркеры успеха — в logcat).
+
 ### Переменные окружения (compile-time, `build.rs`)
 
 Обязательные: `ORIGA_CDN_BASE_URL`; для сборки `origa_landing` (clippy/test) — также `ORIGA_APP_BASE_URL` (или пара `ORIGA_BASE_URI` + `ORIGA_APP_URI_PREFIX`), без неё `origa_landing/build.rs` паникует.

--- a/docs/decisions/ADR-044-android-jni-context-ownership.md
+++ b/docs/decisions/ADR-044-android-jni-context-ownership.md
@@ -1,0 +1,97 @@
+# ADR-044: Android JNI context ownership (ndk-context publication)
+
+## Status
+
+**Accepted** (2026-09-03).
+
+## Date
+
+2026-09-03.
+
+## Context
+
+`init_platform_verifier_android` (added in #355) reads the JavaVM and the
+Activity context from the `ndk-context` crate global and relies on the
+windowing layer to populate it before Rust startup code runs. That contract
+was implicit: `tao 0.34` — the windowing library beneath wry beneath tauri —
+called `ndk_context::initialize_android_context()` while starting the
+activity, and our code read what it left behind. Nothing in `Cargo.toml`
+declared the dependency on that side effect.
+
+Tauri 2.11 (#443) pulled in `tao 0.35`, whose mobile multi-window refactor
+removed the `ndk-context` dependency entirely. The moment it landed, the
+first read on Android aborted the process on every launch:
+
+```text
+PANIC at ndk-context/src/lib.rs:72: android context was not initialized
+```
+
+Nothing in our code changed; an undocumented side effect of a transitive
+dependency disappeared. The same break hit every Tauri 2.11 app reading
+`ndk-context` (android-native-keyring-store#21, plugins-workspace#2900).
+CI did not catch it: host clippy/test never compiles
+`#[cfg(target_os = "android")]` code, the release pipeline builds the APK
+without running it, and Playwright e2e drives the web build in a desktop
+browser — no CI layer executed the app on Android.
+
+## Decision
+
+We own the Android context invariant instead of assuming it:
+
+1. `tauri/src/android_context.rs` (Android-only) captures the JavaVM in
+   `JNI_OnLoad` — the JVM invokes it on `System.loadLibrary`; neither tao,
+   wry nor tauri define that symbol, so there is no collision. The
+   Application context is resolved via `ActivityThread.currentApplication()`
+   (a hidden but de-facto stable API, standard practice upstream) and pinned
+   as a leaked global ref for the process lifetime.
+2. Both are published into `ndk-context::initialize_android_context` under a
+   CAS guard (ndk-context asserts on re-publication; a second `JNI_OnLoad`
+   is possible on classloader splits). Publishing into the shared global —
+   rather than private statics — fixes every reader, including transitive
+   ones (`tauri-plugin-tts` depends on `ndk-context`).
+3. The Application context (not the Activity) is published: an Activity can
+   be torn down and recreated at any time (the deep-link recreate flow,
+   ADR-010), while the Application object outlives every Activity — and it
+   is what the verifier keeps a reference to for its entire lifetime.
+4. Failure policy: every step degrades to `false` + `tracing::error!` +
+   logcat (via `android.util.Log` JNI calls). Nothing in the module panics —
+   it runs across the FFI boundary and release profiles build with
+   `panic = "abort"`.
+5. Single-publisher assumption: only this module calls
+   `initialize_android_context`. The CAS guard protects against our own
+   re-entry; a hypothetical foreign publisher trips ndk-context's assert
+   (abort in release, caught by `catch_unwind` in unwind-enabled profiles).
+6. Observability: two startup markers are emitted to logcat —
+   `[android-context] published JavaVM+Application to ndk-context` and
+   `[rustls] platform-verifier initialized for Android` — because tracing on
+   Android has no logcat backend (Sentry-only) and native stdout goes to
+   /dev/null. The `tracing::info!` counterparts are kept for Sentry.
+7. CI net: the `android-smoke` job (ci.yml) builds a debug APK, boots an
+   emulator, launches the app and asserts process liveness plus both
+   markers, and fails on the ndk-context panic text. It also runs
+   `cargo check -p origa-app --lib --target x86_64-linux-android` as a
+   minutes-scale fail-fast for code host clippy never sees.
+
+## Alternatives considered
+
+| Alternative | Verdict |
+| --- | --- |
+| Pin tao < 0.35 / Tauri < 2.11 | Blocks security updates; the break is a supported upstream configuration, not a bug to freeze out. |
+| `webpki-roots` instead of the platform verifier | Removes JNI entirely, but changes the TLS trust model (no user/enterprise CAs, roots frozen per release) and requires workspace-wide reqwest feature surgery. |
+| `RuntimeHandle::run_on_android_context` | The sanctioned dispatch path, but timing-fragile (panics when the activity is not registered yet) and fixes only our reader while `tauri-plugin-tts` keeps reading an unpublished global. |
+
+## Consequences
+
+- The first read of `ndk_context::android_context()` on Android is now
+  guaranteed populated by code we own, not by a transitive side effect.
+- The smoke job adds ~20–30 min to cold PR runs touching `core`/`tauri`
+  (workspace build with ort/lindera + emulator image + boot; warm runs are
+  materially cheaper via the rust cache). Accepted trade-off: it is the only
+  automated net for Android startup crashes.
+- The smoke test runs the x86_64 ABI (emulator), not the production aarch64;
+  the fixed code is ABI-independent (pure JNI, no ISA-specific paths), and
+  production builds stay aarch64 via `_build-tauri.yml`.
+- If Tauri later restores ndk-context publication upstream, OUR publication
+  must be removed at the same time: with `panic = "abort"` release profiles
+  a second publisher aborts the process on ndk-context's assert regardless
+  of pointer validity — coexistence is not safe by construction.

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -91,12 +91,14 @@ tauri-plugin-haptics.workspace = true
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 tauri-plugin-aswebauth.workspace = true
 
-# Android-only: rustls-platform-verifier JNI initialization.
-# reqwest (Sentry transport, lindera build) pulls in rustls-platform-verifier
-# on non-WASM targets. On Android it must be initialized with a JNI context
-# before any TLS handshake, or the process aborts. jni crate is needed to
-# obtain JNIEnv from the JavaVM. ndk-context provides the JavaVM/Activity
-# pointers (initialized by tao before main()).
+# Android-only: rustls-platform-verifier JNI initialization + our own
+# ndk-context publication. Since Tauri 2.11 (tao 0.35) nothing publishes the
+# JavaVM/Application into `ndk-context` (tao dropped the dependency), so
+# tauri/src/android_context.rs owns that invariant: JNI_OnLoad captures the
+# JavaVM, the Application context is resolved via
+# ActivityThread.currentApplication(), both are published for every reader
+# (the verifier init below, tauri-plugin-tts). The jni crate is needed for
+# the JNI calls themselves.
 # Pinned to 0.21: rustls-platform-verifier 0.6 takes jni 0.21 types in
 # android::init_with_env; a direct 0.22 dep (dependabot #455) breaks the
 # Android build with mismatched JNIEnv/JObject types.

--- a/tauri/scripts/android_smoke.sh
+++ b/tauri/scripts/android_smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Android smoke test: install a debug APK on a booted emulator, launch the
+# app, and assert that the process stays alive AND that the startup
+# invariants observable via logcat hold:
+#   1. the JavaVM/Application publication into ndk-context succeeded
+#      (marker: "[android-context] published");
+#   2. rustls-platform-verifier initialized (marker: "[rustls]
+#      platform-verifier initialized for Android");
+#   3. the ndk-context panic text is absent.
+# Both markers are emitted through android.util.Log (JNI) — the app's only
+# reliable logcat channel: tracing has no logcat backend and native
+# stdout/stderr go to /dev/null regardless of debuggability (ADR-044).
+#
+# Usage: android_smoke.sh <apk-path> [package-id]
+# Env: ADB (default "adb"), BOOT_TIMEOUT_S, LAUNCH_TIMEOUT_S, SETTLE_S.
+# Requires: adb in PATH; an emulator/device already attached (boot is
+# awaited here).
+set -euo pipefail
+
+ADB="${ADB:-adb}"
+APK="${1:?usage: android_smoke.sh <apk-path> [package-id]}"
+PACKAGE="${2:-net.uwuwu.origa}"
+BOOT_TIMEOUT_S="${BOOT_TIMEOUT_S:-300}"
+LAUNCH_TIMEOUT_S="${LAUNCH_TIMEOUT_S:-15}"
+SETTLE_S="${SETTLE_S:-5}"
+
+MARKER_CONTEXT='[android-context] published'
+MARKER_RUSTLS='[rustls] platform-verifier initialized for Android'
+PANIC_TEXT='android context was not initialized'
+
+fail() {
+    echo "::error::android-smoke: $1" >&2
+    echo "--- logcat tail ---" >&2
+    $ADB logcat -d 2>/dev/null | tail -n 200 >&2 || true
+    exit 1
+}
+
+# adb pidof exits non-zero when the process is absent; strip whitespace from
+# the (possibly CRLF-terminated) shell output.
+pid_of() {
+    # Keep inner whitespace (multiple pids must stay "123 456", not "123456").
+    $ADB shell pidof "$PACKAGE" 2>/dev/null | tr -d '\r' || true
+}
+
+[ -f "$APK" ] || fail "APK not found: $APK"
+
+echo "android-smoke: waiting for device + boot completion"
+$ADB wait-for-device
+deadline=$(( $(date +%s) + BOOT_TIMEOUT_S ))
+until [ "$($ADB shell getprop sys.boot_completed 2>/dev/null | tr -d '[:space:]\r')" = "1" ]; do
+    [ "$(date +%s)" -lt "$deadline" ] || fail "emulator did not finish booting in ${BOOT_TIMEOUT_S}s"
+    sleep 2
+done
+
+echo "android-smoke: installing $APK"
+$ADB install -r "$APK" > /dev/null 2>&1 || fail "adb install failed for $APK"
+$ADB logcat -c
+
+activity="$($ADB shell cmd package resolve-activity --brief -c android.intent.category.LAUNCHER "$PACKAGE" 2>/dev/null | tail -n 1 | tr -d '[:space:]\r' || true)"
+[ -n "$activity" ] || fail "could not resolve launcher activity for $PACKAGE"
+echo "android-smoke: launching $activity"
+$ADB shell am start -n "$activity" > /dev/null || fail "am start failed for $activity"
+
+deadline=$(( $(date +%s) + LAUNCH_TIMEOUT_S ))
+until [ -n "$(pid_of)" ]; do
+    [ "$(date +%s)" -lt "$deadline" ] || fail "process $PACKAGE did not start within ${LAUNCH_TIMEOUT_S}s"
+    sleep 1
+done
+
+sleep "$SETTLE_S"
+pid="$(pid_of)"
+[ -n "$pid" ] || fail "process $PACKAGE died within ${SETTLE_S}s of launch"
+
+logcat="$($ADB logcat -d 2>/dev/null || true)"
+
+case "$logcat" in
+    *"$PANIC_TEXT"*) fail "ndk-context panic text found in logcat" ;;
+esac
+case "$logcat" in
+    *"$MARKER_CONTEXT"*) : ;;
+    *) fail "context publication marker missing in logcat (app alive but startup invariant violated)" ;;
+esac
+case "$logcat" in
+    *"$MARKER_RUSTLS"*) : ;;
+    *) fail "rustls platform-verifier init marker missing in logcat (app alive but verifier not initialized)" ;;
+esac
+
+echo "android-smoke: OK (pid=$pid, publication + verifier markers present, no panic)"

--- a/tauri/scripts/android_smoke.sh
+++ b/tauri/scripts/android_smoke.sh
@@ -30,6 +30,8 @@ PANIC_TEXT='android context was not initialized'
 
 fail() {
     echo "::error::android-smoke: $1" >&2
+    echo "--- emulator.log tail ---" >&2
+    tail -n 40 "${EMU_LOG:-/tmp/emulator.log}" >&2 2>/dev/null || true
     echo "--- logcat tail ---" >&2
     $ADB logcat -d 2>/dev/null | tail -n 200 >&2 || true
     exit 1
@@ -44,8 +46,14 @@ pid_of() {
 
 [ -f "$APK" ] || fail "APK not found: $APK"
 
-echo "android-smoke: waiting for device + boot completion"
-$ADB wait-for-device
+echo "android-smoke: waiting for device attachment + boot completion"
+# Bounded replacement for `adb wait-for-device` (which hangs forever when
+# the emulator process died before registering a transport).
+deadline=$(( $(date +%s) + BOOT_TIMEOUT_S ))
+until $ADB devices | awk 'NR>1 && $2=="device"' | grep -q .; do
+    [ "$(date +%s)" -lt "$deadline" ] || fail "no device attached within ${BOOT_TIMEOUT_S}s (emulator may have crashed - see emulator.log above)"
+    sleep 2
+done
 deadline=$(( $(date +%s) + BOOT_TIMEOUT_S ))
 until [ "$($ADB shell getprop sys.boot_completed 2>/dev/null | tr -d '[:space:]\r')" = "1" ]; do
     [ "$(date +%s)" -lt "$deadline" ] || fail "emulator did not finish booting in ${BOOT_TIMEOUT_S}s"

--- a/tauri/src/android_context.rs
+++ b/tauri/src/android_context.rs
@@ -1,0 +1,203 @@
+//! Android JNI context ownership: JavaVM + Application context publication.
+//!
+//! Tauri 2.11 (tao 0.35) stopped publishing the JavaVM and Application
+//! context into the [`ndk-context`] crate global, and every reader of
+//! `ndk_context::android_context()` (the rustls-platform-verifier init in
+//! `lib.rs`, `tauri-plugin-tts`) panicked with "android context was not
+//! initialized" on launch. We own that invariant now: the JVM calls
+//! [`JNI_OnLoad`] when the native library is loaded (neither tao, wry nor
+//! tauri define that symbol), we capture the JavaVM there, resolve the
+//! Application context via `ActivityThread.currentApplication()`, and
+//! publish both into `ndk-context` for every consumer. See ADR-044.
+//!
+//! Failure policy: every step degrades to `false` + `tracing::error!` +
+//! logcat. Nothing here may panic — it runs across the JNI FFI boundary and
+//! release profiles build with `panic = "abort"` (uncatchable).
+//!
+//! Single-publisher assumption (ADR-044): in this process only this module
+//! calls `ndk_context::initialize_android_context`. The CAS guard protects
+//! against our own re-entry (a second `JNI_OnLoad` is possible on
+//! classloader splits); a hypothetical foreign publisher would abort on
+//! ndk-context's `assert!(previous.is_some())` in `panic = "abort"` profiles
+//! — `catch_unwind` only helps in unwind-enabled ones (debug/smoke).
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use jni::{JavaVM, objects::JObject};
+
+mod logcat;
+
+pub use logcat::logcat_info;
+
+/// Raw `*mut jni_sys::JavaVM` captured by [`JNI_OnLoad`], stored as `usize`
+/// so the static stays `Send + Sync` without depending on jni wrapper types.
+static JAVA_VM_PTR: AtomicUsize = AtomicUsize::new(0);
+/// Raw `jobject` of the leaked Application global ref (see [`publish`]).
+static APP_CONTEXT_PTR: AtomicUsize = AtomicUsize::new(0);
+/// Raw `jobject` of the leaked Application class-loader global ref, kept so
+/// consumers can resolve app classes from arbitrary threads.
+static CLASS_LOADER_PTR: AtomicUsize = AtomicUsize::new(0);
+/// Guard against a second publication: `ndk_context::initialize_android_context`
+/// asserts on `previous.is_some()`, and a second `JNI_OnLoad` is possible.
+static PUBLISHED: AtomicBool = AtomicBool::new(false);
+
+/// Called by the JVM once on `System.loadLibrary` — the earliest point where
+/// a JavaVM is reachable, before any Tauri startup code runs. Always returns
+/// `JNI_VERSION_1_6`: `JNI_ERR` would fail the `loadLibrary` call and kill
+/// the app outright, which is strictly worse than degraded TLS.
+#[unsafe(no_mangle)]
+pub extern "system" fn JNI_OnLoad(
+    vm: *mut jni::sys::JavaVM,
+    _reserved: *mut core::ffi::c_void,
+) -> jni::sys::jint {
+    JAVA_VM_PTR.store(vm as usize, Ordering::Release);
+    if ensure_initialized() {
+        logcat_info("[android-context] published JavaVM+Application to ndk-context");
+    }
+    jni::sys::JNI_VERSION_1_6
+}
+
+/// Publish the JavaVM + Application context into `ndk-context`, idempotently.
+///
+/// Returns `true` when a valid context is available to readers (`java_vm`,
+/// `app_context`), `false` on any failure — logging the reason, never
+/// panicking. Normal flow: `JNI_OnLoad` already did the work and this is a
+/// cheap no-op.
+pub fn ensure_initialized() -> bool {
+    if is_published() {
+        return true;
+    }
+    let Some(vm) = captured_java_vm() else {
+        tracing::error!("[android-context] JNI_OnLoad has not run; no JavaVM to publish");
+        return false;
+    };
+    let mut attached = match vm.attach_current_thread() {
+        Ok(attached) => attached,
+        Err(e) => {
+            tracing::error!("[android-context] failed to attach thread to JVM: {e:?}");
+            return false;
+        },
+    };
+    let env = &mut *attached;
+
+    let Some(app) = current_application(env) else {
+        tracing::error!(
+            "[android-context] ActivityThread.currentApplication() returned null; \
+             loadLibrary ran before Application.onCreate?"
+        );
+        return false;
+    };
+    let Ok(app_global) = env.new_global_ref(&app) else {
+        tracing::error!("[android-context] failed to create Application global ref");
+        return false;
+    };
+    let loader = env
+        .call_method(&app, "getClassLoader", "()Ljava/lang/ClassLoader;", &[])
+        .and_then(|loader| loader.l())
+        .and_then(|loader| env.new_global_ref(&loader));
+    let Ok(loader_global) = loader else {
+        tracing::error!("[android-context] failed to capture Application class loader");
+        return false;
+    };
+
+    publish(app_global, loader_global)
+}
+
+/// Whether `ndk-context` has been populated by this module.
+pub fn is_published() -> bool {
+    PUBLISHED.load(Ordering::Acquire)
+}
+
+/// The JavaVM captured by [`JNI_OnLoad`], if the library was loaded through
+/// the JVM.
+pub fn java_vm() -> Option<JavaVM> {
+    captured_java_vm()
+}
+
+/// The Application context (process-lifetime global ref), after publication.
+pub fn app_context() -> Option<JObject<'static>> {
+    raw_object(APP_CONTEXT_PTR.load(Ordering::Acquire))
+}
+
+/// Resolve the Application object. `ActivityThread` is a hidden but stable
+/// system class; `currentApplication()` is the standard reflection-based
+/// accessor used across the Android ecosystem (see ADR-044).
+fn current_application<'local>(env: &mut jni::JNIEnv<'local>) -> Option<JObject<'local>> {
+    let activity_thread = env.find_class("android/app/ActivityThread").ok()?;
+    let application = env
+        .call_static_method(
+            activity_thread,
+            "currentApplication",
+            "()Landroid/app/Application;",
+            &[],
+        )
+        .ok()?
+        .l()
+        .ok()?;
+    if application.as_raw().is_null() {
+        return None;
+    }
+    Some(application)
+}
+
+/// Take ownership of both global refs, leak them (process lifetime — exactly
+/// the contract `ndk-context` assumes: it stores raw pointers and never
+/// releases them), and hand them to `ndk-context` under the CAS guard.
+/// Pointers are stored BEFORE the flag: any reader that observes
+/// `is_published() == true` always finds valid pointers (the Release on the
+/// CAS publishes the stores above). A racing loser of the CAS leaks a second
+/// global ref to the same Application — benign, leaking is this module's
+/// contract.
+fn publish(app_global: jni::objects::GlobalRef, loader_global: jni::objects::GlobalRef) -> bool {
+    let app_raw = app_global.as_obj().as_raw();
+    let loader_raw = loader_global.as_obj().as_raw();
+    APP_CONTEXT_PTR.store(app_raw as usize, Ordering::Release);
+    CLASS_LOADER_PTR.store(loader_raw as usize, Ordering::Release);
+    std::mem::forget((app_global, loader_global));
+
+    if PUBLISHED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        // Another thread won the race and owns the ndk-context publication;
+        // our pointers (same underlying objects) are valid either way.
+        return true;
+    }
+
+    // Safety: both pointers are process-lifetime global refs (leaked above,
+    // pinned by the GC) and the JavaVM is the one the JVM handed to
+    // JNI_OnLoad. Single-publisher guarantee: the CAS above.
+    let publication = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        ndk_context::initialize_android_context(
+            JAVA_VM_PTR.load(Ordering::Acquire) as *mut core::ffi::c_void,
+            app_raw as *mut core::ffi::c_void,
+        );
+    }));
+    if publication.is_err() {
+        tracing::error!(
+            "[android-context] ndk-context reported a pre-existing publisher (panic); \
+             our pointers remain valid but the owner is not this module"
+        );
+    }
+    true
+}
+
+fn captured_java_vm() -> Option<JavaVM> {
+    let raw = JAVA_VM_PTR.load(Ordering::Acquire);
+    if raw == 0 {
+        return None;
+    }
+    // Safety: stored verbatim by JNI_OnLoad from the JVM-provided pointer.
+    unsafe { JavaVM::from_raw(raw as *mut jni::sys::JavaVM) }.ok()
+}
+
+/// Reconstruct a wrapper over a process-lifetime global ref. Safety: the
+/// pointer was produced by `new_global_ref` and deliberately leaked in
+/// [`publish`]; the GC pins it for the process lifetime, and a plain
+/// `JObject` has no drop glue (nothing ever deletes it as a local ref).
+fn raw_object(raw: usize) -> Option<JObject<'static>> {
+    if raw == 0 {
+        return None;
+    }
+    Some(unsafe { JObject::from_raw(raw as jni::sys::jobject) })
+}

--- a/tauri/src/android_context/logcat.rs
+++ b/tauri/src/android_context/logcat.rs
@@ -1,0 +1,36 @@
+//! Emit diagnostics to logcat through `android.util.Log`.
+//!
+//! The only reliable observability channel on Android: tracing has no
+//! logcat backend wired in this app (`init_tracing` registers the Sentry
+//! layer only on non-desktop targets) and native stdout goes to /dev/null.
+//! The CI smoke test asserts on these markers (see ADR-044).
+
+use super::captured_java_vm;
+
+/// Emit a message to logcat through `android.util.Log`. Best-effort by
+/// contract: on ANY failure this is a silent no-op (plus an error trace
+/// through the JVM-free channel); it must never disrupt initialization.
+pub fn logcat_info(message: &str) {
+    let Some(vm) = captured_java_vm() else {
+        return;
+    };
+    let Ok(mut attached) = vm.attach_current_thread() else {
+        return;
+    };
+    let env = &mut *attached;
+    let logged = (|| -> jni::errors::Result<()> {
+        let log_class = env.find_class("android/util/Log")?;
+        let tag = env.new_string("origa")?;
+        let message = env.new_string(message)?;
+        env.call_static_method(
+            log_class,
+            "i",
+            "(Ljava/lang/String;Ljava/lang/String;)I",
+            &[(&tag).into(), (&message).into()],
+        )?;
+        Ok(())
+    })();
+    if let Err(e) = logged {
+        tracing::error!("[android-context] logcat write failed: {e:?}");
+    }
+}

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -1,4 +1,9 @@
 mod auth_store;
+// Android JNI context ownership: since Tauri 2.11 (tao 0.35) nothing
+// publishes the JavaVM/Application into `ndk-context`, so this module owns
+// the invariant (JNI_OnLoad capture + publication). See ADR-044.
+#[cfg(target_os = "android")]
+mod android_context;
 // device-ai native file-based speech recognition. macOS-only — the device-ai
 // Rust backend is compiled in only on macOS/iOS/Android (see tauri/Cargo.toml)
 // and the speech-recognize backend is implemented for macOS. The
@@ -62,11 +67,15 @@ pub fn run() {
     // transport) must be initialized with a JNI context before any TLS
     // handshake. Without this, the first HTTPS request panics with
     // "Expect rustls-platform-verifier to be initialized" and aborts the
-    // process. We dispatch to the Android event loop to obtain the JNI
-    // env + Activity context, blocking until init completes.
-    //
-    // This must happen BEFORE `init_sentry()`, because the Sentry transport
-    // creates a reqwest client that performs the first TLS handshake.
+    // process. The JavaVM/Application are published into `ndk-context` by
+    // `JNI_OnLoad` at library load (see `android_context`, ADR-044) — this
+    // call is defense-in-depth for paths where publication has not happened
+    // yet, and the verifier init below reads from that publication.
+    #[cfg(target_os = "android")]
+    android_context::ensure_initialized();
+
+    // Must happen BEFORE `init_sentry()`: the Sentry transport creates a
+    // reqwest client that performs the first TLS handshake.
     #[cfg(target_os = "android")]
     init_platform_verifier_android();
 
@@ -313,55 +322,57 @@ fn init_sentry() -> Option<sentry::ClientInitGuard> {
     Some(guard)
 }
 
-/// Initialize `rustls-platform-verifier` with the Android JVM/Activity context.
+/// Initialize `rustls-platform-verifier` with the Android Application context.
 ///
 /// On Android, reqwest (used by the Sentry transport) uses
 /// `rustls-platform-verifier` for TLS certificate validation. The verifier
 /// panics ("Expect rustls-platform-verifier to be initialized") unless
-/// `init_with_env` has been called with a JNI `JNIEnv` and Activity context.
+/// `init_with_env` has been called with a JNI `JNIEnv` and Application
+/// context.
 ///
-/// We obtain the JavaVM and Activity context via `ndk_context`, which tao
-/// initializes before `main()` is called (see tao's `ndk_glue::create`).
-/// This avoids the deadlock risk of `wry::dispatch` (which posts to the
-/// event loop on the same thread that `run()` blocks).
+/// The JavaVM and Application context come from our own publication in
+/// `android_context` (ADR-044) — `ndk_context::android_context()` is NOT
+/// used here: since Tauri 2.11 (tao 0.35) nothing populates that global and
+/// reading it aborts the process.
 ///
 /// This must happen BEFORE `init_sentry()`, because the Sentry transport
 /// creates a reqwest client that performs the first TLS handshake.
 #[cfg(target_os = "android")]
 fn init_platform_verifier_android() {
     use jni::JNIEnv;
-    use jni::objects::JObject;
 
-    let ctx = ndk_context::android_context();
-
-    // Safety: ndk_context stores a valid JavaVM pointer initialized by tao.
-    let vm = match unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) } {
-        Ok(vm) => vm,
-        Err(e) => {
-            tracing::error!("[rustls] failed to get JavaVM: {e:?}");
-            return;
-        },
+    let Some(vm) = android_context::java_vm() else {
+        tracing::error!("[rustls] no JavaVM published, skipping platform-verifier init");
+        android_context::logcat_info("[rustls] init skipped: no JavaVM");
+        return;
+    };
+    let Some(context) = android_context::app_context() else {
+        tracing::error!("[rustls] no Application context published, skipping verifier init");
+        android_context::logcat_info("[rustls] init skipped: no Application context");
+        return;
     };
 
     // Attach the current thread to the JVM. The returned guard detaches
-    // automatically when dropped, but we only need the env for the init call.
-    let mut env = match vm.attach_current_thread() {
-        Ok(env) => env,
+    // automatically when dropped; only the init call needs the env.
+    let mut attached = match vm.attach_current_thread() {
+        Ok(attached) => attached,
         Err(e) => {
             tracing::error!("[rustls] failed to attach thread to JVM: {e:?}");
             return;
         },
     };
+    let env = &mut *attached;
 
-    // Safety: ndk_context stores a valid Android Context (Activity) jobject.
-    let context = unsafe { JObject::from_raw(ctx.context() as jni::sys::jobject) };
-
-    match rustls_platform_verifier::android::init_with_env(&mut env, context) {
+    match rustls_platform_verifier::android::init_with_env(env, context) {
         Ok(()) => {
+            // Both channels on purpose: tracing feeds Sentry in production
+            // (ADR-036), logcat is the CI smoke-test marker (ADR-044).
             tracing::info!("[rustls] platform-verifier initialized for Android");
+            android_context::logcat_info("[rustls] platform-verifier initialized for Android");
         },
         Err(e) => {
             tracing::error!("[rustls] platform-verifier init failed: {e:?}");
+            android_context::logcat_info("[rustls] init failed");
         },
     }
 }


### PR DESCRIPTION
## Root cause

Since Tauri 2.11 (#443 pulled in tao 0.35) nothing publishes the JavaVM/Application into the `ndk-context` crate global — tao 0.35 dropped the dependency in its mobile multi-window refactor. `init_platform_verifier_android` (#355) still reads `ndk_context::android_context()`, so **every Android launch aborts** with:

```text
PANIC at ndk-context/src/lib.rs:72: android context was not initialized
```

Our code never changed; an undocumented side effect of a transitive dependency disappeared. Same break hits every Tauri 2.11 app reading ndk-context (android-native-keyring-store#21, plugins-workspace#2900).

## Why CI didn't catch it

Host clippy/test never compiles `#[cfg(target_os = "android")]` code; release jobs build the APK without running it; Playwright e2e drives the web build in a desktop browser. No CI layer executed the app on Android.

## What this does

1. **test(android)** — `android-smoke` CI job: boots an emulator, installs a debug APK (x86_64, same ABI as the emulator; production stays aarch64), launches the app, asserts process liveness + two startup markers emitted via `android.util.Log` (JNI) — the only reliable logcat channel (tracing has no logcat backend, native stdout → /dev/null). Fail-closed: any missing marker or the panic text = red. WASM built in-job with `--release` (debug bundle OOM-kills the WebView heap, tauri#13554).
2. **fix(android)** — `tauri/src/android_context.rs` owns the invariant: `JNI_OnLoad` captures the JavaVM at library load (no symbol collision — verified: tao/wry/tauri don't define it), Application context resolved via `ActivityThread.currentApplication()`, both published into `ndk-context` under a CAS guard (fixes every reader, incl. `tauri-plugin-tts`). `init_platform_verifier_android` reads from our publication instead of the panicking global.
3. **docs** — ADR-044 (alternatives weighed: webpki-roots, `run_on_android_context`, pinning tao) + AGENTS.md dev note.

## Staged validation (TDD)

This PR is pushed in slices: the smoke job lands **first** and is expected to go **red** on the not-yet-fixed code (that is the proof the net catches this bug class), the fix commit follows and turns it green. `gh pr merge --auto` is enabled — the merge fires only on the final green state.

## Verification

- host: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude origa_landing` (2299 passed / 0 failed)
- android module type-checked against real jni 0.21 + ndk-context 0.1 via a scratch crate (`clippy -D warnings` clean); full `cargo check --target x86_64-linux-android` runs inside the smoke job (needs NDK)
- shellcheck on the smoke script; CI YAML parsed; gate invariants 1–4 respected (run_android_smoke ⊆ run_cdn_download)
- Android/emulator behavior verified on-device by CI only (no local NDK) — 1–2 shake-out iterations are anticipated for the emulator infra