### PR TITLE
fix: acquaintance UX batch + Duolingo JLPT distribution + dictionary casing

### DIFF
--- a/end2end/helpers/lesson.ts
+++ b/end2end/helpers/lesson.ts
@@ -48,9 +48,18 @@ export async function runAcquaintancePresentation(page: Page): Promise<void> {
 /// (ре-рендер после do_rate смонтировал фронт следующей карты): если
 /// клик проиграл гонку WASM ре-рендеру, панель остаётся видимой и
 /// попытка повторяется.
+/// Финальный ответ — особый случай: карточка замораживается с открытым
+/// ответом (кнопки рейтинга скрыты окном финиша), и флоу завершает
+/// экран «Знакомство завершено»/завершения урока — повторные клики
+/// по замороженной карте не нужны.
 async function answerTrainingRating(page: Page, button: string): Promise<boolean> {
 	const answer = page.getByTestId("acquaintance-training-answer");
+	const rating = page.getByTestId(button);
+	const finals = page
+		.getByTestId("acquaintance-completed")
+		.or(page.getByTestId("lesson-complete-screen"));
 	for (let attempt = 0; attempt < 8; attempt++) {
+		if (await finals.isVisible().catch(() => false)) return true;
 		const answerVisible = await answer
 			.waitFor({ state: "visible", timeout: 700 })
 			.then(() => true)
@@ -62,15 +71,32 @@ async function answerTrainingRating(page: Page, button: string): Promise<boolean
 				.catch(() => null);
 			continue;
 		}
-		await page
-			.getByTestId(button)
-			.click({ timeout: 1500 })
-			.catch(() => null);
-		const hidden = await answer
+		// Ответ открыт. Рейтинга нет — окно финиша руки: ждём финальный
+		// экран (карточка заморожена, кликать больше нечего).
+		const ratingVisible = await rating
+			.waitFor({ state: "visible", timeout: 700 })
+			.then(() => true)
+			.catch(() => false);
+		if (!ratingVisible) {
+			if (
+				await finals
+					.waitFor({ state: "visible", timeout: 2500 })
+					.then(() => true)
+					.catch(() => false)
+			) {
+				return true;
+			}
+			continue;
+		}
+		await rating.click({ timeout: 1500 }).catch(() => null);
+		const recorded = await answer
 			.waitFor({ state: "hidden", timeout: 2500 })
 			.then(() => true)
 			.catch(() => false);
-		if (hidden) return true;
+		if (recorded) return true;
+		// Ответ не скрылся: либо гонка ре-рендера (повторим на следующей
+		// итерации), либо финальный ответ — следующий проход увидит
+		// финальный экран или скрытый рейтинг.
 	}
 	return false;
 }

--- a/origa/tests/well_known_sets_audit.rs
+++ b/origa/tests/well_known_sets_audit.rs
@@ -1,19 +1,32 @@
-//! Well-known sets JLPT level audit (#178 S-3).
+//! Well-known sets JLPT level audit (#178 S-3, hardened for the 2026-09
+//! level-distribution fix).
 //!
-//! Guards against the blanket N5 tag previously applied to every Duolingo and
-//! Spy x Family set regardless of actual content difficulty. The Duolingo
-//! Section number encoded in each title (1-6) maps deterministically to a JLPT
-//! level (Section 1-2 → N5, 3-4 → N4, 5-6 → N3); Spy x Family content files
-//! all carry `level: "N3"` in their own metadata.
+//! The Duolingo level source of truth is the `level` field carried by every
+//! content file under `cdn/well_known_set/duolingo/` (corpus ground truth:
+//! Section/Модуль 1-3 → N5, 4 → N4, 5-6 → N3). `origa_ui/build.rs` copies it
+//! verbatim into `well_known_sets_meta.json`.
 //!
-//! The `cdn/` directory is gitignored. On a fresh clone without the meta file
-//! the tests **gracefully skip** (pass with a stderr note) rather than panic,
-//! so `cargo test --workspace` stays green in CI environments that do not
-//! have the CDN artifacts. Once the store is present (local dev, release CI
-//! after `scripts/deploy_cdn.py` has been run with the S-3 fixes), the audit
-//! runs for real.
+//! The earlier heuristic parsed the Section number from the set title. It
+//! misread RU-series English titles ("Module 5 Section 16": the parser took
+//! the unit number), which silently dropped 55 sets and mistagged 66 others
+//! with the level of their sub-unit instead of their module. This audit now
+//! guards both invariants directly:
 //!
-//! Run: `cargo test -p origa --test well_known_sets_audit`.
+//! - completeness: every Duolingo content file is present in the meta;
+//! - fidelity: the meta level equals the content file's own `level` field
+//!   and is one of N5/N4/N3.
+//!
+//! Spy x Family content files all carry `level: "N3"` in their own metadata.
+//!
+//! The `cdn/` directory is gitignored. On a fresh clone without the content
+//! files the tests **gracefully skip** (pass with a stderr note) rather than
+//! panic, so `cargo test --workspace` stays green in CI environments that do
+//! not have the CDN artifacts. CI seeds `cdn/` from production S3 and
+//! `cargo build -p origa_ui` regenerates the meta deterministically from the
+//! seeded content before the audit runs.
+//!
+//! Run: `cargo test -p origa --test well_known_sets_audit`
+//! (after `cargo build -p origa_ui` to regenerate a fresh local meta).
 
 use std::fs;
 use std::path::PathBuf;
@@ -34,8 +47,6 @@ struct SetMeta {
     id: String,
     set_type: String,
     level: String,
-    title_en: Option<String>,
-    title_ru: Option<String>,
 }
 
 fn load_meta() -> Option<Vec<SetMeta>> {
@@ -56,72 +67,111 @@ fn load_meta() -> Option<Vec<SetMeta>> {
     Some(parsed)
 }
 
-fn section_from_title(title: &str) -> Option<u32> {
-    let mut iter = title.split_whitespace();
-    while let Some(word) = iter.next() {
-        let lower = word.to_lowercase();
-        if lower == "section" || lower == "модуль" {
-            if let Some(num_word) = iter.next() {
-                if let Ok(num) = num_word.parse::<u32>() {
-                    return Some(num);
-                }
-            }
+/// Every Duolingo content file on disk, mirroring the `duolingo_<dir>_<stem>`
+/// id scheme that `origa_ui/build.rs` generates. Returns `None` when the
+/// content directory is absent (fresh clone without CDN seeding).
+fn duolingo_content_levels() -> Option<Vec<(String, String)>> {
+    let root = cdn_dir().join("well_known_set").join("duolingo");
+    if !root.exists() {
+        eprintln!(
+            "[skip] well_known_sets_audit: {} is absent (cdn/ gitignored on fresh clones)",
+            root.display()
+        );
+        return None;
+    }
+    let mut records = Vec::new();
+    let mut subdirs: Vec<_> = fs::read_dir(&root)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", root.display()))
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|e| e.path())
+        .collect();
+    subdirs.sort();
+    for subdir in subdirs {
+        let parent_name = subdir
+            .file_name()
+            .expect("subdir has a file name")
+            .to_string_lossy()
+            .to_string();
+        let mut files: Vec<_> = fs::read_dir(&subdir)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", subdir.display()))
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|ext| ext == "json")
+            })
+            .map(|e| e.path())
+            .collect();
+        files.sort();
+        for path in files {
+            let stem = path
+                .file_stem()
+                .expect("json file has a stem")
+                .to_string_lossy()
+                .to_string();
+            let set_id = format!("duolingo_{}_{}", parent_name, stem);
+            let raw = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+            let parsed: serde_json::Value = serde_json::from_str(&raw)
+                .unwrap_or_else(|e| panic!("failed to parse {}: {e}", path.display()));
+            let level = parsed
+                .get("level")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            records.push((set_id, level));
         }
     }
-    None
+    Some(records)
 }
 
