### PR TITLE
fix(lesson): AudioRecall reveal pattern — self-assessment on the answer side

### DIFF
--- a/origa_ui/src/pages/lesson/audio_recall_card.rs
+++ b/origa_ui/src/pages/lesson/audio_recall_card.rs
@@ -24,6 +24,7 @@ pub fn AudioRecallCardView(
     card: DomainCard,
     show_result: Signal<bool>,
     on_answer: Callback<bool>,
+    on_reveal: Callback<()>,
     on_replay: Callback<()>,
     native_language: NativeLanguage,
     #[prop(into)] known_kanji: Signal<HashSet<char>>,
@@ -103,23 +104,19 @@ pub fn AudioRecallCardView(
                 </div>
 
                 <Show when=move || !show_result.get()>
-                    <div class="grid grid-cols-2 gap-3">
+                    // Question side: audio + the classic «Показать» reveal —
+                    // the self-assessment lives on the ANSWER side, after the
+                    // learner has seen the word and its translation.
+                    <div class="flex justify-center">
                         <Button
-                            test_id=Signal::derive(|| "audio-recall-dont-know-btn".to_string())
-                            variant=Signal::derive(|| ButtonVariant::Default)
-                            disabled=Signal::derive(move || show_result.get())
-                            on_click=Callback::new(move |_| on_answer.run(false))
+                            variant=Signal::derive(|| ButtonVariant::Filled)
+                            on_click=Callback::new(move |_| on_reveal.run(()))
+                            test_id=Signal::derive(|| "audio-recall-reveal-btn".to_string())
                         >
-                            {t!(i18n, lesson.dont_know_rating)} <span class="kbd-hint">"[1]"</span>
-                        </Button>
-
-                        <Button
-                            test_id=Signal::derive(|| "audio-recall-know-btn".to_string())
-                            variant=Signal::derive(|| ButtonVariant::Olive)
-                            disabled=Signal::derive(move || show_result.get())
-                            on_click=Callback::new(move |_| on_answer.run(true))
-                        >
-                            {t!(i18n, lesson.know)} <span class="kbd-hint">"[2]"</span>
+                            {t!(i18n, lesson.show_answer)}
+                            // Space is taken by the audio replay on this
+                            // side — the reveal is hinted with Enter.
+                            <span class="kbd-hint">{t!(i18n, lesson.enter_key)}</span>
                         </Button>
                     </div>
                 </Show>
@@ -141,6 +138,29 @@ pub fn AudioRecallCardView(
                         text=Signal::derive(move || answer_text.get_value())
                         known_kanji=known_kanji
                     />
+
+                    // Self-assessment buttons appear on the ANSWER side,
+                    // before the manual advance is armed. `on_answer`
+                    // (Callback<bool>, Copy) is captured by both buttons.
+                    <Show when=move || !waiting_for_next.get()>
+                        <div class="grid grid-cols-2 gap-3 mt-4">
+                            <Button
+                                test_id=Signal::derive(|| "audio-recall-dont-know-btn".to_string())
+                                variant=Signal::derive(|| ButtonVariant::Default)
+                                on_click=Callback::new(move |_| on_answer.run(false))
+                            >
+                                {t!(i18n, lesson.dont_know_rating)} <span class="kbd-hint">"[1]"</span>
+                            </Button>
+
+                            <Button
+                                test_id=Signal::derive(|| "audio-recall-know-btn".to_string())
+                                variant=Signal::derive(|| ButtonVariant::Olive)
+                                on_click=Callback::new(move |_| on_answer.run(true))
+                            >
+                                {t!(i18n, lesson.know)} <span class="kbd-hint">"[2]"</span>
+                            </Button>
+                        </div>
+                    </Show>
                 </Show>
 
                 <Show when=move || waiting_for_next.get() && show_result.get()>

--- a/origa_ui/src/pages/lesson/keyboard_handler.rs
+++ b/origa_ui/src/pages/lesson/keyboard_handler.rs
@@ -117,14 +117,22 @@ pub fn create_keyboard_handler(
             }
 
             if is_audio_recall_active {
-                handle_audio_recall_key(
-                    &ev,
-                    &key,
-                    &actions.on_audio_answer,
-                    &actions.on_replay_audio,
-                );
+                let reveal = &actions.show_answer;
+                handle_audio_recall_key(&ev, &key, reveal.as_ref(), &actions.on_replay_audio);
                 return;
             }
+        }
+
+        // Revealed AudioRecall, answer not yet given: 1 = «Не знаю»,
+        // 2 = «Знаю» (the self-assessment lives on the ANSWER side). The
+        // dismiss path above covers the post-answer waiting window.
+        // ORDERING CONTRACT: this branch MUST stay ABOVE the generic
+        // rating branch below — otherwise 1/2 on a revealed audio card
+        // would rate directly (bypassing pending_rating/waiting_for_next,
+        // ADR-033) and skip the NextCard step.
+        if is_audio_recall_active && state.showing_answer && !state.waiting_for_next {
+            handle_audio_rate_key(&key, &actions.on_audio_answer);
+            return;
         }
 
         if state.showing_answer && !is_quiz && !is_yesno && !is_phrase_listen {
@@ -217,29 +225,49 @@ fn handle_yesno_key(
     }
 }
 
-/// AudioRecall hotkeys before the answer: 1 = «Не знаю», 2 = «Знаю»,
-/// Space = replay the audio. Replay is NOT muted: it is an explicit user
-/// action, and a textless card without sound would be unanswerable. After
-/// the answer the universal dismiss path (Space/Enter/digit) takes over.
+/// AudioRecall hotkeys before the reveal, resolved from the key name:
+/// Space = replay the audio, Enter = show the answer («Показать»).
+/// Replay is NOT muted: it is an explicit user action, and a textless
+/// card without sound would be unanswerable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AudioRecallPreRevealKey {
+    Replay,
+    Reveal,
+}
+
+pub(crate) fn resolve_audio_recall_key(key: &str) -> Option<AudioRecallPreRevealKey> {
+    match key {
+        " " => Some(AudioRecallPreRevealKey::Replay),
+        "Enter" => Some(AudioRecallPreRevealKey::Reveal),
+        _ => None,
+    }
+}
+
 fn handle_audio_recall_key(
     ev: &KeyboardEvent,
     key: &str,
-    on_answer: &Callback<bool>,
+    reveal: &dyn Fn(),
     on_replay: &Callback<()>,
 ) {
-    match key {
-        "1" => {
-            ev.prevent_default();
-            on_answer.run(false);
-        },
-        "2" => {
-            ev.prevent_default();
-            on_answer.run(true);
-        },
-        " " => {
+    match resolve_audio_recall_key(key) {
+        Some(AudioRecallPreRevealKey::Replay) => {
             ev.prevent_default();
             on_replay.run(());
         },
+        Some(AudioRecallPreRevealKey::Reveal) => {
+            ev.prevent_default();
+            reveal();
+        },
+        None => {},
+    }
+}
+
+/// AudioRecall rating keys on the ANSWER side: 1 = «Не знаю» (Again),
+/// 2 = «Знаю» (Good). Any other key is ignored.
+fn handle_audio_rate_key(key: &str, on_answer: &Callback<bool>) {
+    match key {
+        "1" => on_answer.run(false),
+        "2" => on_answer.run(true),
         _ => {},
     }
 }
@@ -333,5 +361,57 @@ mod tests {
         // Only single digits — "12" or "1a" do not match.
         assert!(!is_dismiss_key("12"));
         assert!(!is_dismiss_key("1a"));
+    }
+
+    // ─── AudioRecall keyboard matrix (reveal pattern) ────────────────────
+    // The matrix is the essence of the fix: before the reveal only
+    // replay/reveal work; the self-assessment digits live on the ANSWER
+    // side. The dispatch ORDER inside create_keyboard_handler (audio-rate
+    // branch above the generic rating branch) is a separate contract,
+    // documented at the branch.
+
+    #[test]
+    fn audio_recall_before_reveal_resolves_space_replay_and_enter_reveal() {
+        assert_eq!(
+            resolve_audio_recall_key(" "),
+            Some(AudioRecallPreRevealKey::Replay)
+        );
+        assert_eq!(
+            resolve_audio_recall_key("Enter"),
+            Some(AudioRecallPreRevealKey::Reveal)
+        );
+    }
+
+    #[test]
+    fn audio_recall_before_reveal_ignores_digits_and_other_keys() {
+        for key in ["1", "2", "a", "Tab", "Backspace", ""] {
+            assert_eq!(
+                resolve_audio_recall_key(key),
+                None,
+                "{key:?} must do nothing before the reveal"
+            );
+        }
+    }
+
+    #[test]
+    fn audio_rate_keys_map_digits_to_self_assessment() {
+        Owner::new().with(|| {
+            let answers = RwSignal::new(Vec::<bool>::new());
+            let on_answer = Callback::new(move |knows_word: bool| {
+                answers.update(|v| v.push(knows_word));
+            });
+
+            handle_audio_rate_key("1", &on_answer);
+            handle_audio_rate_key("2", &on_answer);
+            for ignored in ["Enter", " ", "a", ""] {
+                handle_audio_rate_key(ignored, &on_answer);
+            }
+
+            assert_eq!(
+                answers.get_untracked(),
+                vec![false, true],
+                "1 = «Не знаю» (false), 2 = «Знаю» (true); other keys ignored"
+            );
+        });
     }
 }

--- a/origa_ui/src/pages/lesson/lesson_card_container.rs
+++ b/origa_ui/src/pages/lesson/lesson_card_container.rs
@@ -336,6 +336,7 @@ pub fn LessonCardContainer() -> impl IntoView {
                                     card=card
                                     show_result=Signal::derive(move || lesson_state.get().showing_answer)
                                     on_answer=on_audio_select
+                                    on_reveal=Callback::new(move |_| show_answer())
                                     on_replay=on_replay_audio
                                     native_language=native_language.get()
                                     known_kanji=Signal::from(known_kanji)

--- a/origa_ui/src/pages/lesson/lesson_wasm_tests.rs
+++ b/origa_ui/src/pages/lesson/lesson_wasm_tests.rs
@@ -2606,7 +2606,7 @@ mod acquaintance_presentation {
 // ═══════════════════════════════════════════════════════════════════════
 
 #[wasm_bindgen_test]
-async fn audio_recall_front_hides_word_and_shows_answer_buttons() {
+async fn audio_recall_front_hides_word_and_shows_reveal_button() {
     let wrapper = create_wrapper();
     mount_with_i18n(&wrapper, || {
         view! {
@@ -2614,6 +2614,7 @@ async fn audio_recall_front_hides_word_and_shows_answer_buttons() {
                 card=vocab_card_fixture("温度")
                 show_result=Signal::from(false)
                 on_answer=Callback::new(|_: bool| {})
+                on_reveal=Callback::new(|()| {})
                 on_replay=Callback::new(|()| {})
                 native_language=origa::domain::NativeLanguage::Russian
                 known_kanji=Signal::derive(|| HashSet::new())
@@ -2639,13 +2640,22 @@ async fn audio_recall_front_hides_word_and_shows_answer_buttons() {
             .is_some(),
         "replay button must render on the question side"
     );
+    assert!(
+        wrapper
+            .query_selector("[data-testid=\"audio-recall-reveal-btn\"]")
+            .unwrap()
+            .is_some(),
+        "the reveal («Показать») button must render on the question side"
+    );
+    // Self-assessment lives on the ANSWER side — the rating buttons must
+    // NOT be on the question side.
     for test_id in ["audio-recall-know-btn", "audio-recall-dont-know-btn"] {
         assert!(
             wrapper
                 .query_selector(&format!("[data-testid=\"{test_id}\"]"))
                 .unwrap()
-                .is_some(),
-            "{test_id} must render before answering"
+                .is_none(),
+            "{test_id} must NOT render before the reveal"
         );
     }
     // The word itself must NOT leak to the question side — audio-only recall
@@ -2657,7 +2667,7 @@ async fn audio_recall_front_hides_word_and_shows_answer_buttons() {
 }
 
 #[wasm_bindgen_test]
-async fn audio_recall_answer_reveals_word_and_next_button() {
+async fn audio_recall_revealed_answer_shows_word_and_rating_buttons() {
     let wrapper = create_wrapper();
     mount_with_i18n(&wrapper, || {
         view! {
@@ -2665,10 +2675,11 @@ async fn audio_recall_answer_reveals_word_and_next_button() {
                 card=vocab_card_fixture("温度")
                 show_result=Signal::from(true)
                 on_answer=Callback::new(|_: bool| {})
+                on_reveal=Callback::new(|()| {})
                 on_replay=Callback::new(|()| {})
                 native_language=origa::domain::NativeLanguage::Russian
                 known_kanji=Signal::derive(|| HashSet::new())
-                waiting_for_next=Signal::from(true)
+                waiting_for_next=Signal::from(false)
                 on_next_card=Callback::new(|()| {})
             />
         }
@@ -2681,6 +2692,40 @@ async fn audio_recall_answer_reveals_word_and_next_button() {
         page.contains("温度"),
         "the word must render on the answer side; got: {page}"
     );
+    // The self-assessment buttons live on the answer side, before the
+    // manual advance is armed.
+    for test_id in ["audio-recall-know-btn", "audio-recall-dont-know-btn"] {
+        assert!(
+            wrapper
+                .query_selector(&format!("[data-testid=\"{test_id}\"]"))
+                .unwrap()
+                .is_some(),
+            "{test_id} must render on the revealed answer side"
+        );
+    }
+}
+
+#[wasm_bindgen_test]
+async fn audio_recall_answered_hides_rating_and_shows_next_button() {
+    let wrapper = create_wrapper();
+    mount_with_i18n(&wrapper, || {
+        view! {
+            <AudioRecallCardView
+                card=vocab_card_fixture("温度")
+                show_result=Signal::from(true)
+                on_answer=Callback::new(|_: bool| {})
+                on_reveal=Callback::new(|()| {})
+                on_replay=Callback::new(|()| {})
+                native_language=origa::domain::NativeLanguage::Russian
+                known_kanji=Signal::derive(|| HashSet::new())
+                waiting_for_next=Signal::from(true)
+                on_next_card=Callback::new(|()| {})
+            />
+        }
+        .into_any()
+    });
+    tick().await;
+
     assert!(
         wrapper
             .query_selector("[data-testid=\"lesson-card-next-btn\"]")
@@ -2688,6 +2733,16 @@ async fn audio_recall_answer_reveals_word_and_next_button() {
             .is_some(),
         "waiting_for_next must show the next-card button"
     );
+    // Once answered, the rating buttons give way to the advance control.
+    for test_id in ["audio-recall-know-btn", "audio-recall-dont-know-btn"] {
+        assert!(
+            wrapper
+                .query_selector(&format!("[data-testid=\"{test_id}\"]"))
+                .unwrap()
+                .is_none(),
+            "{test_id} must NOT render after the answer is given"
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Owner report after v0.7.14: the AudioRecall card offered «Знаю/Не знаю» directly on the question side (quiz pattern). The correct canon mirrors every other lesson card:

- **Question side**: audio (autoplay + replay, Space) + a «Показать» button [Enter] — nothing else
- **Answer side**: the word + reading + translation is revealed first, then «Не знаю [1]» / «Знаю [2]» arm the manual advance (ADR-033), NextCardButton follows

Keyboard matrix is now three-state and unit-tested: before the reveal only replay/reveal work; on the revealed-not-yet-rated card 1/2 dispatch through `on_audio_answer` (pending_rating + waiting_for_next); after the answer the universal dismiss path advances. The audio-rate branch carries an explicit ORDERING CONTRACT comment — it must stay above the generic rating branch, otherwise digits would rate directly and bypass ADR-033.

## Verification

| Check | Result |
|---|---|
| clippy `-D warnings` / fmt / qlty | ✅ 0 errors / No issues |
| cargo test --workspace | ✅ 2432 passed / 0 failed (+3 keyboard-matrix tests) |
| wasm-pack test (browser) | ✅ 297 passed / 0 failed |

wasm tests rewritten for the new UX: front (play + reveal button present, rating buttons absent, word hidden), revealed (word + rating buttons), answered (NextCard, rating buttons hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)