### PR TITLE
fix(apple): generate the SIWA nonce in Rust (iOS SwiftPM has no CryptoKit)

### DIFF
--- a/tauri-plugin-aswebauth/Cargo.toml
+++ b/tauri-plugin-aswebauth/Cargo.toml
@@ -23,14 +23,17 @@ tauri.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+# Nonce generation/hash is shared by the macOS implementation and the iOS
+# command (the Swift side only forwards the pre-hashed value), so these stay
+# target-independent.
+base64.workspace = true
+rand.workspace = true
+sha2.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2.workspace = true
 block2.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-rand.workspace = true
-sha2.workspace = true
-base64.workspace = true
 objc2-foundation = { workspace = true, features = ["NSURL", "NSString", "NSError", "NSArray", "NSData"] }
 objc2-app-kit = { workspace = true, features = ["NSWindow", "NSResponder"] }
 objc2-authentication-services = { workspace = true, features = [

--- a/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
+++ b/tauri-plugin-aswebauth/ios/Sources/AsWebAuthPlugin.swift
@@ -21,8 +21,6 @@
 //    client nonce.
 
 import AuthenticationServices
-import CryptoKit
-import Security
 import SwiftRs
 import Tauri
 import UIKit
@@ -31,6 +29,14 @@ import WebKit
 struct StartAuthArgs: Decodable {
     let url: String
     let callbackScheme: String
+}
+
+/// The Rust command generates the raw nonce and its lowercase-hex SHA-256
+/// (see `tauri-plugin-aswebauth/src/nonce.rs` for the cross-platform
+/// contract); this struct only carries the hash over to the sheet request.
+struct SignInWithAppleArgs: Decodable {
+    let nonceHash: String
+    let nonce: String
 }
 
 class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
@@ -90,11 +96,14 @@ class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding, 
     /// Guideline 4: authentication must complete without leaving the app).
     ///
     /// Nonce contract shared with the macOS client and the TrailBase endpoint:
-    /// the raw nonce is returned to the caller, and its lowercase-hex SHA-256
-    /// (over the raw string's UTF-8 bytes) is what the identity token's
-    /// `nonce` claim carries. Known-answer vector:
+    /// the raw nonce is generated and hashed by the Rust command, which sends
+    /// the hash here; this method puts it on the authorization request
+    /// (`request.nonce`) and echoes the RAW value back with the result.
+    /// Known-answer vector:
     /// sha256Hex("test") == "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".
     @objc public func signInWithApple(_ invoke: Invoke) throws {
+        let args = try invoke.parseArgs(SignInWithAppleArgs.self)
+
         // All flow-state mutations happen on the main queue: the delegate
         // callbacks (main-thread by protocol) clear the same properties, and
         // the invoke itself may arrive on a non-main IPC thread.
@@ -104,26 +113,18 @@ class AsWebAuthPlugin: Plugin, ASWebAuthenticationPresentationContextProviding, 
                 return
             }
 
-            var nonceBytes = [UInt8](repeating: 0, count: 32)
-            let status = SecRandomCopyBytes(kSecRandomDefault, nonceBytes.count, &nonceBytes)
-            guard status == errSecSuccess else {
-                invoke.reject("nonce generation failed (SecRandomCopyBytes: \(status))")
-                return
-            }
-            let rawNonce = Self.base64URLEncodedNoPad(Data(nonceBytes))
-
             // Email only: the profile is built from the email address, and
             // Apple shares the name exactly once — requesting it just to
             // discard the value would add consent noise without a consumer.
             let request = ASAuthorizationAppleIDProvider().createRequest()
             request.requestedScopes = [.email]
-            request.nonce = Self.sha256Hex(rawNonce)
+            request.nonce = args.nonceHash
 
             let controller = ASAuthorizationController(authorizationRequests: [request])
             controller.delegate = self
             controller.presentationContextProvider = self
 
-            self.appleSignInFlow = (invoke: invoke, rawNonce: rawNonce)
+            self.appleSignInFlow = (invoke: invoke, rawNonce: args.nonce)
             self.authorizationController = controller
 
             controller.performRequests()

--- a/tauri-plugin-aswebauth/src/commands.rs
+++ b/tauri-plugin-aswebauth/src/commands.rs
@@ -130,18 +130,39 @@ pub async fn sign_in_with_apple<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
 ) -> Result<AppleCredential, String> {
     use crate::AsWebAuthState;
+    use crate::nonce::{generate_raw_nonce, sha256_hex};
     use tauri::Manager;
 
     let state = app
         .try_state::<AsWebAuthState<R>>()
         .ok_or("aswebauth plugin not initialized")?;
 
+    // The nonce is generated and hashed here: the Swift side neither
+    // generates nor hashes (no CryptoKit dependency there). It puts the
+    // pre-hashed value on the authorization request and echoes the RAW nonce
+    // back with the identity token; the login endpoint re-hashes it against
+    // the token claim.
+    let raw_nonce = generate_raw_nonce();
+    let args = StartAppleArgs {
+        nonce_hash: sha256_hex(&raw_nonce),
+        nonce: raw_nonce,
+    };
+
     let result: AppleCredential = state
         .handle
-        .run_mobile_plugin::<AppleCredential>("signInWithApple", ())
+        .run_mobile_plugin("signInWithApple", args)
         .map_err(|e| e.to_string())?;
 
     Ok(result)
+}
+
+/// Arguments for the iOS `signInWithApple` Swift method (camelCase on the
+/// wire, matching the Swift `Decodable` struct).
+#[cfg(target_os = "ios")]
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StartAppleArgs {
+    nonce_hash: String,
 }
 
 /// macOS: native Sign in with Apple via `ASAuthorizationController`

--- a/tauri-plugin-aswebauth/src/lib.rs
+++ b/tauri-plugin-aswebauth/src/lib.rs
@@ -43,6 +43,8 @@ tauri::ios_plugin_binding!(init_plugin_aswebauth);
 mod commands;
 #[cfg(target_os = "macos")]
 pub(crate) mod macos;
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+pub(crate) mod nonce;
 #[cfg(target_os = "macos")]
 pub(crate) mod siwa;
 

--- a/tauri-plugin-aswebauth/src/nonce.rs
+++ b/tauri-plugin-aswebauth/src/nonce.rs
@@ -1,0 +1,62 @@
+// Copyright 2026 yurvon-screamo
+// SPDX-License-Identifier: MIT
+
+//! Anti-replay nonce for the native Sign in with Apple flow.
+//!
+//! Platform-independent on purpose: both the macOS implementation (`siwa.rs`)
+//! and the iOS command (which passes the values to the Swift plugin) use this
+//! module, so the nonce contract lives in exactly one place.
+//!
+//! Contract (shared with the TrailBase endpoint and pinned by unit tests on
+//! every platform): the raw nonce is 32 random bytes base64url-encoded without
+//! padding; `request.nonce` = lowercase-hex SHA-256 of the raw string's UTF-8
+//! bytes. Known-answer vector: `sha256_hex("test") ==
+//! "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"`.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+/// Generates the raw client nonce: 32 random bytes, base64url-encoded without
+/// padding (RFC 4648 §5, un-padded — same alphabet as PKCE verifiers).
+pub(crate) fn generate_raw_nonce() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Lowercase-hex SHA-256 of the raw nonce string's UTF-8 bytes.
+pub(crate) fn sha256_hex(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The nonce hash is a cross-platform contract (macOS Rust, iOS Swift
+    /// consumer, TrailBase endpoint): pin the documented known-answer vector.
+    #[test]
+    fn sha256_hex_matches_the_cross_platform_test_vector() {
+        assert_eq!(
+            sha256_hex("test"),
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+        );
+    }
+
+    /// The raw nonce must be valid base64url without padding: 32 bytes
+    /// encode to exactly 43 characters.
+    #[test]
+    fn generated_nonce_is_43_char_base64url() {
+        let nonce = generate_raw_nonce();
+        assert_eq!(nonce.len(), 43);
+        assert!(!nonce.contains('+') && !nonce.contains('/') && !nonce.contains('='));
+    }
+}

--- a/tauri-plugin-aswebauth/src/siwa.rs
+++ b/tauri-plugin-aswebauth/src/siwa.rs
@@ -41,11 +41,10 @@ use objc2_authentication_services::{
 use objc2_foundation::{
     MainThreadMarker, NSArray, NSError, NSObjectProtocol, NSString, NSUTF8StringEncoding,
 };
-use rand::RngCore;
-use sha2::{Digest, Sha256};
 use tauri::Manager;
 
 use crate::commands::AppleCredential;
+use crate::nonce::{generate_raw_nonce, sha256_hex};
 
 /// Controller + delegate kept alive until the flow completes.
 ///
@@ -287,31 +286,6 @@ impl AppleIdDelegate {
     }
 }
 
-/// Generates the raw client nonce: 32 random bytes, base64url-encoded without
-/// padding (RFC 4648 §5, un-padded — same alphabet as PKCE verifiers).
-fn generate_raw_nonce() -> String {
-    use base64::Engine as _;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-
-    let mut bytes = [0u8; 32];
-    rand::rng().fill_bytes(&mut bytes);
-    URL_SAFE_NO_PAD.encode(bytes)
-}
-
-/// Lowercase-hex SHA-256 of the raw nonce string's UTF-8 bytes.
-///
-/// Known-answer vector shared with the TrailBase endpoint and the iOS client:
-/// `sha256_hex("test") == "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"`.
-fn sha256_hex(value: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(value.as_bytes());
-    hasher
-        .finalize()
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect()
-}
-
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
@@ -322,25 +296,6 @@ mod tests {
     fn canceled_authorization_maps_to_cancelled_marker() {
         // Canceled == 1001 per ASAuthorizationError.
         assert_eq!(ASAuthorizationError::Canceled.0, 1001);
-    }
-
-    /// The nonce hash is a cross-platform contract (macOS Rust, iOS Swift,
-    /// TrailBase endpoint): pin the documented known-answer vector.
-    #[test]
-    fn sha256_hex_matches_the_cross_platform_test_vector() {
-        assert_eq!(
-            sha256_hex("test"),
-            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
-        );
-    }
-
-    /// The raw nonce must be valid base64url without padding: 32 bytes
-    /// encode to exactly 43 characters.
-    #[test]
-    fn generated_nonce_is_43_char_base64url() {
-        let nonce = generate_raw_nonce();
-        assert_eq!(nonce.len(), 43);
-        assert!(!nonce.contains('+') && !nonce.contains('/') && !nonce.contains('='));
     }
 
     /// The slot hands its payload out exactly once: after the first take it


### PR DESCRIPTION
Follow-up to #506: the v0.7.7 iOS build failed — `CryptoKit.Insecure.SHA256` does not resolve in the plugin's SwiftPM build context.

Moves the nonce generation and hashing into a target-independent Rust module (`nonce.rs`, covered by the known-answer-vector tests). The iOS Swift side receives both values via the plugin args, puts the hash on the authorization request and echoes the raw nonce back — no CryptoKit/Security imports left. macOS behavior unchanged. Needed for the v0.7.8 iOS artifact.