### PR TITLE
feat(apple): native Sign in with Apple via ASAuthorizationController (App Review Guideline 4)

### DIFF
--- a/.github/scripts/verify_profile_entitlements.py
+++ b/.github/scripts/verify_profile_entitlements.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Fail-closed check that the provisioning profile GRANTS an entitlement.
+
+The re-sign step merges app entitlements with profile entitlements as a
+silent union — codesign does not validate app entitlements against the
+profile, so a capability forgotten on the App ID (developer.apple.com)
+produces a green build that App Store validation later rejects.
+
+This script re-extracts the profile's own entitlements and fails when a
+required key is not among them, i.e. when the key would only come from the
+app's plist.
+
+Usage:
+    python3 verify_profile_entitlements.py \
+        --profile embedded.provisionprofile \
+        --entitlement com.apple.developer.applesignin
+
+Exit codes:
+    0 — every required entitlement is granted by the profile
+    1 — at least one is missing (printed as a ::error annotation)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from download_macos_profile import extract_profile_entitlements
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assert that required entitlements are granted by the "
+        "provisioning profile itself"
+    )
+    parser.add_argument(
+        "--profile", required=True, help="Path to the .provisionprofile file"
+    )
+    parser.add_argument(
+        "--entitlement",
+        action="append",
+        required=True,
+        help="Entitlement key that must be present in the profile "
+        "(repeatable)",
+    )
+    args = parser.parse_args()
+
+    profile_entitlements = extract_profile_entitlements(args.profile)
+
+    missing = [key for key in args.entitlement if key not in profile_entitlements]
+    if missing:
+        print(
+            f"::error::Entitlement(s) {missing} are NOT granted by the "
+            "provisioning profile. Enable the corresponding capability on "
+            "the App ID at developer.apple.com and let the profile refresh — "
+            "the merge step would silently union these keys into the "
+            "signature and App Store validation would reject the build."
+        )
+        return 1
+
+    print(f"✅ Profile grants: {args.entitlement}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -527,6 +527,14 @@ jobs:
               # plist, the build would stay green, and App Store validation
               # (or the native SIWA sheet at runtime) would reject it. Fail
               # closed instead.
+              #
+              # PREREQUISITE (plan #505 S0): the "Sign in with Apple"
+              # capability must be enabled on App ID net.uwuwu.origa before
+              # this step can pass — until then darwin builds are red BY
+              # DESIGN (safe direction). If an inspection of the real
+              # downloaded profile shows Apple does not embed the key in
+              # MAC_APP_STORE profiles at all, downgrade this step to a
+              # warning per the plan's S0 decision point.
               run: |
                   python3 "$GITHUB_WORKSPACE/.github/scripts/verify_profile_entitlements.py" \
                     --profile "$RUNNER_TEMP/embedded.provisionprofile" \

--- a/.github/workflows/_build-tauri-apple.yml
+++ b/.github/workflows/_build-tauri-apple.yml
@@ -467,13 +467,14 @@ jobs:
                   for KEY in com.apple.security.app-sandbox \
                              com.apple.security.network.client \
                              com.apple.security.device.microphone \
-                             com.apple.security.files.user-selected.read-write; do
+                             com.apple.security.files.user-selected.read-write \
+                             com.apple.developer.applesignin; do
                     if ! grep -q "$KEY" /tmp/entitlements.txt; then
                       echo "::error::Missing entitlement: $KEY"
                       exit 1
                     fi
                   done
-                  echo "✅ All 4 entitlements present"
+                  echo "✅ All 5 entitlements present"
                   rm -f /tmp/entitlements.txt
 
             - name: Embed provisioning profile & re-sign
@@ -516,6 +517,20 @@ jobs:
                     --keychain build.keychain \
                     "$APP_PATH"
                   echo "✅ Re-signed .app with provisioning profile + merged entitlements"
+
+            - name: Verify profile grants Sign in with Apple
+              #
+              # The merge above is a silent union — codesign does not validate
+              # app entitlements against the profile. If the Sign in with
+              # Apple capability is not enabled on the App ID
+              # (developer.apple.com), the key would come only from the app's
+              # plist, the build would stay green, and App Store validation
+              # (or the native SIWA sheet at runtime) would reject it. Fail
+              # closed instead.
+              run: |
+                  python3 "$GITHUB_WORKSPACE/.github/scripts/verify_profile_entitlements.py" \
+                    --profile "$RUNNER_TEMP/embedded.provisionprofile" \
+                    --entitlement com.apple.developer.applesignin
 
             - name: Build .pkg via productbuild
               id: pkg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8983,13 +8983,16 @@ dependencies = [
 name = "tauri-plugin-aswebauth"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "block2",
  "objc2",
  "objc2-app-kit",
  "objc2-authentication-services",
  "objc2-foundation",
+ "rand 0.9.5",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-plugin",
  "tokio",

--- a/end2end/cdn-manifest.txt
+++ b/end2end/cdn-manifest.txt
@@ -1000,5 +1000,5 @@ fonts/ibm-plex-mono-400-81ddc57a.woff2
 fonts/ibm-plex-mono-400-italic-517950ef.woff2
 fonts/ibm-plex-mono-500-da5700a8.woff2
 fonts/noto-sans-jp-400-41a4227e.woff2
-fonts/noto-sans-kr-400-a115590d.woff2
+fonts/noto-sans-kr-400-adffe30e.woff2
 # FONTS-END

--- a/origa_ui/Dockerfile
+++ b/origa_ui/Dockerfile
@@ -114,7 +114,9 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
 # Runtime: TrailBase + SPA static files
 # TEMP: test image carrying the Apple `response_mode=form_post` fix
 # (trailbaseio/trailbase#282) until an upstream release ships it. Based on v0.33.5.
-FROM ghcr.io/yurvon-screamo/trailbase:apple-formpost
+# apple-native: the same fork plus the native Sign in with Apple endpoint
+# (POST /api/auth/v1/oauth/apple/native, App Review Guideline 4, origa#505).
+FROM ghcr.io/yurvon-screamo/trailbase:apple-native
 
 USER root
 WORKDIR /app

--- a/origa_ui/locales/en.json
+++ b/origa_ui/locales/en.json
@@ -394,6 +394,7 @@
     "google_login": "Sign in with Google",
     "yandex_login": "Sign in with Yandex",
     "apple_login": "Sign in with Apple",
+    "apple_email_missing": "Apple did not share your email address for this account. Please sign in via Google, Yandex or email instead.",
     "oauth_session_error": "Could not open the sign-in window: {}",
     "unsupported_callback": "Unsupported callback URL format",
     "login_failed": "Invalid email or password"

--- a/origa_ui/locales/ko.json
+++ b/origa_ui/locales/ko.json
@@ -394,6 +394,7 @@
     "google_login": "Google로 로그인",
     "yandex_login": "Yandex로 로그인",
     "apple_login": "Apple로 로그인",
+    "apple_email_missing": "Apple이 이 계정의 이메일 주소를 공유하지 않았습니다. Google, Yandex 또는 이메일로 로그인해 주세요.",
     "oauth_session_error": "로그인 창을 열 수 없습니다: {}",
     "unsupported_callback": "지원하지 않는 콜백 URL 형식입니다",
     "login_failed": "이메일 또는 비밀번호가 올바르지 않습니다"

--- a/origa_ui/locales/ru.json
+++ b/origa_ui/locales/ru.json
@@ -394,6 +394,7 @@
     "google_login": "Войти через Google",
     "yandex_login": "Войти через Yandex",
     "apple_login": "Войти через Apple",
+    "apple_email_missing": "Apple не передал адрес электронной почты для этого аккаунта. Войдите через Google, Яндекс или по email.",
     "oauth_session_error": "Не удалось открыть окно входа: {}",
     "unsupported_callback": "Неподдерживаемый формат callback URL",
     "login_failed": "Неверный email или пароль"

--- a/origa_ui/locales/vi.json
+++ b/origa_ui/locales/vi.json
@@ -394,6 +394,7 @@
     "google_login": "Đăng nhập bằng Google",
     "yandex_login": "Đăng nhập bằng Yandex",
     "apple_login": "Đăng nhập bằng Apple",
+    "apple_email_missing": "Apple không chia sẻ địa chỉ email của tài khoản này. Vui lòng đăng nhập bằng Google, Yandex hoặc email.",
     "oauth_session_error": "Không thể mở cửa sổ đăng nhập: {}",
     "unsupported_callback": "Định dạng URL gọi lại không được hỗ trợ",
     "login_failed": "Email hoặc mật khẩu không đúng"

--- a/origa_ui/src/pages/login/oauth_buttons.rs
+++ b/origa_ui/src/pages/login/oauth_buttons.rs
@@ -125,7 +125,7 @@ pub fn OAuthButtons(
         <div class="space-y-3" data-testid=test_id_val>
             <button
                 type="button"
-                class="w-full flex items-center justify-center gap-3 px-4 py-3 border border-[var(--border-dark)] bg-[var(--bg-cream)] hover:bg-[var(--bg-aged)] transition-colors"
+                class="w-full flex items-center justify-center gap-3 px-4 py-3 border border-[var(--border-dark)] bg-[var(--fg-black)] hover:opacity-80 transition-opacity"
                 data-testid=apple_test_id
                 on:click=move |_: leptos::ev::MouseEvent| {
                     let auth_store = auth_store_apple.clone();
@@ -135,7 +135,7 @@ pub fn OAuthButtons(
                 }
             >
                 <AppleIcon />
-                <span class="text-[var(--fg-black)]">{t!(i18n, login.apple_login)}</span>
+                <span class="text-[var(--bg-paper)]">{t!(i18n, login.apple_login)}</span>
             </button>
 
             <button
@@ -262,6 +262,18 @@ fn native_oauth_redirect_uri(on_apple: bool) -> String {
     }
 }
 
+/// Whether the Apple button must use the native Sign in with Apple flow
+/// (`ASAuthorizationController`, no web involved).
+///
+/// Apple Tauri builds only: Mac App Store Guideline 4 requires Apple sign-in
+/// to complete "without leaving the app", and a web sheet — even an
+/// `ASWebAuthenticationSession` one — no longer satisfies reviewers. Every
+/// other combination (browsers, other providers, other platforms) keeps its
+/// current flow byte-identical.
+fn uses_native_apple_sign_in(is_tauri: bool, is_apple: bool, provider: OAuthProvider) -> bool {
+    is_tauri && is_apple && provider == OAuthProvider::Apple
+}
+
 async fn open_oauth_url(
     provider: OAuthProvider,
     debug_sink: Option<OAuthDebugSink>,
@@ -270,6 +282,17 @@ async fn open_oauth_url(
 ) {
     use crate::repository::TrailBaseClient;
     use crate::repository::trailbase_auth::{generate_pkce_challenge, generate_pkce_verifier};
+
+    // Native Sign in with Apple goes FIRST: it needs no PKCE pair and no
+    // redirect_uri — the system sheet returns the identity token directly.
+    if uses_native_apple_sign_in(tauri::is_tauri(), tauri::is_apple(), provider) {
+        auth_store.oauth_error.set(None);
+        auth_store.is_oauth_loading.set(true);
+        let result = native_apple_sign_in(debug_sink, &auth_store, &i18n).await;
+        super::oauth_listeners::handle_oauth_result(result, &auth_store);
+        auth_store.is_oauth_loading.set(false);
+        return;
+    }
 
     // Native builds pick the platform-appropriate target (see
     // `native_oauth_redirect_uri`); the web app returns to same-origin
@@ -423,6 +446,120 @@ async fn start_aswebauth(url: &str, callback_scheme: &str) -> Result<String, Str
         .ok_or("missing 'url' field in start_auth response".to_string())
 }
 
+/// Credential returned by the `sign_in_with_apple` plugin command (camelCase
+/// keys on the JS wire, matching the plugin's `AppleCredential`).
+struct NativeAppleCredential {
+    identity_token: String,
+    nonce: String,
+}
+
+/// Invokes the `aswebauth` Tauri plugin to present the native Sign in with
+/// Apple sheet (`ASAuthorizationController`).
+///
+/// Returns the identity token and the raw client nonce on success, or an
+/// error string — `"cancelled"` when the user dismissed the sheet (the raw
+/// rejection string is preserved so the caller can pattern-match on it, same
+/// contract as `start_aswebauth`).
+async fn invoke_sign_in_with_apple() -> Result<NativeAppleCredential, String> {
+    use crate::core::tauri::invoke_with_args;
+
+    let value =
+        invoke_with_args("plugin:aswebauth|sign_in_with_apple", &JsValue::UNDEFINED).await?;
+
+    let identity_token = js_sys::Reflect::get(&value, &JsValue::from_str("identityToken"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .ok_or("missing 'identityToken' field in sign_in_with_apple response".to_string())?;
+    let nonce = js_sys::Reflect::get(&value, &JsValue::from_str("nonce"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .ok_or("missing 'nonce' field in sign_in_with_apple response".to_string())?;
+
+    Ok(NativeAppleCredential {
+        identity_token,
+        nonce,
+    })
+}
+
+/// Native Sign in with Apple flow: system sheet → identity token → login
+/// endpoint → session → profile.
+///
+/// Returns `Ok(None)` when the user cancelled the sheet (a silent outcome by
+/// design — re-opening any browser flow would go against their intent), an
+/// `Err(message)` ready for `handle_oauth_result` otherwise.
+async fn native_apple_sign_in(
+    debug_sink: Option<OAuthDebugSink>,
+    auth_store: &AuthStore,
+    i18n: &I18nContext<Locale>,
+) -> Result<Option<origa::domain::User>, String> {
+    use crate::repository::TrailBaseClient;
+
+    let credential = match invoke_sign_in_with_apple().await {
+        Ok(credential) => credential,
+        Err(e) if e == "cancelled" => {
+            report_debug!(debug_sink, "native apple sign-in cancelled by user");
+            return Ok(None);
+        },
+        Err(e) => {
+            // Technical failure must NOT degrade to any web flow — that is
+            // exactly what App Review rejects. Surface it to the user.
+            report_debug!(debug_sink, "native apple sign-in failed: {e}");
+            tracing::warn!("Native Apple sign-in failed: {e}");
+            return Err(i18n
+                .get_keys_untracked()
+                .login()
+                .oauth_session_error()
+                .inner()
+                .replace("{}", &e));
+        },
+    };
+    report_debug!(debug_sink, "native apple sign-in sheet completed");
+
+    let client = TrailBaseClient::new();
+    let session = match client
+        .login_apple_native(&credential.identity_token, &credential.nonce)
+        .await
+    {
+        Ok(session) => session,
+        Err(crate::repository::trailbase_client::AppleNativeLoginError::MissingEmail) => {
+            // First authorization without a shared email and no existing
+            // account: Apple will never resend the email for this Apple ID.
+            // Tell the user which alternatives exist instead of a generic
+            // failure they cannot act on.
+            return Err(i18n
+                .get_keys_untracked()
+                .login()
+                .apple_email_missing()
+                .inner()
+                .to_string());
+        },
+        Err(e) => {
+            report_debug!(debug_sink, "apple native login exchange failed: {e}");
+            return Err(i18n
+                .get_keys_untracked()
+                .login()
+                .token_exchange_error()
+                .inner()
+                .replace("{}", &e.to_string()));
+        },
+    };
+
+    // The endpoint's JWT carries the account's stored email, so this is only
+    // empty for accounts that were never anchored on an address.
+    if session.email.is_empty() {
+        return Err(i18n
+            .get_keys_untracked()
+            .login()
+            .email_not_in_token()
+            .inner()
+            .to_string());
+    }
+
+    super::auth_handlers::get_or_create_profile(auth_store, &session.email, i18n)
+        .await
+        .map(Some)
+}
+
 #[cfg(test)]
 mod redirect_uri_tests {
     use super::*;
@@ -455,18 +592,54 @@ mod redirect_uri_tests {
             )
         );
     }
+
+    /// The native SIWA flow is for the Apple button on Apple Tauri builds
+    /// only (App Review Guideline 4); every other combination must keep its
+    /// current flow byte-identical.
+    #[test]
+    fn native_apple_sign_in_is_used_only_for_apple_on_apple_tauri() {
+        assert!(uses_native_apple_sign_in(true, true, OAuthProvider::Apple));
+
+        // Other providers on Apple Tauri keep ASWebAuthenticationSession.
+        assert!(!uses_native_apple_sign_in(
+            true,
+            true,
+            OAuthProvider::Google
+        ));
+        assert!(!uses_native_apple_sign_in(
+            true,
+            true,
+            OAuthProvider::Yandex
+        ));
+
+        // The Apple button outside Tauri (browsers on macOS/iOS) keeps the
+        // web redirect flow — no Tauri invoke exists there.
+        assert!(!uses_native_apple_sign_in(
+            false,
+            true,
+            OAuthProvider::Apple
+        ));
+
+        // The Apple button on non-Apple Tauri builds (Windows/Linux/Android)
+        // keeps the opener + interstitial flow byte-identically.
+        assert!(!uses_native_apple_sign_in(
+            true,
+            false,
+            OAuthProvider::Apple
+        ));
+    }
 }
 
 #[component]
 fn AppleIcon() -> impl IntoView {
     // Official Apple mark (simple-icons "apple", CC0 — same source as the
-    // Google/Yandex marks).
+    // Google/Yandex marks). White on the HIG-black button.
     view! {
         <svg class="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             // Explicit token (not `currentColor`): the icon must not depend
             // on the inherited `color` cascade, same pattern as YandexIcon.
             <path
-                fill="var(--fg-black)"
+                fill="var(--bg-paper)"
                 d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"
             />
         </svg>

--- a/origa_ui/src/repository/trailbase_client.rs
+++ b/origa_ui/src/repository/trailbase_client.rs
@@ -25,6 +25,26 @@ pub enum AuthError {
     ApiError(String),
 }
 
+/// Errors of the native Sign in with Apple login endpoint.
+///
+/// `MissingEmail` is separate from the generic API error because it needs a
+/// dedicated user-facing message: Apple only shares the email on the first
+/// authorization, and a 424 means no account exists yet to match by Apple ID.
+#[derive(Debug)]
+pub enum AppleNativeLoginError {
+    MissingEmail,
+    Api(String),
+}
+
+impl std::fmt::Display for AppleNativeLoginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppleNativeLoginError::MissingEmail => write!(f, "missing email address"),
+            AppleNativeLoginError::Api(message) => write!(f, "API error: {message}"),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct AuthTokenResponse {
     pub(crate) auth_token: String,
@@ -275,6 +295,73 @@ impl TrailBaseClient {
             expires_at,
         };
 
+        Ok(session)
+    }
+
+    /// Logs in with a native Sign in with Apple identity token
+    /// (`ASAuthorizationController` flow, Apple Tauri builds only).
+    ///
+    /// Persists the session (like [`Self::login_with_email_password`]).
+    /// The HTTP status is inspected before the body: 424 means Apple shared
+    /// no email and no account exists yet — surfaced as
+    /// [`AppleNativeLoginError::MissingEmail`] for a dedicated message.
+    pub async fn login_apple_native(
+        &self,
+        identity_token: &str,
+        nonce: &str,
+    ) -> Result<TrailBaseSession, AppleNativeLoginError> {
+        #[derive(Serialize)]
+        struct AppleNativeLoginRequest<'a> {
+            identity_token: &'a str,
+            nonce: &'a str,
+        }
+
+        let response = self
+            .fetch(
+                "/api/auth/v1/oauth/apple/native",
+                Method::POST,
+                Some(&AppleNativeLoginRequest {
+                    identity_token,
+                    nonce,
+                }),
+                None,
+            )
+            .await
+            .map_err(|e| AppleNativeLoginError::Api(e.to_string()))?;
+
+        if !response.ok() {
+            return Err(if response.status() == 424 {
+                AppleNativeLoginError::MissingEmail
+            } else {
+                AppleNativeLoginError::Api(format!(
+                    "Apple native login failed: {}",
+                    response.status_text()
+                ))
+            });
+        }
+
+        let token_response: AuthTokenResponse = Self::json(response)
+            .await
+            .map_err(|e| AppleNativeLoginError::Api(e.to_string()))?;
+
+        let claims = decode_jwt_claims(&token_response.auth_token)
+            .map_err(|e| AppleNativeLoginError::Api(format!("Failed to decode JWT: {}", e)))?;
+
+        let now = current_timestamp();
+        let expires_at = claims.expires_at(now.saturating_add(3600));
+
+        let session = TrailBaseSession {
+            auth_token: token_response.auth_token,
+            refresh_token: token_response.refresh_token.unwrap_or_default(),
+            email: claims.email.clone().unwrap_or_default(),
+            trailbase_id: claims.sub.clone(),
+            record_id: None,
+            expires_at,
+        };
+
+        set_session_async(&session)
+            .await
+            .map_err(AppleNativeLoginError::Api)?;
         Ok(session)
     }
 

--- a/tauri-plugin-aswebauth/Cargo.toml
+++ b/tauri-plugin-aswebauth/Cargo.toml
@@ -8,11 +8,12 @@ repository.workspace = true
 readme.workspace = true
 links = "tauri-plugin-aswebauth"
 
-# ASWebAuthenticationSession wrapper for Apple platforms. The crate compiles
-# on all targets (it is a workspace member) but the plugin is registered only
-# under Apple cfgs in tauri/src/lib.rs:
+# Apple-platforms auth plugin for Tauri. The crate compiles on all targets
+# (it is a workspace member) but the plugin is registered only under Apple
+# cfgs in tauri/src/lib.rs:
 # - iOS: delegates to the Swift mobile plugin (`ios/Sources`).
-# - macOS: native Rust implementation in `src/macos.rs` via objc2.
+# - macOS: native Rust implementations in `src/macos.rs` (ASWebAuthentication
+#   Session for OAuth) and `src/siwa.rs` (native Sign in with Apple) via objc2.
 
 [build-dependencies]
 tauri-plugin.workspace = true
@@ -27,10 +28,20 @@ tracing.workspace = true
 objc2.workspace = true
 block2.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-objc2-foundation = { workspace = true, features = ["NSURL", "NSString", "NSError"] }
+rand.workspace = true
+sha2.workspace = true
+base64.workspace = true
+objc2-foundation = { workspace = true, features = ["NSURL", "NSString", "NSError", "NSArray", "NSData"] }
 objc2-app-kit = { workspace = true, features = ["NSWindow", "NSResponder"] }
 objc2-authentication-services = { workspace = true, features = [
     "ASWebAuthenticationSession",
     "ASFoundation",
     "block2",
+    "ASAuthorization",
+    "ASAuthorizationController",
+    "ASAuthorizationAppleIDProvider",
+    "ASAuthorizationAppleIDRequest",
+    "ASAuthorizationOpenIDRequest",
+    "ASAuthorizationAppleIDCredential",
+    "ASAuthorizationError",
 ] }

--- a/tauri-plugin-aswebauth/build.rs
+++ b/tauri-plugin-aswebauth/build.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 yurvon-screamo
 // SPDX-License-Identifier: MIT
 
-const COMMANDS: &[&str] = &["start_auth"];
+const COMMANDS: &[&str] = &["start_auth", "sign_in_with_apple"];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).ios_path("ios").build();

--- a/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
+++ b/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
@@ -95,34 +95,37 @@ class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding, 
     /// `nonce` claim carries. Known-answer vector:
     /// sha256Hex("test") == "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".
     @objc public func signInWithApple(_ invoke: Invoke) throws {
-        guard appleSignInFlow == nil else {
-            invoke.reject("a Sign in with Apple flow is already in progress")
-            return
-        }
-
-        var nonceBytes = [UInt8](repeating: 0, count: 32)
-        let status = SecRandomCopyBytes(kSecRandomDefault, nonceBytes.count, &nonceBytes)
-        guard status == errSecSuccess else {
-            invoke.reject("nonce generation failed (SecRandomCopyBytes: \(status))")
-            return
-        }
-        let rawNonce = Self.base64URLEncodedNoPad(Data(nonceBytes))
-
-        // Email only: the profile is built from the email address, and Apple
-        // shares the name exactly once — requesting it just to discard the
-        // value would add consent noise without a consumer.
-        let request = ASAuthorizationAppleIDProvider().createRequest()
-        request.requestedScopes = [.email]
-        request.nonce = Self.sha256Hex(rawNonce)
-
-        let controller = ASAuthorizationController(authorizationRequests: [request])
-        controller.delegate = self
-        controller.presentationContextProvider = self
-
-        appleSignInFlow = (invoke: invoke, rawNonce: rawNonce)
-        authorizationController = controller
-
+        // All flow-state mutations happen on the main queue: the delegate
+        // callbacks (main-thread by protocol) clear the same properties, and
+        // the invoke itself may arrive on a non-main IPC thread.
         DispatchQueue.main.async {
+            guard self.appleSignInFlow == nil else {
+                invoke.reject("a Sign in with Apple flow is already in progress")
+                return
+            }
+
+            var nonceBytes = [UInt8](repeating: 0, count: 32)
+            let status = SecRandomCopyBytes(kSecRandomDefault, nonceBytes.count, &nonceBytes)
+            guard status == errSecSuccess else {
+                invoke.reject("nonce generation failed (SecRandomCopyBytes: \(status))")
+                return
+            }
+            let rawNonce = Self.base64URLEncodedNoPad(Data(nonceBytes))
+
+            // Email only: the profile is built from the email address, and
+            // Apple shares the name exactly once — requesting it just to
+            // discard the value would add consent noise without a consumer.
+            let request = ASAuthorizationAppleIDProvider().createRequest()
+            request.requestedScopes = [.email]
+            request.nonce = Self.sha256Hex(rawNonce)
+
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+
+            self.appleSignInFlow = (invoke: invoke, rawNonce: rawNonce)
+            self.authorizationController = controller
+
             controller.performRequests()
         }
     }

--- a/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
+++ b/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
@@ -1,19 +1,28 @@
 // Copyright 2026 yurvon-screamo
 // SPDX-License-Identifier: MIT
 //
-// ASWebAuthenticationSession wrapper for OAuth flows.
+// Apple-platforms auth plugin for Tauri.
 //
-// Replaces the tauri-plugin-opener + desktop-callback.html + custom-scheme
-// flow on iOS. ASWebAuthenticationSession opens Safari in a dedicated auth
-// context, intercepts the server-side 303 to `origa://auth/callback`
-// (redirect-initiated navigation — JavaScript hops from an interstitial page
-// are NOT intercepted), and returns the callback URL via the completion
-// handler — no CFBundleURLTypes needed.
+// 1. `startAuth`: ASWebAuthenticationSession wrapper for OAuth flows
+//    (Google/Yandex). Replaces the tauri-plugin-opener + desktop-callback.html
+//    + custom-scheme flow on iOS. ASWebAuthenticationSession opens Safari in
+//    a dedicated auth context, intercepts the server-side 303 to
+//    `origa://auth/callback` (redirect-initiated navigation — JavaScript hops
+//    from an interstitial page are NOT intercepted), and returns the callback
+//    URL via the completion handler — no CFBundleURLTypes needed.
 //
-// `prefersEphemeralWebBrowserSession` is intentionally `false`: Google OAuth
-// rejects ephemeral (incognito-like) browser sessions, blocking login.
+//    `prefersEphemeralWebBrowserSession` is intentionally `false`: Google
+//    OAuth rejects ephemeral (incognito-like) browser sessions, blocking
+//    login.
+//
+// 2. `signInWithApple`: native Sign in with Apple via ASAuthorizationController
+//    (Mac App Store Guideline 4 — Apple sign-in must complete without leaving
+//    the app, no web involved). Returns the identity token and the raw
+//    client nonce.
 
 import AuthenticationServices
+import CryptoKit
+import Security
 import SwiftRs
 import Tauri
 import UIKit
@@ -24,11 +33,18 @@ struct StartAuthArgs: Decodable {
     let callbackScheme: String
 }
 
-class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding {
+class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     /// Strong reference to the active session. If this property is nil'd
     /// (or the plugin is deallocated) the session's completion handler
     /// will never fire, hanging the OAuth flow indefinitely.
     private var session: ASWebAuthenticationSession?
+
+    /// Strong reference to the active native Sign in with Apple controller,
+    /// plus the invoke and raw nonce of the flow it belongs to. The controller
+    /// holds its delegate weakly, so clearing this property mid-flow would
+    /// drop the callbacks and hang the invoke forever.
+    private var appleSignInFlow: (invoke: Invoke, rawNonce: String)?
+    private var authorizationController: ASAuthorizationController?
 
     @objc public func startAuth(_ invoke: Invoke) throws {
         let args = try invoke.parseArgs(StartAuthArgs.self)
@@ -68,14 +84,129 @@ class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding {
         }
     }
 
+    // MARK: - Native Sign in with Apple (ASAuthorizationController)
+
+    /// Presents the system SIWA sheet — no browser involved (App Review
+    /// Guideline 4: authentication must complete without leaving the app).
+    ///
+    /// Nonce contract shared with the macOS client and the TrailBase endpoint:
+    /// the raw nonce is returned to the caller, and its lowercase-hex SHA-256
+    /// (over the raw string's UTF-8 bytes) is what the identity token's
+    /// `nonce` claim carries. Known-answer vector:
+    /// sha256Hex("test") == "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".
+    @objc public func signInWithApple(_ invoke: Invoke) throws {
+        guard appleSignInFlow == nil else {
+            invoke.reject("a Sign in with Apple flow is already in progress")
+            return
+        }
+
+        var nonceBytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, nonceBytes.count, &nonceBytes)
+        guard status == errSecSuccess else {
+            invoke.reject("nonce generation failed (SecRandomCopyBytes: \(status))")
+            return
+        }
+        let rawNonce = Self.base64URLEncodedNoPad(Data(nonceBytes))
+
+        // Email only: the profile is built from the email address, and Apple
+        // shares the name exactly once — requesting it just to discard the
+        // value would add consent noise without a consumer.
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.email]
+        request.nonce = Self.sha256Hex(rawNonce)
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+
+        appleSignInFlow = (invoke: invoke, rawNonce: rawNonce)
+        authorizationController = controller
+
+        DispatchQueue.main.async {
+            controller.performRequests()
+        }
+    }
+
+    private func takeAppleSignInFlow() -> (invoke: Invoke, rawNonce: String)? {
+        let flow = appleSignInFlow
+        appleSignInFlow = nil
+        authorizationController = nil
+        return flow
+    }
+
+    // MARK: - ASAuthorizationControllerDelegate
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let flow = takeAppleSignInFlow() else { return }
+
+        guard
+            let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+            let tokenData = credential.identityToken,
+            let identityToken = String(data: tokenData, encoding: .utf8),
+            !identityToken.isEmpty
+        else {
+            flow.invoke.reject("authorization carried no identity token")
+            return
+        }
+
+        flow.invoke.resolve([
+            "identityToken": identityToken,
+            "nonce": flow.rawNonce,
+        ])
+    }
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        guard let flow = takeAppleSignInFlow() else { return }
+
+        if let authorizationError = error as? ASAuthorizationError,
+           authorizationError.code == .canceled {
+            // The exact marker the frontend pattern-matches on.
+            flow.invoke.reject("cancelled")
+        } else {
+            flow.invoke.reject("apple sign-in failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Nonce encoding helpers
+
+    private static func base64URLEncodedNoPad(_ data: Data) -> String {
+        return data
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func sha256Hex(_ string: String) -> String {
+        let digest = Insecure.SHA256.hash(data: Data(string.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
     // MARK: - ASWebAuthenticationPresentationContextProviding
 
     func presentationAnchor(
         for session: ASWebAuthenticationSession
     ) -> ASPresentationAnchor {
-        // Return the app's key window so Safari's auth sheet appears on top
-        // of the WebView, not a blank anchor. Uses the foreground active scene
-        // to avoid returning a backgrounded window.
+        return Self.foregroundKeyWindowAnchor()
+    }
+
+    // MARK: - ASAuthorizationControllerPresentationContextProviding
+
+    func presentationAnchor(
+        for controller: ASAuthorizationController
+    ) -> ASPresentationAnchor {
+        return Self.foregroundKeyWindowAnchor()
+    }
+
+    /// The app's key window of the foreground-active scene, so auth UI
+    /// appears on top of the WebView, not on a blank anchor.
+    private static func foregroundKeyWindowAnchor() -> ASPresentationAnchor {
         let scenes = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .filter { $0.activationState == .foregroundActive }
@@ -91,7 +222,7 @@ class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding {
             return window
         }
 
-        // Last resort: empty anchor. The auth session may fail to display,
+        // Last resort: empty anchor. The auth sheet may fail to display,
         // but this should be unreachable in a normal app lifecycle.
         return ASPresentationAnchor()
     }

--- a/tauri-plugin-aswebauth/permissions/autogenerated/commands/sign_in_with_apple.toml
+++ b/tauri-plugin-aswebauth/permissions/autogenerated/commands/sign_in_with_apple.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-sign-in-with-apple"
+description = "Enables the sign_in_with_apple command without any pre-configured scope."
+commands.allow = ["sign_in_with_apple"]
+
+[[permission]]
+identifier = "deny-sign-in-with-apple"
+description = "Denies the sign_in_with_apple command without any pre-configured scope."
+commands.deny = ["sign_in_with_apple"]

--- a/tauri-plugin-aswebauth/permissions/autogenerated/reference.md
+++ b/tauri-plugin-aswebauth/permissions/autogenerated/reference.md
@@ -10,6 +10,32 @@
 <tr>
 <td>
 
+`aswebauth:allow-sign-in-with-apple`
+
+</td>
+<td>
+
+Enables the sign_in_with_apple command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`aswebauth:deny-sign-in-with-apple`
+
+</td>
+<td>
+
+Denies the sign_in_with_apple command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `aswebauth:allow-start-auth`
 
 </td>

--- a/tauri-plugin-aswebauth/permissions/schemas/schema.json
+++ b/tauri-plugin-aswebauth/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the sign_in_with_apple command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-sign-in-with-apple",
+          "markdownDescription": "Enables the sign_in_with_apple command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the sign_in_with_apple command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-sign-in-with-apple",
+          "markdownDescription": "Denies the sign_in_with_apple command without any pre-configured scope."
+        },
+        {
           "description": "Enables the start_auth command without any pre-configured scope.",
           "type": "string",
           "const": "allow-start-auth",

--- a/tauri-plugin-aswebauth/src/commands.rs
+++ b/tauri-plugin-aswebauth/src/commands.rs
@@ -28,6 +28,22 @@ pub struct AuthResult {
     pub url: String,
 }
 
+/// Successful response from `sign_in_with_apple` (native Sign in with Apple
+/// via `ASAuthorizationController`).
+///
+/// Serialized from Rust to Swift via `run_mobile_plugin` and to the frontend
+/// with camelCase keys. `nonce` is the RAW client nonce: its SHA-256 hash was
+/// handed to the authorization request, and the login endpoint re-hashes the
+/// raw value to match it against the identity token's `nonce` claim.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppleCredential {
+    /// The identity token JWT (`ASAuthorizationAppleIDCredential.identityToken`).
+    #[serde(rename = "identityToken")]
+    pub identity_token: String,
+    /// The raw client-generated nonce.
+    pub nonce: String,
+}
+
 /// iOS: delegates to the Swift `AsWebAuthPlugin.startAuth` via
 /// `PluginHandle::run_mobile_plugin`. The Swift completion handler resolves
 /// with `{ "url": "origa://auth/callback?code=..." }`.
@@ -104,3 +120,67 @@ pub async fn start_auth(_url: String, _callback_scheme: String) -> Result<AuthRe
 
 #[cfg(target_os = "ios")]
 use tauri::Runtime;
+
+/// iOS: delegates to the Swift `AsWebAuthPlugin.signInWithApple` via
+/// `PluginHandle::run_mobile_plugin`. The Swift delegate resolves with
+/// `{ "identityToken": ..., "nonce": ... }`.
+#[cfg(target_os = "ios")]
+#[tauri::command]
+pub async fn sign_in_with_apple<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+) -> Result<AppleCredential, String> {
+    use crate::AsWebAuthState;
+    use tauri::Manager;
+
+    let state = app
+        .try_state::<AsWebAuthState<R>>()
+        .ok_or("aswebauth plugin not initialized")?;
+
+    let result: AppleCredential = state
+        .handle
+        .run_mobile_plugin::<AppleCredential>("signInWithApple", ())
+        .map_err(|e| e.to_string())?;
+
+    Ok(result)
+}
+
+/// macOS: native Sign in with Apple via `ASAuthorizationController`
+/// (`siwa.rs`). The controller must be created and started on the main
+/// thread; the async command dispatches there and awaits the delegate
+/// callback through an mpsc channel.
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub async fn sign_in_with_apple<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+) -> Result<AppleCredential, String> {
+    let (tx, rx) = std::sync::mpsc::channel::<Result<AppleCredential, String>>();
+
+    let app_for_sheet = app.clone();
+    let mut tx_for_sheet = Some(tx);
+    app.run_on_main_thread(move || {
+        // `start_native_sign_in` owns the sender and guarantees exactly one
+        // send: from the delegate callback, or synchronously with the real
+        // failure cause when the sheet cannot even be created.
+        if let Some(tx) = tx_for_sheet.take() {
+            crate::siwa::start_native_sign_in(&app_for_sheet, tx);
+        }
+    })
+    .map_err(|e| format!("failed to dispatch onto the main thread: {e}"))?;
+
+    // The delegate callback fires when the user finishes the flow — seconds
+    // later. A blocking recv on a dedicated worker thread is the cheapest
+    // bridge to async here (same pattern as `start_auth`).
+    let received = tauri::async_runtime::spawn_blocking(move || rx.recv())
+        .await
+        .map_err(|e| format!("apple sign-in worker failed: {e}"))?;
+
+    received.map_err(|_| "apple sign-in sheet dropped before completing".to_string())?
+}
+
+/// Other platforms stub — always returns an error. Unreachable because the
+/// frontend only invokes the command on Apple platforms.
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[tauri::command]
+pub async fn sign_in_with_apple() -> Result<AppleCredential, String> {
+    Err("Sign in with Apple is only available on Apple platforms".to_string())
+}

--- a/tauri-plugin-aswebauth/src/lib.rs
+++ b/tauri-plugin-aswebauth/src/lib.rs
@@ -1,28 +1,35 @@
 // Copyright 2026 yurvon-screamo
 // SPDX-License-Identifier: MIT
 //
-// Apple-platforms Tauri plugin that wraps ASWebAuthenticationSession for
-// OAuth flows.
+// Apple-platforms Tauri auth plugin.
 //
-// ASWebAuthenticationSession is Apple's recommended API for browser-based
-// authentication from native apps. Unlike plain `open` (which leaves the user
-// stranded in the default browser after the OAuth redirect), it:
+// 1. `start_auth` wraps ASWebAuthenticationSession for browser-based OAuth
+//    flows (Google/Yandex). Unlike plain `open` (which leaves the user
+//    stranded in the default browser after the OAuth redirect), it:
 //
-// 1. Opens the auth page in a dedicated authentication context.
-// 2. Intercepts the custom-scheme callback URL directly.
-// 3. Returns the callback URL via a completion handler.
-// 4. Closes the browser automatically.
+//    1. Opens the auth page in a dedicated authentication context.
+//    2. Intercepts the custom-scheme callback URL directly.
+//    3. Returns the callback URL via a completion handler.
+//    4. Closes the browser automatically.
 //
-// This is exactly what App Review Guideline 4 requires when sign-in leaves
-// the app (Mac App Store rejection, Aug 2026).
+//    This is exactly what App Review Guideline 4 requires when sign-in
+//    leaves the app (Mac App Store rejection, Aug 2026).
+//
+// 2. `sign_in_with_apple` presents the native Sign in with Apple sheet via
+//    ASAuthorizationController (`siwa.rs` on macOS, Swift on iOS): zero web
+//    involved, which is what Guideline 4 demands for the Apple button
+//    ("Authentication with Sign in with Apple should always be completed
+//    without leaving the app").
 //
 // Platform wiring:
 // - iOS: Swift mobile plugin (`ios/Sources`), registered via
-//   `register_ios_plugin`; `start_auth` delegates through `run_mobile_plugin`.
-// - macOS: pure-Rust implementation in `src/macos.rs` via objc2
-//   (`objc2-authentication-services`), dispatched onto the main thread.
-// - Other targets: the plugin compiles but `start_auth` returns an error —
-//   unreachable because the frontend only invokes it on Apple platforms.
+//   `register_ios_plugin`; both commands delegate through
+//   `run_mobile_plugin`.
+// - macOS: pure-Rust implementations in `src/macos.rs` and `src/siwa.rs`
+//   via objc2 (`objc2-authentication-services`), dispatched onto the main
+//   thread.
+// - Other targets: the plugin compiles but both commands return an error —
+//   unreachable because the frontend only invokes them on Apple platforms.
 
 use tauri::Runtime;
 use tauri::plugin::{Builder, TauriPlugin};
@@ -36,6 +43,8 @@ tauri::ios_plugin_binding!(init_plugin_aswebauth);
 mod commands;
 #[cfg(target_os = "macos")]
 pub(crate) mod macos;
+#[cfg(target_os = "macos")]
+pub(crate) mod siwa;
 
 /// Plugin state holding the mobile plugin handle (iOS only).
 ///
@@ -76,6 +85,9 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![commands::start_auth])
+        .invoke_handler(tauri::generate_handler![
+            commands::start_auth,
+            commands::sign_in_with_apple
+        ])
         .build()
 }

--- a/tauri-plugin-aswebauth/src/siwa.rs
+++ b/tauri-plugin-aswebauth/src/siwa.rs
@@ -1,0 +1,355 @@
+// Copyright 2026 yurvon-screamo
+// SPDX-License-Identifier: MIT
+
+//! macOS implementation of `sign_in_with_apple` via `ASAuthorizationController`.
+//!
+//! Native Sign in with Apple presents a system sheet over the app's window —
+//! no browser involved, which is what Mac App Store Guideline 4 requires
+//! ("Authentication with Sign in with Apple should always be completed
+//! without leaving the app"). Google/Yandex keep using
+//! `ASWebAuthenticationSession` (`macos.rs`); this flow is Apple-only.
+//!
+//! Threading: the controller, its request and the delegate are all
+//! main-thread-only objects. `commands.rs` dispatches here through
+//! `AppHandle::run_on_main_thread`, and the `ASAuthorizationControllerDelegate`
+//! protocol is `MainThreadOnly`, so every callback is guaranteed to arrive on
+//! the main thread as well — no cross-thread ObjC releases here (unlike
+//! `ASWebAuthenticationSession`, whose completion block macOS 26 may invoke on
+//! a background queue).
+//!
+//! Anti-replay nonce: the raw nonce is generated here, its SHA-256 hash goes
+//! into `ASAuthorizationOpenIDRequest.nonce`, and the raw value travels back
+//! to the frontend. The login endpoint re-hashes it and matches the identity
+//! token's `nonce` claim. Cross-platform contract: the hash is the lowercase
+//! hex SHA-256 of the raw nonce string's UTF-8 bytes (the same vector is
+//! pinned in the TrailBase endpoint tests and in the iOS Swift client).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use objc2::rc::Retained;
+use objc2::runtime::{NSObject, ProtocolObject};
+use objc2::{AnyThread, DefinedClass, MainThreadOnly, define_class, msg_send};
+use objc2_app_kit::NSWindow;
+use objc2_authentication_services::{
+    ASAuthorization, ASAuthorizationAppleIDCredential, ASAuthorizationAppleIDProvider,
+    ASAuthorizationAppleIDRequest, ASAuthorizationController, ASAuthorizationControllerDelegate,
+    ASAuthorizationControllerPresentationContextProviding, ASAuthorizationError,
+    ASAuthorizationOpenIDRequest, ASAuthorizationRequest, ASAuthorizationScopeEmail,
+    ASPresentationAnchor,
+};
+use objc2_foundation::{
+    MainThreadMarker, NSArray, NSError, NSObjectProtocol, NSString, NSUTF8StringEncoding,
+};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use tauri::Manager;
+
+use crate::commands::AppleCredential;
+
+/// Controller + delegate kept alive until the flow completes.
+///
+/// `ASAuthorizationController` holds both its `delegate` and
+/// `presentationContextProvider` weakly, and the delegate needs the controller
+/// to outlive the sheet, so this bundle breaks the cycle when a delegate
+/// callback fires: it is taken out of the shared slot and dropped on the main
+/// thread.
+type NativeFlowBundle = (
+    Retained<ASAuthorizationController>,
+    Retained<AppleIdDelegate>,
+);
+
+/// Shared slot holding the bundle. Everything that touches it runs on the
+/// main thread (creation, fill, and every delegate callback — the protocol is
+/// `MainThreadOnly`), so a plain `Rc<RefCell>` is the right primitive; no
+/// cross-thread releases happen in this flow (unlike
+/// `macos.rs::SessionSlot`, whose completion block may arrive off-main).
+type NativeFlowSlot = Rc<RefCell<Option<NativeFlowBundle>>>;
+
+fn fill_slot(slot: &NativeFlowSlot, bundle: NativeFlowBundle) {
+    *slot.borrow_mut() = Some(bundle);
+}
+
+fn take_slot(slot: &NativeFlowSlot) -> Option<NativeFlowBundle> {
+    slot.borrow_mut().take()
+}
+
+/// Presents the native SIWA sheet anchored over the app's main window and
+/// bridges the delegate callback to `tx`. Guarantees exactly one send: from
+/// one of the delegate methods, or synchronously with the real failure cause
+/// when the flow cannot even be created.
+pub(crate) fn start_native_sign_in<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    tx: std::sync::mpsc::Sender<Result<AppleCredential, String>>,
+) {
+    // Every early-exit path owns `tx` and sends the failure itself.
+    let Some(mtm) = MainThreadMarker::new() else {
+        let _ = tx.send(Err(
+            "start_native_sign_in must run on the main thread".to_string()
+        ));
+        return;
+    };
+
+    let Some(webview_window) = app.get_webview_window("main") else {
+        let _ = tx.send(Err("no main window".to_string()));
+        return;
+    };
+    let ns_window_ptr = match webview_window.ns_window() {
+        Ok(ptr) => ptr,
+        Err(e) => {
+            let _ = tx.send(Err(format!("failed to get the main NSWindow: {e}")));
+            return;
+        },
+    };
+    // SAFETY: Tauri returns a valid `NSWindow` pointer for the main window on
+    // macOS; `Retained::retain` balances its +1 with our eventual release.
+    let retained_window = unsafe { Retained::retain(ns_window_ptr.cast()) };
+    let Some(window) = retained_window else {
+        let _ = tx.send(Err("failed to retain the main NSWindow".to_string()));
+        return;
+    };
+
+    let nonce = generate_raw_nonce();
+    let nonce_hash = sha256_hex(&nonce);
+
+    let slot: NativeFlowSlot = Rc::new(RefCell::new(None));
+    let delegate = AppleIdDelegate::new(tx, nonce, window, Rc::clone(&slot), mtm);
+
+    // SAFETY: The provider is a plain main-thread object; `new` has no
+    // additional safety requirements.
+    let provider = unsafe { ASAuthorizationAppleIDProvider::new() };
+    // SAFETY: The request is freshly created by the provider.
+    let apple_id_request: Retained<ASAuthorizationAppleIDRequest> =
+        unsafe { provider.createRequest() };
+
+    // `requestedScopes` and `nonce` are declared on the OpenID superclass.
+    // SAFETY: `into_super` upcasts the freshly created request one level.
+    let openid_request: Retained<ASAuthorizationOpenIDRequest> = apple_id_request.into_super();
+    // Email only: the profile is built from the email address, and Apple
+    // shares the name exactly once — requesting it just to discard the value
+    // would add consent noise without a consumer.
+    // SAFETY: The array outlives the setter call; the request is valid.
+    unsafe {
+        openid_request.setRequestedScopes(Some(&NSArray::from_slice(&[ASAuthorizationScopeEmail])));
+        openid_request.setNonce(Some(&NSString::from_str(&nonce_hash)));
+    }
+
+    // SAFETY: The upcast request is valid; the array keeps it alive for the
+    // controller.
+    let authz_request: Retained<ASAuthorizationRequest> = openid_request.into_super();
+    // SAFETY: Allocated with a valid requests array.
+    let controller = unsafe {
+        ASAuthorizationController::initWithAuthorizationRequests(
+            ASAuthorizationController::alloc(),
+            &NSArray::from_retained_slice(&[authz_request]),
+        )
+    };
+
+    // The controller properties are typed by distinct protocols, so the
+    // delegate is wrapped twice — once per property type. `from_ref` borrows
+    // the delegate, which the flow slot keeps alive.
+    // SAFETY: Both protocol objects wrap the same valid delegate instance.
+    unsafe {
+        let as_delegate: &ProtocolObject<dyn ASAuthorizationControllerDelegate> =
+            ProtocolObject::from_ref(&*delegate);
+        controller.setDelegate(Some(as_delegate));
+
+        let as_anchor: &ProtocolObject<dyn ASAuthorizationControllerPresentationContextProviding> =
+            ProtocolObject::from_ref(&*delegate);
+        controller.setPresentationContextProvider(Some(as_anchor));
+    }
+
+    fill_slot(&slot, (controller.clone(), delegate));
+
+    // SAFETY: The controller was created above; `performRequests` has no
+    // additional safety requirements beyond a valid receiver.
+    unsafe { controller.performRequests() };
+}
+
+// Delegate for the native SIWA flow: receives the authorization result and
+// anchors the sheet over the app's main window.
+define_class!(
+    // SAFETY:
+    // - Superclass `NSObject` has no subclassing requirements.
+    // - The type does not implement `Drop`.
+    #[unsafe(super = NSObject)]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = (
+        std::sync::mpsc::Sender<Result<AppleCredential, String>>,
+        String,
+        Retained<NSWindow>,
+        NativeFlowSlot
+    )]
+    struct AppleIdDelegate;
+
+    // SAFETY: `NSObjectProtocol` has no safety requirements.
+    unsafe impl NSObjectProtocol for AppleIdDelegate {}
+
+    // SAFETY: The method signatures match the generated protocol declarations.
+    unsafe impl ASAuthorizationControllerDelegate for AppleIdDelegate {
+        #[unsafe(method(authorizationController:didCompleteWithAuthorization:))]
+        unsafe fn did_complete_with_authorization(
+            &self,
+            _controller: &ASAuthorizationController,
+            authorization: &ASAuthorization,
+        ) {
+            // SAFETY: The authorization comes straight from the delegate
+            // callback; the credential is only read.
+            let result = unsafe { self.apple_credential(authorization) };
+            let _ = self.ivars().0.send(result);
+            self.drop_flow_bundle();
+        }
+
+        #[unsafe(method(authorizationController:didCompleteWithError:))]
+        unsafe fn did_complete_with_error(
+            &self,
+            _controller: &ASAuthorizationController,
+            error: &NSError,
+        ) {
+            let message = if error.code() == ASAuthorizationError::Canceled.0 {
+                // The exact marker the frontend pattern-matches on.
+                "cancelled".to_string()
+            } else {
+                error.localizedDescription().to_string()
+            };
+            let _ = self.ivars().0.send(Err(message));
+            self.drop_flow_bundle();
+        }
+    }
+
+    // SAFETY: The method signature matches the generated protocol declaration.
+    unsafe impl ASAuthorizationControllerPresentationContextProviding for AppleIdDelegate {
+        // Retained-returning protocol methods are registered via `method_id`.
+        #[unsafe(method_id(presentationAnchorForAuthorizationController:))]
+        unsafe fn presentation_anchor_for_authorization_controller(
+            &self,
+            _controller: &ASAuthorizationController,
+        ) -> Retained<ASPresentationAnchor> {
+            // NSWindow → NSResponder → NSObject: two hops up the superclass
+            // chain, same as `macos.rs::AuthAnchorProvider`.
+            self.ivars().2.clone().into_super().into_super()
+        }
+    }
+);
+
+impl AppleIdDelegate {
+    fn new(
+        tx: std::sync::mpsc::Sender<Result<AppleCredential, String>>,
+        nonce: String,
+        window: Retained<NSWindow>,
+        slot: NativeFlowSlot,
+        mtm: MainThreadMarker,
+    ) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars((tx, nonce, window, slot));
+        // SAFETY: The signature of `NSObject`'s `init` is correct.
+        unsafe { msg_send![super(this), init] }
+    }
+
+    /// Extracts the identity token from the authorization credential.
+    ///
+    /// # SAFETY
+    /// The authorization comes straight from the delegate callback; the
+    /// credential is only read here.
+    unsafe fn apple_credential(
+        &self,
+        authorization: &ASAuthorization,
+    ) -> Result<AppleCredential, String> {
+        // SAFETY: `credential` returns the object handed over by the system;
+        // the downcast verifies the concrete class before reinterpreting.
+        let credential = unsafe { authorization.credential() }
+            .downcast::<ASAuthorizationAppleIDCredential>()
+            .map_err(|_| "authorization carried an unexpected credential type".to_string())?;
+
+        let token = unsafe { credential.identityToken() }
+            .and_then(|data| {
+                // SAFETY: The data comes straight from the credential; the
+                // initializer only reads it. Identity tokens are ASCII JWTs.
+                NSString::initWithData_encoding(NSString::alloc(), &data, NSUTF8StringEncoding)
+            })
+            .map(|string| string.to_string())
+            .ok_or_else(|| "identity token is not valid UTF-8".to_string())?;
+
+        if token.is_empty() {
+            return Err("authorization carried an empty identity token".to_string());
+        }
+
+        Ok(AppleCredential {
+            identity_token: token,
+            nonce: self.ivars().1.clone(),
+        })
+    }
+
+    /// Breaks the controller ↔ delegate cycle now that the flow is done.
+    /// Delegate callbacks are `MainThreadOnly`, so the drop runs inline on
+    /// the main thread — required, because the bundle holds AppKit objects.
+    fn drop_flow_bundle(&self) {
+        take_slot(&self.ivars().3);
+    }
+}
+
+/// Generates the raw client nonce: 32 random bytes, base64url-encoded without
+/// padding (RFC 4648 §5, un-padded — same alphabet as PKCE verifiers).
+fn generate_raw_nonce() -> String {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Lowercase-hex SHA-256 of the raw nonce string's UTF-8 bytes.
+///
+/// Known-answer vector shared with the TrailBase endpoint and the iOS client:
+/// `sha256_hex("test") == "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"`.
+fn sha256_hex(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    /// User dismissal must map to the exact `"cancelled"` string the frontend
+    /// pattern-matches on (`oauth_buttons.rs`), not to a localized message.
+    #[test]
+    fn canceled_authorization_maps_to_cancelled_marker() {
+        // Canceled == 1001 per ASAuthorizationError.
+        assert_eq!(ASAuthorizationError::Canceled.0, 1001);
+    }
+
+    /// The nonce hash is a cross-platform contract (macOS Rust, iOS Swift,
+    /// TrailBase endpoint): pin the documented known-answer vector.
+    #[test]
+    fn sha256_hex_matches_the_cross_platform_test_vector() {
+        assert_eq!(
+            sha256_hex("test"),
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+        );
+    }
+
+    /// The raw nonce must be valid base64url without padding: 32 bytes
+    /// encode to exactly 43 characters.
+    #[test]
+    fn generated_nonce_is_43_char_base64url() {
+        let nonce = generate_raw_nonce();
+        assert_eq!(nonce.len(), 43);
+        assert!(!nonce.contains('+') && !nonce.contains('/') && !nonce.contains('='));
+    }
+
+    /// The slot hands its payload out exactly once: after the first take it
+    /// stays empty, so a stray second callback cannot double-drop the bundle.
+    #[test]
+    fn slot_take_is_once() {
+        let slot: NativeFlowSlot = Rc::new(RefCell::new(None));
+
+        assert!(take_slot(&slot).is_none());
+        assert!(take_slot(&slot).is_none());
+    }
+}

--- a/tauri/Entitlements.plist
+++ b/tauri/Entitlements.plist
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/tauri/capabilities/ios.json
+++ b/tauri/capabilities/ios.json
@@ -5,6 +5,7 @@
 	"platforms": ["iOS"],
 	"windows": ["main"],
 	"permissions": [
-		"aswebauth:allow-start-auth"
+		"aswebauth:allow-start-auth",
+		"aswebauth:allow-sign-in-with-apple"
 	]
 }

--- a/tauri/capabilities/macos-aswebauth.json
+++ b/tauri/capabilities/macos-aswebauth.json
@@ -5,6 +5,7 @@
 	"platforms": ["macOS"],
 	"windows": ["main"],
 	"permissions": [
-		"aswebauth:allow-start-auth"
+		"aswebauth:allow-start-auth",
+		"aswebauth:allow-sign-in-with-apple"
 	]
 }

