### PR TITLE
fix(acquaintance): reset finishing window on lesson reload (review follow-up to #498)

### DIFF
--- a/origa/tests/well_known_sets_audit.rs
+++ b/origa/tests/well_known_sets_audit.rs
@@ -115,6 +115,7 @@ fn duolingo_content_levels() -> Option<Vec<(String, String)>> {
                 .get("level")
                 .and_then(|v| v.as_str())
                 .unwrap_or_default()
+                .trim()
                 .to_string();
             records.push((set_id, level));
         }
@@ -141,6 +142,8 @@ fn duolingo_sets_match_content_level_and_are_complete() {
     );
 
     let mut problems: Vec<String> = Vec::new();
+    let content_ids: std::collections::HashSet<&str> =
+        content.iter().map(|(set_id, _)| set_id.as_str()).collect();
     for (set_id, content_level) in &content {
         let Some(meta) = by_id.get(set_id.as_str()) else {
             problems.push(format!(
@@ -157,6 +160,17 @@ fn duolingo_sets_match_content_level_and_are_complete() {
             problems.push(format!(
                 "[{set_id}] meta level {:?} != content level {content_level:?}",
                 meta.level
+            ));
+        }
+    }
+
+    // Обратная полнота: каждая duolingo-запись meta соответствует
+    // контент-файлу — стейл-записи (сет удалён из корпуса) не должны
+    // переживать регенерацию.
+    for meta_id in by_id.keys() {
+        if !content_ids.contains(meta_id) {
+            problems.push(format!(
+                "[{meta_id}] meta entry has no duolingo content file (stale record?)"
             ));
         }
     }

--- a/origa_ui/src/pages/lesson/acquaintance_state.rs
+++ b/origa_ui/src/pages/lesson/acquaintance_state.rs
@@ -329,6 +329,7 @@ mod advance_presentation_tests {
         state.stage = AcquaintanceStage::Completed;
         state.slide_index = 1;
         state.hand_finishing = true;
+        state.skipped_ids.insert(Ulid::new());
 
         // Act: reload пишет новую руку в тот же state
         let fresh = state_with_hand(1).hand.take().expect("hand built");

--- a/origa_ui/src/pages/lesson/acquaintance_state.rs
+++ b/origa_ui/src/pages/lesson/acquaintance_state.rs
@@ -68,6 +68,19 @@ pub fn audio_button_visible(
 }
 
 impl AcquaintanceState {
+    /// Ре-инициализация под новую руку: reload урока переиспользует тот же
+    /// state (компонент не размонтируется), поэтому сбрасывать надо КАЖДОЕ
+    /// поле потока. Несброшенный `hand_finishing` прошлой руки ослеплял
+    /// вторую руку сессии — кнопки показа/тренировки и клавиатура
+    /// гейтились навсегда (ревью PR #498).
+    pub fn start_new_hand(&mut self, hand: AcquaintanceHand) {
+        self.stage = AcquaintanceStage::Presentation;
+        self.hand = Some(hand);
+        self.slide_index = 0;
+        self.skipped_ids.clear();
+        self.hand_finishing = false;
+    }
+
     /// Переходит к следующей непомеченной «Уже знаю» карте.
     /// Возвращает `true`, если показ исчерпан (пора в следующую стадию).
     pub fn advance_presentation(&mut self) -> bool {
@@ -304,6 +317,31 @@ mod advance_presentation_tests {
         assert!(!state.advance_presentation());
         assert_eq!(state.slide_index, 1);
         assert!(state.advance_presentation(), "показ исчерпан");
+    }
+
+    /// Reload урока переиспользует тот же state: несброшенное окно финиша
+    /// прошлой руки ослепляло вторую руку сессии (кнопки/клавиатура
+    /// гейтились навсегда) — ревью PR #498.
+    #[test]
+    fn start_new_hand_resets_finishing_window_and_stream_fields() {
+        // Arrange: state закрытой руки — финиш, продвинутый показ, метки
+        let mut state = state_with_hand(2);
+        state.stage = AcquaintanceStage::Completed;
+        state.slide_index = 1;
+        state.hand_finishing = true;
+
+        // Act: reload пишет новую руку в тот же state
+        let fresh = state_with_hand(1).hand.take().expect("hand built");
+        state.start_new_hand(fresh);
+
+        // Assert
+        assert_eq!(state.stage, AcquaintanceStage::Presentation);
+        assert_eq!(state.slide_index, 0);
+        assert!(
+            !state.hand_finishing,
+            "окно финиша прошлой руки снято — кнопки новой руки работают"
+        );
+        assert!(state.skipped_ids.is_empty());
     }
 
     #[test]

--- a/origa_ui/src/pages/lesson/acquaintance_view.rs
+++ b/origa_ui/src/pages/lesson/acquaintance_view.rs
@@ -876,11 +876,13 @@ fn ActionBar(ctx: AcquaintanceContext) -> impl IntoView {
     });
 
     view! {
-        <div
-            class="mt-4 flex items-center justify-between gap-3"
-            data-testid="acquaintance-action-bar"
-        >
-            <Show when=move || !hand_finishing.get()>
+        // Контейнер гейтится целиком: в окне финиша внизу слайда не должна
+        // висеть пустая полоса с отступом (ревью PR #498).
+        <Show when=move || !hand_finishing.get()>
+            <div
+                class="mt-4 flex items-center justify-between gap-3"
+                data-testid="acquaintance-action-bar"
+            >
                 <Button
                     variant=Signal::derive(|| ButtonVariant::Ghost)
                     on_click=Callback::new(move |_| confirm_open.set(true))
@@ -888,9 +890,7 @@ fn ActionBar(ctx: AcquaintanceContext) -> impl IntoView {
                 >
                     {t!(i18n, acquaintance.already_know)}
                 </Button>
-            </Show>
 
-            <Show when=move || !hand_finishing.get()>
                 <Button
                     variant=Signal::derive(|| ButtonVariant::Filled)
                     on_click=Callback::new(move |_| advance.run(()))
@@ -901,8 +901,8 @@ fn ActionBar(ctx: AcquaintanceContext) -> impl IntoView {
                         {t!(i18n, lesson.space_key)}
                     </span>
                 </Button>
-            </Show>
-        </div>
+            </div>
+        </Show>
 
         <ConfirmModal
             test_id=Signal::derive(|| "acquaintance-know-confirm".to_string())

--- a/origa_ui/src/pages/lesson/content.rs
+++ b/origa_ui/src/pages/lesson/content.rs
@@ -253,12 +253,7 @@ pub fn LessonContent() -> impl IntoView {
                             native_language.get_untracked(),
                             &i18n,
                         );
-                        acq_state_signal.update(|state| {
-                            state.stage = AcquaintanceStage::Presentation;
-                            state.hand = Some(hand);
-                            state.slide_index = 0;
-                            state.skipped_ids.clear();
-                        });
+                        acq_state_signal.update(|state| state.start_new_hand(hand));
                         acq_slides_signal.set(slides);
                     }
                 }

--- a/origa_ui/src/pages/lesson/lesson_wasm_tests.rs
+++ b/origa_ui/src/pages/lesson/lesson_wasm_tests.rs
@@ -1421,6 +1421,121 @@ mod acquaintance_training {
         );
     }
 
+    /// Reload урока переиспользует тот же AcquaintanceState (content.rs):
+    /// после Completed окно финиша обязано сниматься — вторая рука сессии
+    /// работает (кнопки показа на месте). Регресс — несброшенный
+    /// hand_finishing ослеплял новую руку (ревью PR #498).
+    #[wasm_bindgen_test]
+    async fn state_reuse_after_completion_recovers_buttons_for_next_hand() {
+        // Arrange: рука №1 — кандзи, критерий 3 «помню»
+        let ctx = acq_context(AcquaintanceStage::Training);
+        let first_card = Ulid::new();
+        ctx.state.update(|state| {
+            state.hand = Some(
+                origa::domain::AcquaintanceHand::new(vec![(
+                    first_card,
+                    origa::domain::CardType::Kanji,
+                )])
+                .unwrap(),
+            )
+        });
+        ctx.slides.set(vec![AcquaintanceSlideData::Kanji {
+            card_id: first_card,
+            kanji: "明".to_string(),
+            name: "свет".to_string(),
+            radicals: None,
+            example_words: None,
+            on_readings: None,
+            kun_readings: None,
+        }]);
+
+        let wrapper = create_wrapper();
+        let c2 = ctx.clone();
+        mount_with_i18n(&wrapper, move || {
+            provide_context(c2.clone());
+            view! { <div><AcquaintanceHeaderStrip /><AcquaintanceView /></div> }.into_any()
+        });
+        tick().await;
+
+        for _ in 0..3 {
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-reveal-btn\"]")
+                .unwrap()
+                .unwrap()
+                .dyn_into::<web_sys::HtmlElement>()
+                .unwrap()
+                .click();
+            tick().await;
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-rating-remember\"]")
+                .unwrap()
+                .unwrap()
+                .dyn_into::<web_sys::HtmlElement>()
+                .unwrap()
+                .click();
+            tick().await;
+        }
+        let mut persisted = false;
+        for _ in 0..100 {
+            if ctx.state.get_untracked().stage == AcquaintanceStage::Completed {
+                persisted = true;
+                break;
+            }
+            tick().await;
+            gloo_timers::future::TimeoutFuture::new(10).await;
+        }
+        assert!(persisted, "рука №1 закрылась");
+        assert!(
+            ctx.state.get_untracked().hand_finishing,
+            "после закрытия руки №1 окно финиша активно"
+        );
+
+        // Act: reload урока — новая рука пишется в тот же state тем же
+        // путём, что и content.rs (start_new_hand).
+        let second_card = Ulid::new();
+        let second_hand = origa::domain::AcquaintanceHand::new(vec![(
+            second_card,
+            origa::domain::CardType::Vocabulary,
+        )])
+        .unwrap();
+        ctx.slides.set(vec![AcquaintanceSlideData::Vocabulary {
+            card_id: second_card,
+            word: "私".to_string(),
+            pos_label: None,
+            translations: vec!["я".to_string()],
+        }]);
+        ctx.state.update(|state| state.start_new_hand(second_hand));
+        tick().await;
+
+        // Assert: префаза руки №2 жива — бар и кнопки показа на месте.
+        assert_eq!(
+            ctx.state.get_untracked().stage,
+            AcquaintanceStage::Presentation,
+            "рука №2 начинается с показа"
+        );
+        assert!(
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-action-bar\"]")
+                .unwrap()
+                .is_some(),
+            "бар действий руки №2 смонтирован (пустой полосы нет)"
+        );
+        assert!(
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-next-btn\"]")
+                .unwrap()
+                .is_some(),
+            "«Дальше» руки №2 доступна — окно финиша снято"
+        );
+        assert!(
+            wrapper
+                .query_selector("[data-testid=\"acquaintance-know-btn\"]")
+                .unwrap()
+                .is_some(),
+            "«Уже знаю» руки №2 доступна"
+        );
+    }
+
     #[wasm_bindgen_test]
     async fn training_answer_keeps_the_question_visible() {
         // Arrange: тренировка одного слова


### PR DESCRIPTION
## Summary

Review follow-up to #498 (squash-merged before this fix landed — auto-merge fired on green CI while the code-review cycle was still running).

## The bug (found by code review of #498)

The new `hand_finishing` flag was never cleared: `AcquaintanceState` is created once per `LessonContent` mount, and a lesson **reload** re-initializes the hand through the same state. A second hand in a session inherited the finished flag — its presentation/training buttons and keyboard handlers stayed gated forever, and the lesson dead-ended on the first slide of hand #2.

## Fix

- `AcquaintanceState::start_new_hand` — single-owner re-initialization resetting **every** stream field, including `hand_finishing`; `content.rs` uses it on reload.
- Host test on the reset + wasm test driving hand #1 to completion, then reloading hand #2 into the same mounted state and asserting the action bar and buttons recover.

## Review Low items (same review, same fix commit)

- Audit trims the content level like `build.rs` does (symmetric contract).
- Audit checks the reverse direction too: every Duolingo meta entry must have a content file (stale records cannot survive regeneration).
- Presentation action bar container is gated as a whole during the finishing window (no empty striped placeholder under the slide).

## Verification

fmt ✅ · clippy `-D warnings` (origa, origa_ui) ✅ · host tests 1736+504 ✅ (incl. new) · wasm-pack 290 ✅ (incl. new state-reuse regression) · audit red→green intact.