### PR TITLE
fix(ui): keep the tokenizer dictionary load alive when raw-cache writes fail

### DIFF
--- a/origa_ui/src/loaders/dictionary.rs
+++ b/origa_ui/src/loaders/dictionary.rs
@@ -108,10 +108,9 @@ impl RawFileSink for CacheApiSink {
 /// own JS-side copy coexists with the raw Vec. Cache persistence is
 /// best-effort: a sink failure is logged and the load continues, because
 /// the v2 raw cache (~344 MB, single 223 MB entries) can exceed the Cache
-/// API quota on quota-tight WebViews (iOS/macOS WKWebView) — a refused
-/// cache write must never take the tokenizer down (v0.7.5 semantics; the
-/// fatal `?` silently killed furigana and phrase tokenization in
-/// v0.7.6-rc1).
+/// API quota on quota-tight WebViews — a refused cache write must never
+/// take the tokenizer down. Fetch and inflate failures stay fatal: they
+/// mean "no data", not "cache did not persist".
 async fn fetch_inflate_and_persist_via<P: CdnProvider, S: RawFileSink>(
     provider: &P,
     sink: &S,
@@ -283,6 +282,25 @@ mod tests {
         }
     }
 
+    /// CdnProvider mock that cannot fetch anything — an offline CDN.
+    struct OfflineCdn;
+
+    impl CdnProvider for OfflineCdn {
+        fn fetch_text(&self, path: &str) -> impl Future<Output = Result<String, OrigaError>> {
+            std::future::ready(Err(OrigaError::NetworkError {
+                url: path.to_string(),
+                reason: "offline".to_string(),
+            }))
+        }
+
+        fn fetch_bytes(&self, path: &str) -> impl Future<Output = Result<Vec<u8>, OrigaError>> {
+            std::future::ready(Err(OrigaError::NetworkError {
+                url: path.to_string(),
+                reason: "offline".to_string(),
+            }))
+        }
+    }
+
     /// Sink whose every write is rejected, mirroring an exhausted Cache API
     /// quota (`QuotaExceededError` on put — the v0.7.6-rc1 regression
     /// trigger on quota-tight WebViews).
@@ -343,5 +361,26 @@ mod tests {
         // Assert: best-effort must not degrade into never-persisting.
         assert_eq!(files.len(), PIPELINE_ORDER.len());
         assert_eq!(sink.persisted.borrow().len(), PIPELINE_ORDER.len());
+    }
+
+    #[tokio::test]
+    async fn fetch_failure_stays_fatal_for_the_pipeline() {
+        // Arrange: a healthy sink cannot compensate for missing data.
+        let sink = RecordingSink {
+            persisted: std::cell::RefCell::new(Vec::new()),
+        };
+
+        // Act
+        let files = fetch_inflate_and_persist_via(&OfflineCdn, &sink).await;
+
+        // Assert: "no data" is fatal — only cache persistence is best-effort.
+        assert!(
+            files.is_err(),
+            "a fetch failure must stay fatal (best-effort covers writes only)"
+        );
+        assert!(
+            sink.persisted.borrow().is_empty(),
+            "nothing may be persisted when no file was fetched"
+        );
     }
 }

--- a/origa_ui/src/loaders/dictionary.rs
+++ b/origa_ui/src/loaders/dictionary.rs
@@ -86,15 +86,36 @@ pub async fn load_dictionary() -> Result<(), OrigaError> {
     Ok(())
 }
 