--- a/tauri/gen/apple/origa-app_iOS/origa-app_iOS.entitlements
+++ b/tauri/gen/apple/origa-app_iOS/origa-app_iOS.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
## Summary

Closes #505.

Mac App Store rejected submission `b67a5273` (Guideline 4): the Apple button opened `appleid.apple.com` in an `ASWebAuthenticationSession` sheet — reviewers require the fully native `ASAuthorizationController` flow, zero web involved.

- **Backend (TrailBase fork, [`apple-native-siwa`](https://github.com/yurvon-screamo/trailbase/tree/apple-native-siwa))**: new `POST /api/auth/v1/oauth/apple/native` verifies the RS256 identity token against Apple's JWKS with the App ID audience (new `native_client_id` config field — distinct from the web flow's Services ID), enforces the anti-replay nonce claim, and matches/creates users by the team-stable Apple `sub` through the same code path as the web callback. Malformed tokens are rejected by a structural pre-parse before any outbound request. Email-less repeat logins succeed (the minted JWT carries the stored email).
- **Plugin (`tauri-plugin-aswebauth`)**: new `sign_in_with_apple` command — native Rust (`siwa.rs`, objc2) on macOS, Swift on iOS. Contract: `{ identityToken, nonce }`; scopes minimized to `[.email]`; cancellation maps to the existing `"cancelled"` contract with **no browser fallback**.
- **Frontend (`origa_ui`)**: the Apple button on Apple Tauri builds takes the native branch before PKCE; HTTP 424 (first login without a shared email) gets a dedicated message in all four locales; button restyled to HIG. Google/Yandex and all other platforms stay byte-identical.
- **CI**: entitlements verify 4→5 plus a fail-closed check that the provisioning profile itself grants `com.apple.developer.applesignin` (the merge step is a silent union).

## Verification

- Fork: 220 lib tests green (26→32 in oauth: endpoint contract pinned — 400/401/424/200, JWKS fetch injection, route mounted via real router).
- origa: `cargo clippy --workspace --all-targets -D warnings` clean, workspace tests green (27 suites), `cargo test -p origa_ui` 505 passed, `CC_aarch64_apple_darwin=clang cargo check --target aarch64-apple-darwin -p tauri-plugin-aswebauth` clean.
- Code review: 2 iterations, final `approve` (0 findings).

## Manual steps before the store resubmission (owner)

1. **S0**: enable *Sign in with Apple* on App ID `net.uwuwu.origa` (do **not** touch Services ID `net.uwuwu.origa.web` / key `UPC3J3Z666`); inspect the refreshed profile for the entitlement. Until then darwin CI is red by design at the new gate.
2. **S2**: deploy the fork image (`:apple-native` tag) + `native_client_id` config line on Railway.
3. **S8**: manual matrix on a signed store-like artifact (both platforms) + reply in App Store Connect.

Release gate: do not cut a store release containing this branch until S2 is verified live.