-fn expected_duolingo_level(title: &str) -> Option<&'static str> {
-    match section_from_title(title)? {
-        1 | 2 => Some("N5"),
-        3 | 4 => Some("N4"),
-        5 | 6 => Some("N3"),
-        _ => None,
-    }
-}
+const VALID_LEVELS: [&str; 3] = ["N5", "N4", "N3"];
 
 #[test]
-fn duolingo_sets_match_section_to_level_mapping() {
-    let Some(records) = load_meta() else {
+fn duolingo_sets_match_content_level_and_are_complete() {
+    let (Some(records), Some(content)) = (load_meta(), duolingo_content_levels()) else {
         return;
     };
-    let mut problems: Vec<String> = Vec::new();
-    let mut checked = 0u32;
+    let by_id: std::collections::HashMap<&str, &SetMeta> = records
+        .iter()
+        .filter(|r| r.set_type == "DuolingoEn" || r.set_type == "DuolingoRu")
+        .map(|r| (r.id.as_str(), r))
+        .collect();
 
-    for record in records.iter() {
-        if record.set_type != "DuolingoEn" && record.set_type != "DuolingoRu" {
-            continue;
-        }
-        let title_blob = format!(
-            "{} {}",
-            record.title_en.as_deref().unwrap_or(""),
-            record.title_ru.as_deref().unwrap_or("")
-        );
-        let Some(expected) = expected_duolingo_level(&title_blob) else {
-            problems.push(format!(
-                "[{}] Duolingo set with no Section/Модуль in title: {:?}",
-                record.id, title_blob
-            ));
+    assert!(
+        !by_id.is_empty(),
+        "no Duolingo sets in well_known_sets_meta.json — fixture path or set_type values drifted"
+    );
+
+    let mut problems: Vec<String> = Vec::new();
+    for (set_id, content_level) in &content {
+        let Some(meta) = by_id.get(set_id.as_str()) else {
+            problems.push(format!("[{set_id}] content file missing from meta (build.rs skip?)"));
             continue;
         };
-        checked += 1;
-        if record.level != expected {
+        if !VALID_LEVELS.contains(&content_level.as_str()) {
             problems.push(format!(
-                "[{}] level={:?} but title section implies {:?}: {:?}",
-                record.id, record.level, expected, title_blob
+                "[{set_id}] content level {content_level:?} is not one of {VALID_LEVELS:?}"
+            ));
+        }
+        if meta.level != *content_level {
+            problems.push(format!(
+                "[{set_id}] meta level {:?} != content level {content_level:?}",
+                meta.level
             ));
         }
     }
 
     assert!(
-        !problems.is_empty() || checked > 0,
-        "audit did not check any Duolingo sets — fixture path or set_type values drifted"
+        !problems.is_empty() || !content.is_empty(),
+        "audit checked no Duolingo content files — fixture path drifted"
     );
     assert!(
         problems.is_empty(),
-        "Duolingo level audit failed ({} problems out of {} checked):\n{}",
+        "Duolingo level audit failed ({} problems out of {} content files):\n{}",
         problems.len(),
-        checked,
+        content.len(),
         problems.join("\n")
     );
 }

--- a/origa/tests/well_known_sets_audit.rs
+++ b/origa/tests/well_known_sets_audit.rs
@@ -96,11 +96,7 @@ fn duolingo_content_levels() -> Option<Vec<(String, String)>> {
         let mut files: Vec<_> = fs::read_dir(&subdir)
             .unwrap_or_else(|e| panic!("failed to read {}: {e}", subdir.display()))
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.path()
-                    .extension()
-                    .is_some_and(|ext| ext == "json")
-            })
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
             .map(|e| e.path())
             .collect();
         files.sort();
@@ -147,7 +143,9 @@ fn duolingo_sets_match_content_level_and_are_complete() {
     let mut problems: Vec<String> = Vec::new();
     for (set_id, content_level) in &content {
         let Some(meta) = by_id.get(set_id.as_str()) else {
-            problems.push(format!("[{set_id}] content file missing from meta (build.rs skip?)"));
+            problems.push(format!(
+                "[{set_id}] content file missing from meta (build.rs skip?)"
+            ));
             continue;
         };
         if !VALID_LEVELS.contains(&content_level.as_str()) {

--- a/origa_ui/build.rs
+++ b/origa_ui/build.rs
@@ -210,31 +210,6 @@ fn load_json(path: &Path) -> WellKnownSet {
         .unwrap_or_else(|_| panic!("Failed to parse JSON from {}", path.display()))
 }
 
-fn section_number_from_title(title: &str) -> Option<u32> {
-    let mut iter = title.split_whitespace();
-    while let Some(word) = iter.next() {
-        let lower = word.to_lowercase();
-        if lower == "section" || lower == "модуль" {
-            if let Some(num_word) = iter.next() {
-                if let Ok(num) = num_word.parse::<u32>() {
-                    return Some(num);
-                }
-            }
-        }
-    }
-    None
-}
-
-fn duolingo_level_from_title(title_en: &str, title_ru: &str) -> Option<&'static str> {
-    let blob = format!("{title_en} {title_ru}");
-    match section_number_from_title(&blob)? {
-        1 | 2 => Some("N5"),
-        3 | 4 => Some("N4"),
-        5 | 6 => Some("N3"),
-        _ => None,
-    }
-}
-
 fn generate_well_known_meta() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let base_dir = Path::new(&manifest_dir)
@@ -611,25 +586,21 @@ fn generate_well_known_meta() {
 
                 let mut data = load_json(&path);
 
-                let title_en = data
-                    .content
-                    .English
-                    .as_ref()
-                    .map(|e| e.title.as_str())
-                    .unwrap_or("");
-                let title_ru = data
-                    .content
-                    .Russian
-                    .as_ref()
-                    .map(|r| r.title.as_str())
-                    .unwrap_or("");
-
-                let Some(level) = duolingo_level_from_title(title_en, title_ru) else {
+                // Level comes from the content file's own `level` field
+                // (corpus ground truth: Section/Модуль 1-3 → N5, 4 → N4,
+                // 5-6 → N3). Title parsing was removed: RU-series English
+                // titles carry both tokens ("Module 5 Section 16"), so the
+                // heuristic read the sub-unit number — 55 sets were dropped
+                // and 66 tagged with their unit's level instead of their
+                // module's.
+                let level = data.level.trim().to_string();
+                if !matches!(level.as_str(), "N5" | "N4" | "N3") {
                     eprintln!(
-                        "cargo:warning=Skipping duolingo set: no Section/Модуль in title for duolingo/{parent_name}/{stem}"
+                        "cargo:warning=Skipping duolingo set: invalid level {:?} for duolingo/{parent_name}/{stem}",
+                        level
                     );
                     continue;
-                };
+                }
 
                 let set_id = format!("duolingo_{}_{}", parent_name, stem);
                 let set_type = if stem.contains("_en_") {
@@ -638,7 +609,7 @@ fn generate_well_known_meta() {
                     "DuolingoRu"
                 };
 
-                meta_list.push(extract_meta(&mut data, &set_id, set_type, level));
+                meta_list.push(extract_meta(&mut data, &set_id, set_type, &level));
             }
         }
     }

--- a/origa_ui/input.css
+++ b/origa_ui/input.css
@@ -1920,6 +1920,20 @@ rt {
     color: var(--fg-muted);
 }
 
+/* === Acquaintance Training Front Dim === */
+/* Приглушение вопроса тренировки знакомства на стороне ответа.
+   Раньше был tailwind opacity-60: opacity обёртки каскадировала во все
+   DOM-потомки, включая тултип кандзи (.kanji-popup), и делала его
+   полупрозрачным (баг-репорт). Пока тултип открыт — приглушение
+   обёртки снимается. */
+.front-dimmed {
+    opacity: 0.6;
+}
+
+.front-dimmed:has(.kanji-popup) {
+    opacity: 1;
+}
+
 /* === Translator Text === */
 .translator-text {
     display: inline;

--- a/origa_ui/src/pages/lesson/acquaintance_state.rs
+++ b/origa_ui/src/pages/lesson/acquaintance_state.rs
@@ -30,6 +30,12 @@ pub struct AcquaintanceState {
     pub hand: Option<AcquaintanceHand>,
     pub slide_index: usize,
     pub skipped_ids: HashSet<Ulid>,
+    /// Рука закрывается: персистенция идёт, экран завершения ещё не
+    /// смонтирован (stage станет Completed после коммита записи — защита
+    /// бага #462). UI в этом окне замораживает отвеченную карту и прячет
+    /// кнопки: без флага после финального ответа пере-показывался вопрос
+    /// «лишней картой», которую затем резко перекрывал экран завершения.
+    pub hand_finishing: bool,
 }
 
 /// Автозвук слова (механизм урока, lesson_card.rs): звучит, когда TTS
@@ -170,6 +176,11 @@ impl AcquaintanceContext {
     /// когда тест/пользователь перезагружал страницу сразу после
     /// завершения руки — fire-and-forget `spawn_local` не успевал).
     pub fn complete_hand(&self) {
+        // Флаг финиша — синхронно, до персистенции: UI сразу замораживает
+        // отвеченную карту и прячет кнопки (см. hand_finishing), не дожидаясь
+        // коммита записи и монтирования экрана завершения.
+        self.state.update(|state| state.hand_finishing = true);
+
         let ids = self.state.with(|state| {
             state
                 .hand
@@ -280,6 +291,7 @@ mod advance_presentation_tests {
             hand: Some(hand),
             slide_index: 0,
             skipped_ids: HashSet::new(),
+            hand_finishing: false,
         }
     }
 
@@ -309,6 +321,7 @@ mod advance_presentation_tests {
             hand: Some(hand),
             slide_index: 0,
             skipped_ids: HashSet::from([b]),
+            hand_finishing: false,
         };
 
         // Act / Assert: первый advance перепрыгивает b и показывает c

--- a/origa_ui/src/pages/lesson/acquaintance_view.rs
+++ b/origa_ui/src/pages/lesson/acquaintance_view.rs
@@ -11,12 +11,11 @@ use super::keyboard_handler::is_typing_target;
 use super::training_view::TrainingBody;
 use crate::i18n::*;
 use crate::ui_components::{
-    Button, ButtonVariant, Card, ConfirmModal, FuriganaText, KanjiAnimation, MarkdownText,
-    MarkdownVariant, ReadingItem, Tag, is_speech_supported, speak_word, speak_word_immediate,
+    AudioButtons, Button, ButtonVariant, Card, ConfirmModal, FuriganaText, KanjiAnimation,
+    MarkdownText, MarkdownVariant, ReadingItem, Tag, is_speech_supported, speak_word,
 };
 use leptos::prelude::*;
 use leptos::task::spawn_local;
-use leptos_icons::Icon;
 use leptos_use::use_event_listener;
 use origa::domain::{AcquaintanceSubphase, NativeLanguage};
 use origa::traits::UserRepository;
@@ -136,6 +135,41 @@ pub fn AcquaintanceView() -> impl IntoView {
             .and_then(|slide| slide.pos_label().map(str::to_string))
     });
 
+    // Слово текущей карты: в показе — слайд по индексу, в тренировке —
+    // карта из сигнала контекста.
+    let current_word = Signal::derive(move || {
+        let ctx = ctx_stored.get_value();
+        let state = ctx.state.get();
+        let card_id = match state.stage {
+            AcquaintanceStage::Presentation => ctx
+                .slides
+                .get()
+                .get(state.slide_index)
+                .map(|slide| slide.card_id()),
+            _ => ctx.current_card.get(),
+        };
+        card_id.and_then(|id| {
+            ctx.slides
+                .get()
+                .iter()
+                .find(|slide| slide.card_id() == id)
+                .and_then(|slide| slide.word().map(str::to_string))
+        })
+    });
+
+    // Кнопка озвучки видна, когда японская сторона слова на экране
+    // (Reverse-фронт прячет её — кнопка не подсказывает ответ).
+    let audio_visible = Signal::derive(move || {
+        let ctx = ctx_stored.get_value();
+        let state = ctx.state.get();
+        audio_button_visible(
+            state.stage,
+            state.hand.as_ref().and_then(|hand| hand.subphase()),
+            ctx.showing_answer.get(),
+            current_word.get().is_some(),
+        )
+    });
+
     view! {
         <div data-testid="acquaintance-view" class="relative px-0.5 sm:px-1 py-1 sm:py-2 flex flex-col grow">
             <Show when=move || {
@@ -173,6 +207,29 @@ pub fn AcquaintanceView() -> impl IntoView {
                         </Tag>
                     </Show>
                 </div>
+
+                // Кнопка озвучки — правый край ряда тегов, как в обычном
+                // уроке (LessonCardTags: ml-auto). Замыкание по слову:
+                // AudioButtons берёт текст при монтировании, смена слова
+                // пересоздаёт кнопку (паттерн lesson_card_header).
+                {move || {
+                    current_word
+                        .get()
+                        .filter(|_| audio_visible.get())
+                        .map(|word| {
+                            view! {
+                                <div class="ml-auto shrink-0">
+                                    <AudioButtons
+                                        text=word
+                                        audio_path=None
+                                        test_id=Signal::derive(|| {
+                                            "acquaintance-audio-btn".to_string()
+                                        })
+                                    />
+                                </div>
+                            }
+                        })
+                }}
             </div>
             </Show>
 
@@ -180,8 +237,11 @@ pub fn AcquaintanceView() -> impl IntoView {
                 let ctx = ctx_stored.get_value();
                 ctx.state.get().stage == AcquaintanceStage::Completed
             }>
+                // anima-page-fade: экран завершения появляется мягким
+                // входом, а не мгновенной заменой тренировочной карты
+                // (юзер-репорт о резком появлении окна).
                 <Card
-                    class=Signal::derive(|| "p-6 mb-4".to_string())
+                    class=Signal::derive(|| "p-6 mb-4 anima-page-fade".to_string())
                     test_id=Signal::derive(|| "acquaintance-completed-card".to_string())
                 >
                     <TransitionScreen ctx=ctx_stored.get_value() />
@@ -220,10 +280,11 @@ pub fn AcquaintanceView() -> impl IntoView {
     }
 }
 
-/// Полоса руки и кнопка озвучки в общем хедере урока: во время знакомства
-/// LessonProgress скрыт, его место занимает полоса руки — прогресс не
-/// съедает полезную высоту карточки (перенос из шапки знакомства).
-/// Кнопка озвучки — справа от полосы, как в шапке руки ранее.
+/// Полоса руки в общем хедере урока: во время знакомства LessonProgress
+/// скрыт, его место занимает полоса руки — прогресс не съедает полезную
+/// высоту карточки. Кнопка озвучки живёт НЕ здесь, а в ряду тегов
+/// AcquaintanceView: появляясь рядом с полосой, она меняла ширину
+/// контейнера и полоса прыгала между картами (баг-репорт).
 #[component]
 pub(crate) fn AcquaintanceHeaderStrip() -> impl IntoView {
     let i18n = use_i18n();
@@ -304,59 +365,8 @@ pub(crate) fn AcquaintanceHeaderStrip() -> impl IntoView {
         }
     });
 
-    // Слово текущей карты: в показе — слайд по индексу, в тренировке —
-    // карта из сигнала контекста.
-    let current_word = Signal::derive(move || {
-        let ctx = ctx_stored.get_value();
-        let state = ctx.state.get();
-        let card_id = match state.stage {
-            AcquaintanceStage::Presentation => ctx
-                .slides
-                .get()
-                .get(state.slide_index)
-                .map(|slide| slide.card_id()),
-            _ => ctx.current_card.get(),
-        };
-        card_id.and_then(|id| {
-            ctx.slides
-                .get()
-                .iter()
-                .find(|slide| slide.card_id() == id)
-                .and_then(|slide| slide.word().map(str::to_string))
-        })
-    });
-
-    // Кнопка озвучки: видна, когда японская сторона слова на экране
-    // (Reverse-фронт прячет её — кнопка не подсказывает ответ).
-    let audio_visible = Signal::derive(move || {
-        let ctx = ctx_stored.get_value();
-        let state = ctx.state.get();
-        audio_button_visible(
-            state.stage,
-            state.hand.as_ref().and_then(|hand| hand.subphase()),
-            ctx.showing_answer.get(),
-            current_word.get().is_some(),
-        )
-    });
-    let speak_current_word = Callback::new(move |_: ()| {
-        if let Some(word) = current_word.get() {
-            speak_word(&word, 1.0);
-        }
-    });
-
     view! {
-        <div class="flex items-center justify-end gap-2 min-w-0">
-            <HandProgressStrip total progress label=strip_label />
-            <Show when=move || audio_visible.get()>
-                <button
-                    data-testid="acquaintance-audio-btn"
-                    class="text-[var(--fg-muted)] hover:text-[var(--fg-black)] transition-colors cursor-pointer shrink-0"
-                    on:click=move |_| speak_current_word.run(())
-                >
-                    <Icon icon=icondata::LuPlay width="16" height="16" />
-                </button>
-            </Show>
-        </div>
+        <HandProgressStrip total progress label=strip_label />
     }
 }
 
@@ -430,6 +440,9 @@ fn PresentationBody(ctx: AcquaintanceContext) -> impl IntoView {
     // звучит один раз — новой картой; retired карта не переигрывается
     // (баг-репорт: дубль звука после «Уже знаю»). Пересоздание слайдов
     // без смены карты (полный rebuild slides.set) тоже молчит.
+    // Тот же канал, что и автозвук обычного урока (speak_word): сначала
+    // CDN pitch-аудио файла, TTS — только fallback (юзер-репорт: в
+    // знакомстве звучал TTS вместо аудиофайла).
     let is_muted =
         use_context::<super::lesson_state::LessonContext>().map(|lesson_ctx| lesson_ctx.is_muted);
     let autoplay_card_id = Memo::new(move |_| {
@@ -456,7 +469,7 @@ fn PresentationBody(ctx: AcquaintanceContext) -> impl IntoView {
             .find(|slide| slide.card_id() == card_id)
             .and_then(|slide| slide.word().map(str::to_string));
         if let Some(word) = word {
-            speak_word_immediate(&word, 1.0);
+            speak_word(&word, 1.0);
         }
     });
 
@@ -840,11 +853,22 @@ fn ActionBar(ctx: AcquaintanceContext) -> impl IntoView {
 
     // Space = «Дальше» в показе (спека §8.3).
     let kb_ctx = StoredValue::new(ctx.clone());
+    // Окно финиша (все карты выведены, рука закрывается): кнопки показа
+    // скрыты, Space не листает — иначе advance при пустой активной руке
+    // уводил бы в пустую тренировку поверх ждущего экрана завершения.
+    let hand_finishing = Signal::derive(move || {
+        let ctx = kb_ctx.get_value();
+        ctx.state.with(|state| state.hand_finishing)
+    });
     let _ = use_event_listener(document(), leptos::ev::keydown, move |ev| {
         if is_typing_target(ev.target().as_ref()) {
             return;
         }
-        let stage = kb_ctx.get_value().state.get().stage;
+        let ctx = kb_ctx.get_value();
+        if ctx.state.with_untracked(|state| state.hand_finishing) {
+            return;
+        }
+        let stage = ctx.state.get().stage;
         if resolve_key_action(stage, false, &ev.key()) == Some(AcquaintanceKeyAction::Advance) {
             ev.prevent_default();
             advance.run(());
@@ -856,24 +880,28 @@ fn ActionBar(ctx: AcquaintanceContext) -> impl IntoView {
             class="mt-4 flex items-center justify-between gap-3"
             data-testid="acquaintance-action-bar"
         >
-            <Button
-                variant=Signal::derive(|| ButtonVariant::Ghost)
-                on_click=Callback::new(move |_| confirm_open.set(true))
-                test_id=Signal::derive(|| "acquaintance-know-btn".to_string())
-            >
-                {t!(i18n, acquaintance.already_know)}
-            </Button>
+            <Show when=move || !hand_finishing.get()>
+                <Button
+                    variant=Signal::derive(|| ButtonVariant::Ghost)
+                    on_click=Callback::new(move |_| confirm_open.set(true))
+                    test_id=Signal::derive(|| "acquaintance-know-btn".to_string())
+                >
+                    {t!(i18n, acquaintance.already_know)}
+                </Button>
+            </Show>
 
-            <Button
-                variant=Signal::derive(|| ButtonVariant::Filled)
-                on_click=Callback::new(move |_| advance.run(()))
-                test_id=Signal::derive(|| "acquaintance-next-btn".to_string())
-            >
-                <span>{t!(i18n, lesson.next)}</span>
-                <span class="kbd-hint text-[var(--fg-light)]">
-                    {t!(i18n, lesson.space_key)}
-                </span>
-            </Button>
+            <Show when=move || !hand_finishing.get()>
+                <Button
+                    variant=Signal::derive(|| ButtonVariant::Filled)
+                    on_click=Callback::new(move |_| advance.run(()))
+                    test_id=Signal::derive(|| "acquaintance-next-btn".to_string())
+                >
+                    <span>{t!(i18n, lesson.next)}</span>
+                    <span class="kbd-hint text-[var(--fg-light)]">
+                        {t!(i18n, lesson.space_key)}
+                    </span>
+                </Button>
+            </Show>
         </div>
 
         <ConfirmModal

--- a/origa_ui/src/pages/lesson/lesson_wasm_tests.rs
+++ b/origa_ui/src/pages/lesson/lesson_wasm_tests.rs
@@ -1185,6 +1185,242 @@ mod acquaintance_training {
         }
     }
 
+    /// Внедряет настоящую таблицу стилей приложения в страницу теста:
+    /// wasm-тесты бегут в bare-HTML без dist-CSS, а computed-стили
+    /// (`.front-dimmed` + `:has(.kanji-popup)`) браузер считает только по
+    /// загруженному CSS. `@tailwind`-директивы браузер пропускает как
+    /// неизвестные at-правила — остальной CSS применяется.
+    fn inject_app_stylesheet() {
+        let doc = document();
+        let head = doc.head().expect("test page has a <head>");
+        if head
+            .query_selector("style[data-app-css]")
+            .expect("querySelector on <head>")
+            .is_some()
+        {
+            return;
+        }
+        let style = doc.create_element("style").expect("<style> creates");
+        style.set_attribute("data-app-css", "").expect("attr sets");
+        style.set_text_content(Some(include_str!("../../../input.css")));
+        head.append_child(&style).expect("<style> appends");
+    }
+
+    fn computed_opacity(el: &web_sys::Element) -> String {
+        web_sys::window()
+            .expect("window in browser test")
+            .get_computed_style(el)
+            .expect("getComputedStyle resolves")
+            .expect("element has a computed style")
+            .get_property_value("opacity")
+            .expect("opacity is a string")
+    }
+    /// Тултип кандзи на приглушённом вопросе (сторона ответа) обязан быть
+    /// непрозрачным: opacity обёртки снимается, пока тултип открыт
+    /// (`.front-dimmed:has(.kanji-popup)`). Регресс — возврат к голому
+    /// `opacity-60` на обёртке: тогда каскад приглушал и тултип.
+    #[wasm_bindgen_test]
+    async fn answered_front_dim_lifts_while_kanji_tooltip_open() {
+        // Arrange: настоящий CSS + мини-кандзи-словарь для тултипа
+        inject_app_stylesheet();
+        origa::dictionary::kanji::init_kanji(origa::dictionary::kanji::KanjiData {
+            kanji_json: r#"{"kanji":[{"kanji":"私","jlpt":"N5","used_in":100,"description_ru":["я, личное местоимение"],"description_en":[],"radicals":["禾"],"popular_words":[],"on_readings":["シ"],"kun_readings":["わた"]}]}"#.to_string(),
+        })
+        .expect("mini kanji dict");
+
+        let ctx = acq_context(AcquaintanceStage::Training);
+        let card_id = Ulid::new();
+        ctx.state.update(|state| {
+            state.hand = Some(
+                origa::domain::AcquaintanceHand::new(vec![(
+                    card_id,
+                    origa::domain::CardType::Vocabulary,
+                )])
+                .unwrap(),
+            )
+        });
+        ctx.slides.set(vec![AcquaintanceSlideData::Vocabulary {
+            card_id,
+            word: "私".to_string(),
+            pos_label: None,
+            translations: vec!["я".to_string()],
+        }]);
+
+        let wrapper = create_wrapper();
+        let c2 = ctx.clone();
+        mount_with_i18n(&wrapper, move || {
+            provide_context(c2.clone());
+            view! { <TrainingBody ctx=c2.clone() /> }.into_any()
+        });
+        tick().await;
+
+        // Act: раскрыть ответ — фронт приглушён.
+        wrapper
+            .query_selector("[data-testid=\"acquaintance-reveal-btn\"]")
+            .unwrap()
+            .unwrap()
+            .dyn_into::<web_sys::HtmlElement>()
+            .unwrap()
+            .click();
+        tick().await;
+
+        let front_wrap = wrapper
+            .query_selector(".front-dimmed")
+            .expect("querySelector works")
+            .expect("после раскрытия фронт приглушён классом front-dimmed");
+        assert_eq!(
+            computed_opacity(&front_wrap),
+            "0.6",
+            "вопрос на стороне ответа приглушён"
+        );
+
+        // Открыть тултип кандзи кликом — приглушение снимается.
+        wrapper
+            .query_selector("[data-testid=\"acquaintance-training-front\"] .kanji-char-hover")
+            .unwrap()
+            .unwrap()
+            .dyn_into::<web_sys::HtmlElement>()
+            .unwrap()
+            .click();
+        tick().await;
+
+        assert!(
+            wrapper.query_selector(".kanji-popup").unwrap().is_some(),
+            "клик по кандзи открывает тултип"
+        );
+        assert_eq!(
+            computed_opacity(&front_wrap),
+            "1",
+            "открытый тултип снимает приглушение обёртки — сам тултип непрозрачен"
+        );
+
+        // Закрыть тултип повторным кликом — приглушение возвращается.
+        wrapper
+            .query_selector("[data-testid=\"acquaintance-training-front\"] .kanji-char-hover")
+            .unwrap()
+            .unwrap()
+            .dyn_into::<web_sys::HtmlElement>()
+            .unwrap()
+            .click();
+        tick().await;
+
+        assert!(
+            wrapper.query_selector(".kanji-popup").unwrap().is_none(),
+            "повторный клик закрывает тултип"
+        );
+        assert_eq!(
+            computed_opacity(&front_wrap),
+            "0.6",
+            "закрытый тултип возвращает приглушение вопроса"
+        );
+    }
+
+    /// Финальный ответ тренировки (HandCompleted) замораживает отвеченную
+    /// карту до монтирования экрана завершения: ответ остаётся на экране
+    /// (без «лишнего вопроса»), кнопки рейтинга/раскрытия скрыты — окно
+    /// финиша закрывается только экраном «Знакомство завершено».
+    /// Одновременно guards от remount-регрессий: обновление состояния
+    /// финиша не должно перемонтировать дерево тренировки.
+    #[wasm_bindgen_test]
+    async fn final_answer_freezes_answered_card_until_completion_screen() {
+        // Arrange: рука из одного кандзи (критерий — 3 «помню»)
+        let ctx = acq_context(AcquaintanceStage::Training);
+        let card_id = Ulid::new();
+        ctx.state.update(|state| {
+            state.hand = Some(
+                origa::domain::AcquaintanceHand::new(vec![(
+                    card_id,
+                    origa::domain::CardType::Kanji,
+                )])
+                .unwrap(),
+            )
+        });
+        ctx.slides.set(vec![AcquaintanceSlideData::Kanji {
+            card_id,
+            kanji: "明".to_string(),
+            name: "свет".to_string(),
+            radicals: None,
+            example_words: None,
+            on_readings: None,
+            kun_readings: None,
+        }]);
+
+        let wrapper = create_wrapper();
+        let c2 = ctx.clone();
+        mount_with_i18n(&wrapper, move || {
+            provide_context(c2.clone());
+            view! { <div><AcquaintanceHeaderStrip /><AcquaintanceView /></div> }.into_any()
+        });
+        tick().await;
+
+        // Act: три «помню» — третья закрывает руку (HandCompleted).
+        for _ in 0..3 {
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-reveal-btn\"]")
+                .unwrap()
+                .unwrap()
+                .dyn_into::<web_sys::HtmlElement>()
+                .unwrap()
+                .click();
+            tick().await;
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-rating-remember\"]")
+                .unwrap()
+                .unwrap()
+                .dyn_into::<web_sys::HtmlElement>()
+                .unwrap()
+                .click();
+            tick().await;
+        }
+
+        // Assert: окно финиша — отвеченная карта заморожена, лишнего
+        // вопроса нет, кнопки скрыты.
+        assert!(
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-training-answer\"]")
+                .unwrap()
+                .is_some(),
+            "финальный ответ остаётся на экране — «лишнего вопроса» нет"
+        );
+        assert!(
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-rating-remember\"]")
+                .unwrap()
+                .is_none(),
+            "кнопки рейтинга скрыты в окне финиша"
+        );
+        assert!(
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-reveal-btn\"]")
+                .unwrap()
+                .is_none(),
+            "кнопка раскрытия скрыта в окне финиша"
+        );
+
+        // Персистенция (IDB-макротаск) завершает руку — экран завершения
+        // сменяет замороженную карту (фикс #462: сейв до Completed).
+        let mut persisted = false;
+        for _ in 0..100 {
+            if ctx.state.get_untracked().stage == AcquaintanceStage::Completed {
+                persisted = true;
+                break;
+            }
+            tick().await;
+            gloo_timers::future::TimeoutFuture::new(10).await;
+        }
+        assert!(
+            persisted,
+            "persistence poll exhausted (~1s): stage never reached Completed"
+        );
+        assert!(
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-completed\"]")
+                .unwrap()
+                .is_some(),
+            "экран «Знакомство завершено» сменил замороженную карту"
+        );
+    }
+
     #[wasm_bindgen_test]
     async fn training_answer_keeps_the_question_visible() {
         // Arrange: тренировка одного слова
@@ -1940,7 +2176,65 @@ mod acquaintance_presentation {
     }
 
     #[wasm_bindgen_test]
-    async fn header_shows_audio_button_and_pos_tag_for_word_slide() {
+    async fn header_strip_has_no_audio_button_only_progress_strip() {
+        // Arrange: слайд слова — кнопка озвучки существует, но живёт в
+        // ряду тегов карточки, а не в стрипе хедера (баг-репорт: кнопка
+        // у полосы меняла её ширину — полоса прыгала между картами).
+        let ctx = acq_context(AcquaintanceStage::Presentation);
+        let card_id = Ulid::new();
+        ctx.state.update(|state| {
+            state.hand = Some(hand_of(card_id, origa::domain::CardType::Vocabulary))
+        });
+        ctx.slides.set(vec![AcquaintanceSlideData::Vocabulary {
+            card_id,
+            word: "読む".to_string(),
+            pos_label: None,
+            translations: vec!["читать".to_string()],
+        }]);
+
+        // Act
+        let wrapper = create_wrapper();
+        let c2 = ctx.clone();
+        mount_with_i18n(&wrapper, move || {
+            provide_context(c2.clone());
+            view! {
+                <div>
+                    <div data-testid="test-acq-header-strip"><AcquaintanceHeaderStrip /></div>
+                    <AcquaintanceView />
+                </div>
+            }
+            .into_any()
+        });
+        tick().await;
+
+        // Assert: кнопка есть, но НЕ в стрипе хедера — стрип содержит
+        // только полосу руки.
+        let strip = wrapper
+            .query_selector("[data-testid=\"test-acq-header-strip\"]")
+            .unwrap()
+            .unwrap();
+        assert!(
+            strip
+                .query_selector("[data-testid=\"acquaintance-audio-btn\"]")
+                .unwrap()
+                .is_none(),
+            "в стрипе хедера только полоса — кнопка озвучки там не живёт"
+        );
+        let view_root = wrapper
+            .query_selector("[data-testid=\"acquaintance-view\"]")
+            .unwrap()
+            .unwrap();
+        assert!(
+            view_root
+                .query_selector("[data-testid=\"acquaintance-audio-btn\"]")
+                .unwrap()
+                .is_some(),
+            "кнопка озвучки в ряду тегов карточки"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn tags_row_shows_audio_button_and_pos_tag_for_word_slide() {
         // Arrange: слайд слова с частью речи
         let ctx = acq_context(AcquaintanceStage::Presentation);
         let card_id = Ulid::new();
@@ -1963,13 +2257,13 @@ mod acquaintance_presentation {
         });
         tick().await;
 
-        // Assert: кнопка озвучки в шапке (рядом с полосой) и POS-тег
+        // Assert: кнопка озвучки в ряду тегов карточки и POS-тег
         assert!(
             wrapper
                 .query_selector("[data-testid=\"acquaintance-audio-btn\"]")
                 .unwrap()
                 .is_some(),
-            "кнопка озвучки слова в шапке"
+            "кнопка озвучки слова в ряду тегов"
         );
         let pos_tag = wrapper
             .query_selector("[data-testid=\"acquaintance-pos-tag\"]")
@@ -1987,7 +2281,7 @@ mod acquaintance_presentation {
     }
 
     #[wasm_bindgen_test]
-    async fn header_audio_button_hidden_on_kanji_slide() {
+    async fn tags_row_audio_button_hidden_on_kanji_slide() {
         // Arrange
         let ctx = acq_context(AcquaintanceStage::Presentation);
         let card_id = Ulid::new();

--- a/origa_ui/src/pages/lesson/training_view.rs
+++ b/origa_ui/src/pages/lesson/training_view.rs
@@ -9,7 +9,7 @@ use super::keyboard_handler::is_typing_target;
 use crate::i18n::*;
 use crate::ui_components::{
     Button, ButtonVariant, FuriganaText, MarkdownText, MarkdownVariant, ReadingGroup,
-    is_speech_supported, speak_word, speak_word_immediate,
+    is_speech_supported, speak_word,
 };
 use leptos::prelude::*;
 use leptos_use::use_event_listener;
@@ -17,19 +17,27 @@ use origa::domain::{AcquaintanceSubphase, AnswerOutcome, NativeLanguage};
 use ulid::Ulid;
 
 /// Раскрытие ответа: и кнопка, и Space ведут себя одинаково.
+/// Окно финиша руки (hand_finishing) игнорируется: карта уже отвечена,
+/// повторное раскрытие невозможно.
 fn do_reveal(
     ctx_stored: &StoredValue<AcquaintanceContext>,
     current_id: &Memo<Ulid>,
     showing_answer: &RwSignal<bool>,
 ) {
+    let ctx = ctx_stored.get_value();
+    if ctx.state.with_untracked(|state| state.hand_finishing) {
+        return;
+    }
     showing_answer.set(true);
     let card_id = current_id.get_untracked();
     if !card_id.is_nil() {
-        speak_reverse_answer(&ctx_stored.get_value(), card_id);
+        speak_reverse_answer(&ctx, card_id);
     }
 }
 
 /// Запись ответа: и кнопки [1]/[2], и клавиши 1/2 ведут себя одинаково.
+/// Окно финиша руки (hand_finishing) игнорируется — защита от двойного
+/// клика/клавиши до монтирования экрана завершения.
 fn do_rate(
     ctx_stored: &StoredValue<AcquaintanceContext>,
     current_id: &Memo<Ulid>,
@@ -38,23 +46,20 @@ fn do_rate(
     training_order: &RwSignal<Vec<Ulid>>,
     remembered: bool,
 ) {
-    let outcome = record_on_hand(
-        &ctx_stored.get_value(),
-        current_id.get_untracked(),
-        remembered,
-    );
+    let ctx = ctx_stored.get_value();
+    if ctx.state.with_untracked(|state| state.hand_finishing) {
+        return;
+    }
+    let outcome = record_on_hand(&ctx, current_id.get_untracked(), remembered);
     finish_answer(
-        &ctx_stored.get_value(),
+        &ctx,
         showing_answer,
         rotation_index,
         training_order,
         outcome,
     );
     // Шапке нужен тип новой текущей карты (тег типа).
-    ctx_stored
-        .get_value()
-        .current_card
-        .set(current_id.get_untracked().non_nil());
+    ctx.current_card.set(current_id.get_untracked().non_nil());
 }
 
 /// Fisher–Yates поверх xorshift64; источник энтропии — случайные биты
@@ -123,6 +128,9 @@ pub fn TrainingBody(ctx: AcquaintanceContext) -> impl IntoView {
     // молчит при перезапусках рендер-замыкания с той же картой (запись
     // ответа, пересборка slides), звучит только новой карте. Reverse
     // озвучивается при раскрытии ответа (speak_reverse_answer).
+    // Тот же канал, что и автозвук обычного урока (speak_word): сначала
+    // CDN pitch-аудио файла, TTS — только fallback (юзер-репорт: в
+    // знакомстве звучал TTS вместо аудиофайла).
     let is_muted =
         use_context::<super::lesson_state::LessonContext>().map(|lesson_ctx| lesson_ctx.is_muted);
     let autoplay_ctx = ctx_stored;
@@ -153,7 +161,7 @@ pub fn TrainingBody(ctx: AcquaintanceContext) -> impl IntoView {
             .find(|slide| slide.card_id() == card_id)
             .and_then(|slide| slide.word().map(str::to_string));
         if let Some(word) = word {
-            speak_word_immediate(&word, 1.0);
+            speak_word(&word, 1.0);
         }
     });
 
@@ -164,7 +172,8 @@ pub fn TrainingBody(ctx: AcquaintanceContext) -> impl IntoView {
         .current_card
         .set(current_id.get_untracked().non_nil());
 
-    // Клавиатура: те же хендлы, что у кнопок (спека §8.3).
+    // Клавиатура: те же хендлы, что у кнопок (спека §8.3). Гейты окна
+    // финиша — внутри do_reveal/do_rate.
     let handle_keydown = {
         let c = ctx_stored;
         create_acquaintance_keyboard_handler(
@@ -197,6 +206,12 @@ pub fn TrainingBody(ctx: AcquaintanceContext) -> impl IntoView {
         handle_keydown(ev);
     });
 
+    // Окно финиша: кнопки ухода со слайда скрыты, пока рука закрывается.
+    let hand_finishing = Signal::derive(move || {
+        let ctx = ctx_stored.get_value();
+        ctx.state.with(|state| state.hand_finishing)
+    });
+
     view! {
         <div
             class="flex flex-col grow"
@@ -221,10 +236,13 @@ pub fn TrainingBody(ctx: AcquaintanceContext) -> impl IntoView {
                     // Вопрос остаётся на стороне ответа — уменьшенным и
                     // приглушённым сверху, под ним divider и ответ
                     // (паттерн обычного урока, lesson_card_answer).
+                    // Приглушение — семантический класс front-dimmed, не
+                    // tailwind opacity-60: голая opacity каскадировала в
+                    // тултип кандзи и делала его полупрозрачным.
                     view! {
                         <div
                             class=move || if showing_answer.get() {
-                                "pt-1 pb-2 opacity-60 scale-90 origin-top"
+                                "pt-1 pb-2 scale-90 origin-top front-dimmed"
                             } else {
                                 ""
                             }
@@ -250,7 +268,7 @@ pub fn TrainingBody(ctx: AcquaintanceContext) -> impl IntoView {
                     .into_any()
                 }}
             </div>
-            <Show when=move || !showing_answer.get() fallback=move || ()>
+            <Show when=move || !showing_answer.get() && !hand_finishing.get() fallback=move || ()>
                 <div class="flex justify-center">
                     <Button
                         variant=Signal::derive(|| ButtonVariant::Filled)
@@ -264,7 +282,7 @@ pub fn TrainingBody(ctx: AcquaintanceContext) -> impl IntoView {
                     </Button>
                 </div>
             </Show>
-            <Show when=move || showing_answer.get() fallback=move || ()>
+            <Show when=move || showing_answer.get() && !hand_finishing.get() fallback=move || ()>
                 <div class="mt-4 grid grid-cols-2 gap-3">
                     <Button
                         variant=Signal::derive(|| ButtonVariant::Default)
@@ -400,12 +418,17 @@ fn finish_answer(
     training_order: &RwSignal<Vec<Ulid>>,
     outcome: AnswerOutcome,
 ) {
-    showing_answer.set(false);
-
+    // Финальный ответ: рука закрывается. Отвеченная карта ОСТАЁТСЯ на
+    // экране (showing_answer не сбрасывается) — без этого фронт того же
+    // слова пере-показывался «лишним вопросом», пока идёт запись и до
+    // монтирования экрана завершения (юзер-репорт о резком переходе).
+    // Кнопки и клавиатура гасятся флагом hand_finishing.
     if matches!(outcome, AnswerOutcome::HandCompleted) {
         ctx.complete_hand();
         return;
     }
+
+    showing_answer.set(false);
 
     let prev_last = training_order.get_untracked().last().copied();
     let mut action = AfterAnswerAction::NextCard { reshuffled: false };

--- a/origa_ui/src/ui_components/mod.rs
+++ b/origa_ui/src/ui_components/mod.rs
@@ -147,7 +147,5 @@ pub use toast::{ToastContainer, ToastData, ToastType};
 pub use tooltip::{Tooltip, TooltipPlacementMode};
 pub use typography::{DisplayText, Heading, HeadingLevel, Text, TextSize, TypographyVariant};
 pub use update_drawer::UpdateDrawer;
-pub use word_audio::{
-    register_audio, speak_word, speak_word_immediate, speak_word_with_callback, stop_current_audio,
-};
+pub use word_audio::{register_audio, speak_word, speak_word_with_callback, stop_current_audio};
 pub use word_translations::WordTranslations;

--- a/origa_ui/src/ui_components/word_audio.rs
+++ b/origa_ui/src/ui_components/word_audio.rs
@@ -175,37 +175,6 @@ pub fn speak_word(word: &str, rate: f32) {
     schedule_word_audio_play::<fn()>(word, rate, None);
 }
 
-/// Автозвук показа: звучит НЕМЕДЛЕННО — закэшированное CDN-аудио или
-/// TTS; сетевой prefetch не блокирует старт (первый показ слова раньше
-/// ждал round-trip CDN — заметная задержка после отрисовки карточки).
-/// Параллельно кэш греется фоном, чтобы кнопка повтора уже играла
-/// CDN-аудио.
-pub fn speak_word_immediate(word: &str, rate: f32) {
-    if word.is_empty() {
-        return;
-    }
-    let Some(path) = lookup_audio_path(word) else {
-        speak_word(word, rate);
-        return;
-    };
-    if crate::repository::cdn_provider::get_cached_blob_url(&path).is_some() {
-        // Кэш горячий: CDN-аудио стартует мгновенно.
-        speak_word(word, rate);
-        return;
-    }
-    // Холодный кэш: TTS сейчас, prefetch — фоном для следующих разов.
-    let path_owned = path.to_string();
-    let word_owned = word.to_string();
-    spawn_local(async move {
-        if let Err(e) = crate::repository::cdn_provider::prefetch_blob_url(&path_owned).await {
-            tracing::debug!(word = %word_owned, error = ?e, "background audio warmup failed");
-        }
-    });
-    stop_current_audio();
-    let reading = extract_japanese_text(&get_reading_from_text(word));
-    let _ = speak_tts_text(&reading, rate);
-}
-
 pub fn speak_word_with_callback<F>(word: &str, rate: f32, on_end: F)
 where
     F: FnMut() + 'static,

--- a/scripts/remap_duolingo_spy_levels.py
+++ b/scripts/remap_duolingo_spy_levels.py
@@ -1,23 +1,24 @@
-"""[DEPRECATED] Diagnostic-only remapper for Duolingo / Spy x Family JLPT levels (#178 S-3).
+"""[DEPRECATED] Diagnostic-only remapper for Spy x Family JLPT levels (#178 S-3).
 
-The canonical source of truth is now `origa_ui/build.rs` (`generate_well_known_meta`),
-which parses the Duolingo Section number from each set title and tags every
-Spy x Family set as N3 when `cdn/well_known_set/well_known_sets_meta.json` is
-generated. `cargo build -p origa_ui` overwrites the meta file, so any manual
-edits made by this script would be discarded on the next build.
+The canonical source of truth is `origa_ui/build.rs` (`generate_well_known_meta`):
+Duolingo levels are copied verbatim from each content file's own `level` field,
+and every Spy x Family set is tagged N3 when
+`cdn/well_known_set/well_known_sets_meta.json` is generated. `cargo build -p
+origa_ui` overwrites the meta file, so any manual edits made by this script
+would be discarded on the next build.
 
-This script is kept as a fallback/diagnostic tool to verify the meta file
-matches the expected Section → level mapping without rebuilding, or to repair
-a stale meta file that was committed before the build.rs fix landed.
-
-Mapping (Duolingo official difficulty progression, validated against the
-content of representative sets):
-    Section 1-2  -> N5  (intro: hiragana, basic greetings, simple copula)
-    Section 3-4  -> N4  (TE-form, conditionals, casual speech)
-    Section 5-6  -> N3  (humble/polite forms, conditionals, abstract topics)
+The Duolingo remapping branch was REMOVED (2026-09): the old title heuristic
+("Section 1-2 -> N5, 3-4 -> N4, 5-6 -> N3") contradicted the corpus ground
+truth carried by the content `level` fields (Section/Module 1-3 -> N5,
+4 -> N4, 5-6 -> N3) and misread RU-series English titles ("Module 5 Section
+16"), dropping 55 sets and mistagging 66. Re-adding it here would fight the
+canonical source. See `origa/tests/well_known_sets_audit.rs` for the guarded
+invariants (completeness + meta level == content level).
 
 Spy x Family content files all carry `level: "N3"` in their own metadata
-(verified across all 12 episodes); the meta file simply wasn't synced.
+(verified across all 12 episodes); this script remains a fallback/diagnostic
+tool to verify or repair a stale Spy tagging in the meta file without
+rebuilding.
 
 Run:
     python scripts/remap_duolingo_spy_levels.py --cdn cdn
@@ -28,21 +29,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
 from _cdn_io import atomic_write_json
 
-SECTION_RE = re.compile(r"(?:Section|Модуль)\s+(\d+)", re.IGNORECASE)
-SECTION_TO_LEVEL: dict[int, str] = {
-    1: "N5",
-    2: "N5",
-    3: "N4",
-    4: "N4",
-    5: "N3",
-    6: "N3",
-}
 SPY_FAMILY_LEVEL = "N3"
 
 
@@ -61,20 +52,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def derive_duolingo_level(title_en: str, title_ru: str) -> str | None:
-    blob = f"{title_en} {title_ru}"
-    m = SECTION_RE.search(blob)
-    if not m:
-        return None
-    section = int(m.group(1))
-    return SECTION_TO_LEVEL.get(section)
-
-
-def is_duolingo(record: dict) -> bool:
-    set_type = record.get("set_type", "")
-    return set_type in {"DuolingoEn", "DuolingoRu"}
-
-
 def is_spy_family(record: dict) -> bool:
     return record.get("set_type") == "SpyFamily"
 
@@ -89,55 +66,26 @@ def main() -> int:
     with open(meta_path, encoding="utf-8") as f:
         records = json.load(f)
 
-    duolingo_changes: list[tuple[str, str, str]] = []
     spy_changes: list[tuple[str, str, str]] = []
-    skipped_no_section: list[str] = []
 
     for record in records:
         rid = record.get("id", "?")
         old_level = record.get("level")
 
-        if is_duolingo(record):
-            new_level = derive_duolingo_level(
-                record.get("title_en", "") or "",
-                record.get("title_ru", "") or "",
-            )
-            if new_level is None:
-                skipped_no_section.append(rid)
-                continue
-            if new_level != old_level:
-                record["level"] = new_level
-                duolingo_changes.append((rid, old_level, new_level))
-        elif is_spy_family(record):
+        if is_spy_family(record):
             if SPY_FAMILY_LEVEL != old_level:
                 record["level"] = SPY_FAMILY_LEVEL
                 spy_changes.append((rid, old_level, SPY_FAMILY_LEVEL))
 
-    print(f"Duolingo updates: {len(duolingo_changes)}")
-    by_change: dict[tuple[str, str], int] = {}
-    for _, old, new in duolingo_changes:
-        by_change[(old, new)] = by_change.get((old, new), 0) + 1
-    for (old, new), count in sorted(by_change.items()):
-        print(f"  {old} -> {new}: {count}")
-
-    print(f"\nSpy x Family updates: {len(spy_changes)}")
+    print(f"Spy x Family updates: {len(spy_changes)}")
     for rid, old, new in spy_changes[:5]:
         print(f"  [{rid}] {old} -> {new}")
     if len(spy_changes) > 5:
         print(f"  ... and {len(spy_changes) - 5} more")
 
-    if skipped_no_section:
-        print(
-            f"\nWARNING: {len(skipped_no_section)} Duolingo sets with no Section/Модуль in title — left unchanged"
-        )
-        for rid in skipped_no_section[:5]:
-            print(f"  {rid}")
-
-    if not args.dry_run and (duolingo_changes or spy_changes):
+    if not args.dry_run and spy_changes:
         atomic_write_json(meta_path, records)
-        print(
-            f"\nWrote {len(duolingo_changes) + len(spy_changes)} updates to {meta_path}"
-        )
+        print(f"\nWrote {len(spy_changes)} updates to {meta_path}")
     elif args.dry_run:
         print("\n--dry-run: no files modified.")
     else:


### PR DESCRIPTION
## Summary

Batch of six user-reported bug fixes: four acquaintance-mode UX issues, the Duolingo set JLPT distribution, and a dictionary casing defect. CDN data changes are **already deployed** (dictionary chunks, regenerated `vocabulary.rkyv`, `well_known_sets_meta.json`; remote manifest verified in sync).

## Fixes

### 1. Duolingo sets: wrong JLPT distribution, lessons/modules mixed up
`origa_ui/build.rs` derived the level from the first `Section`/`Модуль` token of the EN+RU title blob. RU-series English titles carry **both** tokens (`Module 5 Section 16`), so the parser read the sub-unit number: **55 sets were silently dropped** (unit number > 6) and **66 sets were tagged with their unit's level** instead of their module's (e.g. `Модуль 5 Раздел 1` tagged N5 while its content is N3).

Levels now come verbatim from each content file's own `level` field (corpus ground truth: Section/Модуль 1-3 → N5, 4 → N4, 5-6 → N3; 451/451 files self-consistent). Empty/invalid level → skip + `cargo:warning`, same as before.

The audit test (`well_known_sets_audit.rs`) was rewritten TDD-style to guard the real invariants: **completeness** (every content file present in meta) and **fidelity** (meta level == content level ∈ {N5,N4,N3}). It was red against the pre-fix meta (121 problems) and is green after the fix. The deprecated remap script lost its Duolingo branch (Spy-only; its old 3-4→N4 mapping contradicted the corpus).

### 2. 米 translation casing (`сША`)
Spot-fix of the mixed-case initialism class in RU translations (first letter lowercase, rest uppercase — a corpus title-casing artifact): `сША/сМИ/нПС/пЗУ/гЧП/иЗО/кПД/пИН/кПП/аБВ/гАМК` → all-caps across 8 chunk files (16 entries), plus the USA family from the report (`米`, `米国`, `米ソ`, `アメリカ`, `スターズ・アンド・ストライプス`; EN `united States (of America)` → `United States (of America)`). Only tokens whose norm is all-caps were touched; `vocabulary.rkyv` regenerated and deployed.

**NOTICED BUT NOT TOUCHING** (out of scope, separate class defects): fully-lowercase RU abbreviations (`сша` in dozens of entries like `全米`, `対米`, `米軍`) and broken EN titlecasing (`san Jose`, `new York`, …). Auto-capitalizing proper nouns corpus-wide is risky (JMdict uses lowercase deliberately); needs a dedicated pass.

### 3. Acquaintance Play button jumped the progress strip
The audio button lived in the lesson header next to `HandProgressStrip`; its show/hide (Reverse front hides it) resized the strip between cards. Moved to the tags row right edge (`ml-auto`) — the same `AudioButtons` component and placement as the regular lesson's `LessonCardTags`. The header strip now renders only the progress strip.

Behavior note: the button now has an `is_playing` state (pause icon, disabled while playing) — identical to the regular lesson, which is the point of the fix.

### 4. Acquaintance autoplay sounded like TTS instead of the audio file
Presentation/training Forward autoplay used `speak_word_immediate`, which plays TTS whenever the CDN blob cache is cold — and acquaintance words are new by definition, so the cache is always cold. Both call sites now use `speak_word` (CDN pitch-audio file first, TTS only as fallback), identical to the regular lesson. `speak_word_immediate` is removed.

Accepted trade-off: the first autoplay of a word may wait for the CDN prefetch round-trip (same as the regular lesson card); repeats play instantly from cache.

### 5. Kanji tooltip on the answered training side was semi-transparent
The dimmed question wrapper used a raw `opacity-60`, which cascades into every DOM descendant — including `.kanji-popup`. Replaced with the semantic `.front-dimmed` class plus a `:has(.kanji-popup)` rule that lifts the dim while the tooltip is open. Covered by a wasm test that injects the **real** stylesheet (`include_str!` of `input.css`) and asserts computed wrapper opacity `0.6 → 1 → 0.6` across tooltip open/close (the bare wasm-test page has no CSS, so plain computed-style assertions would be false-green).

### 6. "Знакомство завершено" appeared abruptly over an extra question
The final training answer reset `showing_answer` before the async hand completion, so the same card re-asked as a phantom question until the Completed card snapped in. New `hand_finishing` state flag is set **synchronously** by `complete_hand()`:
- the answered card stays frozen on screen (no phantom question);
- rating/reveal buttons, presentation «Дальше»/«Уже знаю», and their keyboard handlers are gated (both `complete_hand` call paths covered);
- the completion card enters with `anima-page-fade`.

The persistence-first design (save before `Completed`, bug #462 protection) is preserved. e2e helper `answerTrainingRating` recognizes the finishing window (answer visible, rating hidden) and waits for the final screen instead of re-clicking the frozen card.

## Verification

| Check | Result |
| --- | --- |
| `cargo fmt --check` | ✅ |
| `cargo clippy -p origa -p origa_ui --all-targets -- -D warnings` | ✅ |
| `cargo test -p origa -p origa_ui` (host, 2242 tests) | ✅ |
| `wasm-pack test --headless --chrome origa_ui --features csr` (289 tests, incl. 5 new/rewritten) | ✅ |
| `tsc --noEmit` (end2end) | ✅ |
| `qlty check` | ✅ |
| `cargo test -p origa --test well_known_sets_audit` | ✅ (red→green TDD) |
| CDN deploy + remote manifest byte-verified | ✅ |

Note: the dictionary fix (米) is not exercised by e2e — the CI CDN cache key is not content-sensitive for chunks; verified via deploy diff + remote byte comparison instead.

## Docs DoD check

`/docs/*` pages were checked against the changed behavior: no documented claims are affected (the hand strip stays in the header, word audio narration is still true, Duolingo level mapping is not documented).