-/// Fetch deflated files from the CDN one at a time (words first), inflate
-/// them and persist the raw bytes to the v2 cache right away — no buffer
-/// clones: the single-file cache API borrows the bytes and only the Cache
-/// API's own JS-side copy coexists with the raw Vec. The retired v1 cache
-/// is deleted only after the full v2 set is stored, so an offline user
-/// never loses a working dictionary to a half-finished migration.
-async fn fetch_inflate_and_cache_raw() -> Result<Vec<(String, Vec<u8>)>, OrigaError> {
-    let provider = cdn_provider();
+/// Persistence sink for the fetch→inflate→persist pipeline. Production
+/// writes each raw file into the Cache API; tests inject failures to pin
+/// the best-effort contract (a cache failure must never kill the load).
+trait RawFileSink {
+    async fn persist(&self, path: &str, raw: &[u8]) -> Result<(), OrigaError>;
+}
 
+/// Production sink: the v2 raw Cache API entry for one dictionary file.
+struct CacheApiSink;
+
+impl RawFileSink for CacheApiSink {
+    async fn persist(&self, path: &str, raw: &[u8]) -> Result<(), OrigaError> {
+        save_dictionary_file_to_cache(path, raw).await
+    }
+}
+
+/// Fetch deflated files from the CDN one at a time (words first), inflate
+/// them and hand each raw file to the sink right away — no buffer clones:
+/// the single-file cache API borrows the bytes and only the Cache API's
+/// own JS-side copy coexists with the raw Vec. Cache persistence is
+/// best-effort: a sink failure is logged and the load continues, because
+/// the v2 raw cache (~344 MB, single 223 MB entries) can exceed the Cache
+/// API quota on quota-tight WebViews (iOS/macOS WKWebView) — a refused
+/// cache write must never take the tokenizer down (v0.7.5 semantics; the
+/// fatal `?` silently killed furigana and phrase tokenization in
+/// v0.7.6-rc1).
+async fn fetch_inflate_and_persist_via<P: CdnProvider, S: RawFileSink>(
+    provider: &P,
+    sink: &S,
+) -> Result<Vec<(String, Vec<u8>)>, OrigaError> {
     let mut raw_files: Vec<(String, Vec<u8>)> = Vec::with_capacity(PIPELINE_ORDER.len());
     for file in PIPELINE_ORDER {
         let path = dict_path(file);
@@ -105,13 +126,25 @@ async fn fetch_inflate_and_cache_raw() -> Result<Vec<(String, Vec<u8>)>, OrigaEr
             compressed
         };
         yield_to_browser().await;
-        save_dictionary_file_to_cache(&path, &raw).await?;
-        tracing::debug!("📖 Cached raw {path} ({} bytes)", raw.len());
+        if let Err(e) = sink.persist(&path, &raw).await {
+            tracing::warn!("Failed to cache raw dictionary file {path}: {e:?}");
+        } else {
+            tracing::debug!("📖 Cached raw {path} ({} bytes)", raw.len());
+        }
         raw_files.push((path, raw));
     }
 
-    cleanup_legacy_dictionary_cache().await;
     Ok(raw_files)
+}
+
+async fn fetch_inflate_and_cache_raw() -> Result<Vec<(String, Vec<u8>)>, OrigaError> {
+    let files = fetch_inflate_and_persist_via(cdn_provider(), &CacheApiSink).await?;
+    // The retired v1 cache is deleted only after the full v2 set is stored,
+    // so an offline user never loses a working dictionary to a half-finished
+    // migration. Wasm-only side effect — kept out of the hermetic pipeline
+    // core above (native tests exercise the core without a window).
+    cleanup_legacy_dictionary_cache().await;
+    Ok(files)
 }
 
 /// Group raw file bytes under their bare names (dropping the versioned
