### PR TITLE
fix(apple): add the missing nonce field to StartAppleArgs

### DIFF
--- a/.github/workflows/tmp-apple-build.yml
+++ b/.github/workflows/tmp-apple-build.yml
@@ -25,7 +25,7 @@ jobs:
             version: 0.7.8-alpha.tmp1
             version_type: prerelease
             commit_sha: ${{ github.sha }}
-            build_date: 2026-09-09
+            build_date: "2026-09-09"
         secrets:
             apple-api-issuer: ${{ secrets.apple-api-issuer }}
             apple-api-key: ${{ secrets.apple-api-key }}

--- a/tauri-plugin-aswebauth/src/commands.rs
+++ b/tauri-plugin-aswebauth/src/commands.rs
@@ -163,6 +163,7 @@ pub async fn sign_in_with_apple<R: tauri::Runtime>(
 #[serde(rename_all = "camelCase")]
 struct StartAppleArgs {
     nonce_hash: String,
+    nonce: String,
 }
 
 /// macOS: native Sign in with Apple via `ASAuthorizationController`


### PR DESCRIPTION
Follow-up to #509: the iOS command passes `nonce: raw_nonce` into `StartAppleArgs`, but the struct only declares `nonce_hash` — the v0.7.9 iOS build failed with E0560 (the struct field was lost during branch shuffling). The TMP Apple build check workflow (introduced in #511) runs on this PR, so the iOS SwiftPM/Rust compile and the macOS pipeline (incl. the entitlement gate) are verified here before merge — no release tag needed for verification.