@@ -214,5 +247,101 @@ mod tests {
         let raw = inflate(&compressed).unwrap();
 
         assert_eq!(raw, b"payload for the tokenizer");
+    }
+
+    fn deflate(payload: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+        let mut encoder =
+            flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(payload).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// CdnProvider mock over the external CDN boundary: serves a tiny valid
+    /// payload for every pipeline path (deflated for the eight lindera
+    /// files, raw JSON for metadata.json) and fails for anything else.
+    struct TinyDictCdn;
+
+    impl CdnProvider for TinyDictCdn {
+        fn fetch_text(&self, path: &str) -> impl Future<Output = Result<String, OrigaError>> {
+            std::future::ready(Err(OrigaError::NetworkError {
+                url: path.to_string(),
+                reason: "text fetch is not stubbed in pipeline tests".to_string(),
+            }))
+        }
+
+        fn fetch_bytes(&self, path: &str) -> impl Future<Output = Result<Vec<u8>, OrigaError>> {
+            let result = match PIPELINE_ORDER.iter().find(|f| dict_path(f) == path) {
+                Some(file) if !is_inflatable(file) => Ok(br#"{"name":"sudachidict"}"#.to_vec()),
+                Some(_) => Ok(deflate(b"tiny-raw-payload")),
+                None => Err(OrigaError::NetworkError {
+                    url: path.to_string(),
+                    reason: "not stubbed".to_string(),
+                }),
+            };
+            std::future::ready(result)
+        }
+    }
+
+    /// Sink whose every write is rejected, mirroring an exhausted Cache API
+    /// quota (`QuotaExceededError` on put — the v0.7.6-rc1 regression
+    /// trigger on quota-tight WebViews).
+    struct QuotaExhaustedSink;
+
+    impl RawFileSink for QuotaExhaustedSink {
+        async fn persist(&self, path: &str, _raw: &[u8]) -> Result<(), OrigaError> {
+            Err(OrigaError::RepositoryError {
+                reason: format!("Cache put failed for {path}: simulated QuotaExceededError"),
+            })
+        }
+    }
+
+    struct RecordingSink {
+        persisted: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl RawFileSink for RecordingSink {
+        async fn persist(&self, path: &str, _raw: &[u8]) -> Result<(), OrigaError> {
+            self.persisted.borrow_mut().push(path.to_string());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn quota_exhausted_cache_write_does_not_kill_the_dictionary_load() {
+        // Arrange
+        let provider = TinyDictCdn;
+        let sink = QuotaExhaustedSink;
+
+        // Act
+        let files = fetch_inflate_and_persist_via(&provider, &sink).await;
+
+        // Assert
+        let files = files
+            .expect("a cache-write failure must not kill the dictionary load (v0.7.5 semantics)");
+        assert_eq!(files.len(), PIPELINE_ORDER.len());
+        for (path, raw) in &files {
+            let bare_name = path.rsplit('/').next().unwrap_or(path);
+            if is_inflatable(bare_name) {
+                assert_eq!(raw, b"tiny-raw-payload", "{path} must be inflated");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_pipeline_persists_every_file() {
+        // Arrange
+        let sink = RecordingSink {
+            persisted: std::cell::RefCell::new(Vec::new()),
+        };
+
+        // Act
+        let files = fetch_inflate_and_persist_via(&TinyDictCdn, &sink)
+            .await
+            .expect("the tiny pipeline must load");
+
+        // Assert: best-effort must not degrade into never-persisting.
+        assert_eq!(files.len(), PIPELINE_ORDER.len());
+        assert_eq!(sink.persisted.borrow().len(), PIPELINE_ORDER.len());
     }
 }


### PR DESCRIPTION
## Summary

A dictionary **cache-write** failure was fatal for `load_dictionary()` since #490 (v0.7.6-rc1), silently killing the lindera segmenter — and with it **furigana annotation and phrase tokenization** (both consume `tokenize_text`). v0.7.5 treated the same write as best-effort.

## Root cause (diagnosed, TDD red→green→revert→red)

`fetch_inflate_and_cache_raw` changed the raw-file cache write from best-effort to fatal:

```rust
save_dictionary_file_to_cache(&path, &raw).await?;   // ← rc1
```

while the v2 raw cache grew **75 MB → 344 MB** (single 223 MB `dict.words` entry). On quota-tight WebViews (iOS/macOS WKWebView) `cache.put` rejects with `QuotaExceededError` → `load_dictionary()` → `Err` → swallowed in `routes.rs` (`is_dictionary_loaded.set(true)` unconditionally) → the app runs with a dead tokenizer; every consumer degrades silently (`tokenize_text(...).unwrap_or_default()`, `furiganize_segments` plain-text fallback).

Evidence (workspace `origa-rc-furigana-diag`, not merged):

- **RED (rc1 code)**: wasm probe with `Cache.prototype.put` rejecting → `CONFIRMED DEFECT: ... Repository error: Cache put failed for /__origa_dict_file__dict.words: QuotaExceededError` — attributed exactly to the dictionary save.
- **GREEN (best-effort patch)**: same probe passes; all 9 files fetched from the production CDN with every write rejected.
- **REVERT → RED again**: the probe pins the contract, not an environment accident.
- **Elimination**: real prod blobs (furigana 28 MB, vocabulary 40 MB) deserialize and answer lookups; the real SudachiDict set inflates/assembles/inits/tokenizes (`食べ物` → 1 token) — CDN data and the client deserialize path are healthy.
- Deduction C1→C2: v0.7.5 shipped the same *fatal* `open_cache()` in `fetch_bytes` and worked on the same devices ⇒ Cache API **availability** is not the trigger; the delta is the **write** failing (quota/entry size).

## Fix

- Restore best-effort semantics for the raw-cache write (warn + continue), parameterized behind a tiny `RawFileSink` so the contract is hermetically testable (no network, no browser).
- Regression tests (native, hermetic):
  - `quota_exhausted_cache_write_does_not_kill_the_dictionary_load` — failing sink → pipeline still returns the full inflated set;
  - `successful_pipeline_persists_every_file` — best-effort does not degrade into never-persisting.

## Why CI did not catch it (v0.7.6-rc1)

1. The `WASM Component Tests` job on the rc1 tag **died on a crates.io network flake** — the only suite able to exercise the new wasm load path never ran; the RC was tagged with a red CI Gate.
2. `loading_rkyv` e2e asserts **transport** (`.rkyv` URLs requested, fallback URLs not requested), not dictionary function.
3. Native loader tests use 3-entry mock fixtures; the Cache API layer was a documented coverage gap, and no test injected a write failure.
4. Loader errors are swallowed by the orchestrator (`is_*_loaded.set(true)` unconditional), so the e2e "app loaded" gate stays green with dead dictionaries.

Follow-ups (not in this PR): surface loader failures instead of swallowing (routes.rs), an e2e gate asserting furigana ruby / token rendering with real dictionaries, and the latent provider defect (`fetch_bytes` fatally requires Cache API availability — present since v0.7.5; with `caches` absent the wasm executor aborts uncaught).

## Testing

- `cargo test -p origa_ui` — new hermetic pipeline tests + existing suite green
- `cargo clippy -p origa_ui --all-targets -- -D warnings`, `cargo fmt` — clean
- Full red→green→revert→red cycle on the rc1 worktree against the production CDN (diagnostic probe, workspace-local)
